### PR TITLE
Add simple smtp email messaging backend

### DIFF
--- a/engine/apps/base/email_backend.py
+++ b/engine/apps/base/email_backend.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.core.mail import send_mail
+
+from apps.alerts.incident_appearance.templaters import AlertEmailTemplater
+from apps.base.messaging import BaseMessagingBackend
+
+
+class SimpleEmailBackend(BaseMessagingBackend):
+    backend_id = "SMTPEMAIL"
+    label = "Email"
+    short_label = "Email"
+    available_for_use = True
+
+    def serialize_user(self, user):
+        return {"email": user.email}
+
+    def notify_user(self, user, alert_group, notification_policy):
+        alert = alert_group.alerts.last()
+        # use existing Email templater
+        templated_alert = AlertEmailTemplater(alert).render()
+
+        title = templated_alert.title
+        message = templated_alert.message
+        email_from = settings.EMAIL_HOST_USER
+        recipient_list = [user.email]
+        # send email through Django setup
+        send_mail(title, message, email_from, recipient_list)

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -464,6 +464,16 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = getenv_integer("DATA_UPLOAD_MAX_MEMORY_SIZE", 1_04
 SLOW_THRESHOLD_SECONDS = 2.0
 
 EXTRA_MESSAGING_BACKENDS = []
+ENABLE_SMTP_EMAIL_BACKEND = getenv_boolean("ENABLE_SMTP_EMAIL_BACKEND", False)
+if ENABLE_SMTP_EMAIL_BACKEND:
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = os.environ.get("EMAIL_HOST")
+    EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+    EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+    EMAIL_PORT = getenv_integer("EMAIL_PORT", 587)
+    EMAIL_USE_TLS = getenv_boolean("EMAIL_USE_TLS", False)
+    DEFAULT_FROM_EMAIL = os.environ.get("DEFAULT_FROM_EMAIL")
+    EXTRA_MESSAGING_BACKENDS = [("apps.base.email_backend.SimpleEmailBackend", 587)]
 
 INSTALLED_ONCALL_INTEGRATIONS = [
     "config_integrations.alertmanager",


### PR DESCRIPTION
Simple email messaging backend, using Django `send_mail` setup.
There is room for improvement, this is a really simple/basic implementation.

**To try it**

1. Set the following variables in your .env file (or environment variables):
```
ENABLE_SMTP_EMAIL_BACKEND = True
EMAIL_HOST = <email host>
EMAIL_HOST_USER = <email host username>
EMAIL_HOST_PASSWORD = <email host password>
EMAIL_PORT = <email port, defaults to 587>
EMAIL_USE_TLS = <enable tls, defaults to False>
```
2. You can now choose "Email" as a notification option in your user's profile.
3. Notifications will be sent to the set user email address, and will use the existing email templates.
