### PR TITLE
Reshape webhook payload

### DIFF
--- a/engine/apps/alerts/models/custom_button.py
+++ b/engine/apps/alerts/models/custom_button.py
@@ -118,11 +118,8 @@ class CustomButton(models.Model):
         elif self.data:
             rendered_data = Template(self.data).render(
                 {
-                    "alert_title": self._escape_string(alert.title),
-                    "alert_message": self._escape_string(alert.message),
-                    "alert_url": alert.link_to_upstream_details,
                     "alert_payload": self._escape_alert_payload(alert.raw_request_data),
-                    "alert_payload_json": json.dumps(alert.raw_request_data),
+                    "alert_group_id": alert.group.public_primary_key,
                 }
             )
             post_kwargs["json"] = json.loads(rendered_data)

--- a/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookForm.config.ts
+++ b/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookForm.config.ts
@@ -36,7 +36,7 @@ export const form: { name: string; fields: FormItem[] } = {
       name: 'data',
       getDisabled: (form_data) => Boolean(form_data.forward_whole_payload),
       type: FormItemType.TextArea,
-      description: 'Available variables: {{ alert_title }}, {{ alert_message }}, {{ alert_url }}, {{ alert_payload }}',
+      description: 'Available variables: {{ alert_payload }}, {{ alert_group_id }}',
       extra: {
         rows: 9,
       },


### PR DESCRIPTION
1. Remove alert.title, alert.message, alert.image_url from webhook payload, they are deprecated. 

    In the past we calculated title, message and image url for each alert at the moment when we received them. Then this was 
    replaced by templates system, but these calculations was left too. With latest @iskhakov changes which introduced 
    **UniversalAPIView** for almost every integration we removed leftovers and started to pass None as title, message and 
    image_url. That caused this [issue](https://github.com/grafana/oncall/issues/202).
2. Pass alert_group_id to webhook payload. 