### PR TITLE
Remove too high connections numbers from uwsgi.ini

### DIFF
--- a/engine/uwsgi.ini
+++ b/engine/uwsgi.ini
@@ -11,7 +11,6 @@ harakiri=620
 max-requests=5000
 vacuum=True
 buffer-size=65535
-listen=1024
 http-auto-chunked=True
 http-timeout=620
 post-buffering=1


### PR DESCRIPTION
fixes https://github.com/grafana/oncall/issues/84