### PR TITLE
Fix externalRedis for correct template

### DIFF
--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -120,7 +120,7 @@ externalRabbitmq:
 redis:
   enabled: true
 
-external_redis:
+externalRedis:
   host:
   password:
 


### PR DESCRIPTION
`externalRedis` in https://github.com/grafana/oncall/blob/dev/helm/oncall/templates/_env.tpl#L141 but here `external_redis`