### PR TITLE
Remove unused caddy volumes from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,5 +171,3 @@ services:
 volumes:
   dbdata:
   rabbitmqdata:
-  caddy_data:
-  caddy_config:


### PR DESCRIPTION
Caddy container has been removed in https://github.com/roock/grafana-oncall/commit/bd923936575bed2a92cfbc5b7e348d9ca4ce1e3d
but volumes have not been removed