### PR TITLE
fix link to documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Grafana Cloud Documentation
 
-Source for documentation at https://grafana.com/docs/amixr/
+Source for documentation at https://grafana.com/docs/oncall/
 
 ## Preview the website
 


### PR DESCRIPTION
Current link https://grafana.com/docs/amixr/ -> 404

Changed to: https://grafana.com/docs/oncall/