### PR TITLE
Remove branch name from temp plugin file

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,8 +30,8 @@ steps:
       - yarn ci-build:finish
       - yarn ci-package
       - cd ci/dist
-      - zip -r grafana-oncall-app-${DRONE_BRANCH}-${DRONE_BUILD_NUMBER}.zip ./grafana-oncall-app
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, skipping archive"; else cp grafana-oncall-app-${DRONE_BRANCH}-${DRONE_BUILD_NUMBER}.zip grafana-oncall-app-${DRONE_TAG}.zip; fi
+      - zip -r grafana-oncall-app.zip ./grafana-oncall-app
+      - if [ -z "$DRONE_TAG" ]; then echo "No tag, skipping archive"; else cp grafana-oncall-app.zip grafana-oncall-app-${DRONE_TAG}.zip; fi
 
   - name: Publish Plugin to GCS (release)
     image: plugins/gcs


### PR DESCRIPTION
Stop using branch name in temp files to avoid character rule difrerences between branch and file names.