### PR TITLE
Limit number of slack messages in resolution notes popup

### DIFF
--- a/engine/apps/slack/tests/test_scenario_steps/test_resolution_note.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_resolution_note.py
@@ -101,3 +101,80 @@ def test_get_resolution_notes_blocks_non_empty(
     ]
 
     assert blocks == expected_blocks
+
+
+@pytest.mark.django_db
+def test_get_resolution_notes_blocks_latest_limit(
+    make_organization_and_user_with_slack_identities,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_resolution_note_slack_message,
+):
+    SlackResolutionNoteModalStep = ScenarioStep.get_step("resolution_note", "ResolutionNoteModalStep")
+    organization, user, slack_team_identity, _ = make_organization_and_user_with_slack_identities()
+    step = SlackResolutionNoteModalStep(slack_team_identity)
+
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    max_count = SlackResolutionNoteModalStep.RESOLUTION_NOTE_MESSAGES_MAX_COUNT
+    messages = [
+        make_resolution_note_slack_message(alert_group=alert_group, user=user, added_by_user=user, ts=i, text=i)
+        for i in range(max_count * 2)
+    ]
+
+    blocks = step.get_resolution_notes_blocks(alert_group, "", False)
+
+    expected_blocks = [
+        {
+            "type": "divider",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    ":warning: Listing up to last {} thread messages, "
+                    "you can still add any other message using contextual menu actions."
+                ).format(max_count),
+            },
+        },
+    ]
+    for m in list(reversed(messages))[:max_count]:
+        expected_blocks += [
+            {
+                "type": "divider",
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "{} <!date^{:.0f}^{{date_num}} {{time_secs}}|message_created_at>\n{}".format(
+                        m.user.get_user_verbal_for_team_for_slack(mention=True),
+                        float(m.ts),
+                        m.text,
+                    ),
+                },
+                "accessory": {
+                    "type": "button",
+                    "style": "primary",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "Add",
+                        "emoji": True,
+                    },
+                    "action_id": "AddRemoveThreadMessageStep",
+                    "value": json.dumps(
+                        {
+                            "resolution_note_window_action": "edit",
+                            "msg_value": "add",
+                            "message_pk": m.pk,
+                            "resolution_note_pk": None,
+                            "alert_group_pk": alert_group.pk,
+                        }
+                    ),
+                },
+            },
+        ]
+
+    assert blocks == expected_blocks


### PR DESCRIPTION
Fixes https://github.com/grafana/oncall-private/issues/1276
Reproduced locally to get the error behind the issue:
`[ERROR] no more than 100 items allowed [json-pointer:/view/blocks]'`