### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ RABBITMQ_PASSWORD=rabbitmq_secret_pw
 MYSQL_PASSWORD=mysql_secret_pw
 COMPOSE_PROFILES=with_grafana  # Remove this line if you want to use existing grafana
 GRAFANA_USER=admin
-GRAFANA_PASSWORD=admin" > .env_hobby
+GRAFANA_PASSWORD=admin" > .env
 ```
 
 3. Launch services:
 ```bash
-docker-compose --env-file .env_hobby -f docker-compose.yml up --build -d
+docker-compose -f docker-compose.yml up --build -d
 ```
 
 4. Issue one-time invite token:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker-compose -f docker-compose.yml up --build -d
 
 4. Issue one-time invite token:
 ```bash
-docker-compose --env-file .env_hobby -f docker-compose.yml run engine python manage.py issue_invite_for_the_frontend --override
+docker-compose -f docker-compose.yml run engine python manage.py issue_invite_for_the_frontend --override
 ```
 
 5. Go to [OnCall Plugin Configuration](http://localhost:3000/plugins/grafana-oncall-app), using log in credentials as defined above: `admin`/`admin` (or find OnCall plugin in configuration->plugins) and connect OnCall _plugin_ with OnCall _backend_:


### PR DESCRIPTION
using `.env_hobby` and passing it via `--env-file .env_hobby` causes this error:
```
invalid interpolation format for services.mysql_to_create_grafana_db.command: "required variable MYSQL_PASSWORD is missing a value: err". You may need to escape any $ with another $
```
docker version: 
```
Client: Docker Engine - Community
 Version:           20.10.17
 API version:       1.41
 Go version:        go1.17.11
 Git commit:        100c701
 Built:             Mon Jun  6 23:02:46 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.17
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.17.11
  Git commit:       a89b842
  Built:            Mon Jun  6 23:00:51 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.6
  GitCommit:        10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1
 runc:
  Version:          1.1.2
  GitCommit:        v1.1.2-0-ga916309
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```
Docker compose version:
```
Docker Compose version v2.6.0
```
OS: ubuntu 22.04