### PR TITLE
Add fixes for the mobile app

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/classic_markdown_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/classic_markdown_renderer.py
@@ -1,0 +1,34 @@
+from apps.alerts.incident_appearance.renderers.base_renderer import AlertBaseRenderer, AlertGroupBaseRenderer
+from apps.alerts.incident_appearance.templaters import AlertClassicMarkdownTemplater
+from common.utils import str_or_backup
+
+
+class AlertClassicMarkdownRenderer(AlertBaseRenderer):
+    @property
+    def templater_class(self):
+        return AlertClassicMarkdownTemplater
+
+    def render(self):
+        templated_alert = self.templated_alert
+        rendered_alert = {
+            "title": str_or_backup(templated_alert.title, "Alert"),
+            "message": str_or_backup(templated_alert.message, ""),
+            "image_url": str_or_backup(templated_alert.image_url, None),
+            "source_link": str_or_backup(templated_alert.source_link, None),
+        }
+        return rendered_alert
+
+
+class AlertGroupClassicMarkdownRenderer(AlertGroupBaseRenderer):
+    def __init__(self, alert_group, alert=None):
+        if alert is None:
+            alert = alert_group.alerts.last()
+
+        super().__init__(alert_group, alert)
+
+    @property
+    def alert_renderer_class(self):
+        return AlertClassicMarkdownRenderer
+
+    def render(self):
+        return self.alert_renderer.render()

--- a/engine/apps/alerts/incident_appearance/templaters/__init__.py
+++ b/engine/apps/alerts/incident_appearance/templaters/__init__.py
@@ -5,3 +5,4 @@ from .slack_templater import AlertSlackTemplater  # noqa: F401
 from .sms_templater import AlertSmsTemplater  # noqa: F401
 from .telegram_templater import AlertTelegramTemplater  # noqa: F401
 from .web_templater import AlertWebTemplater  # noqa: F401
+from .classic_markdown_templater import AlertClassicMarkdownTemplater  # noqa: F401

--- a/engine/apps/alerts/incident_appearance/templaters/classic_markdown_templater.py
+++ b/engine/apps/alerts/incident_appearance/templaters/classic_markdown_templater.py
@@ -1,0 +1,30 @@
+import re
+
+from apps.alerts.incident_appearance.templaters.alert_templater import AlertTemplater
+from common.utils import convert_md_to_html, escape_html, url_re, urlize_with_respect_to_a
+
+
+class AlertClassicMarkdownTemplater(AlertTemplater):
+    RENDER_FOR = "web"
+
+    def _render_for(self):
+        return self.RENDER_FOR
+
+    def _postformat(self, templated_alert):
+        link_substitution = {}
+        if templated_alert.title:
+            templated_alert.title = escape_html(self._slack_format_for_web(templated_alert.title))
+        if templated_alert.message:
+            message = escape_html(self._slack_format_for_web(templated_alert.message))
+            link_matches = re.findall(url_re, message)
+            for idx, link in enumerate(link_matches):
+                substitution = f"amixrsubstitutedlink{idx}"
+                link_substitution[substitution] = link
+                message = message.replace(link, substitution)
+
+        return templated_alert
+
+    def _slack_format_for_web(self, data):
+        sf = self.slack_formatter
+        sf.hyperlink_mention_format = "[{title}]({url})"
+        return sf.format(data)

--- a/engine/apps/alerts/tasks/notify_user.py
+++ b/engine/apps/alerts/tasks/notify_user.py
@@ -367,26 +367,33 @@ def perform_notification(log_record_pk):
                 "orgName": f"{alert_group.channel.organization.stack_slug}",
                 "incidentId": f"{alert_group.public_primary_key}",
                 "status": f"{alert_group.status}",
-                "interruption-level": "critical",
+                "aps": {
+                    "alert": f"{message}",
+                    "sound": "bingbong.aiff",
+                }
             },
         )
 
     elif notification_channel == UserNotificationPolicy.NotificationChannel.MOBILE_PUSH_CRITICAL:
-        message = f"!!! {AlertGroupWebRenderer(alert_group).render().get('title', 'Incident')}"
+        message = f"{AlertGroupWebRenderer(alert_group).render().get('title', 'Incident')}"
         thread_id = f"{alert_group.channel.organization.public_primary_key}:{alert_group.public_primary_key}"
         devices_to_notify = APNSDevice.objects.filter(user_id=user.pk)
-        sounds = ["ambulance.aiff"]
         devices_to_notify.send_message(
             message,
             thread_id=thread_id,
             category="USER_NEW_INCIDENT",
-            sound={"critical": 1, "name": f"{random.choice(sounds)}"},
             extra={
                 "orgId": f"{alert_group.channel.organization.public_primary_key}",
                 "orgName": f"{alert_group.channel.organization.stack_slug}",
                 "incidentId": f"{alert_group.public_primary_key}",
                 "status": f"{alert_group.status}",
-                "interruption-level": "critical",
+                "aps": {
+                    "alert": f"Critical page: #{alert_group.inside_team_number}: {message}",
+                    # This is disabled until we gain the Critical Alerts Api permission from apple
+                    # "interruption-level": "critical",
+                    "interruption-level": "time-sensitive",
+                    "sound": "ambulance.aiff",
+                }
             },
         )
     else:

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework import serializers
 
 from apps.alerts.incident_appearance.renderers.web_renderer import AlertGroupWebRenderer
+from apps.alerts.incident_appearance.renderers.classic_markdown_renderer import AlertGroupClassicMarkdownRenderer
 from apps.alerts.models import AlertGroup
 from common.api_helpers.mixins import EagerLoadingMixin
 
@@ -39,6 +40,7 @@ class AlertGroupListSerializer(EagerLoadingMixin, serializers.ModelSerializer):
 
     alerts_count = serializers.IntegerField(read_only=True)
     render_for_web = serializers.SerializerMethodField()
+    render_for_classic_markdown = serializers.SerializerMethodField()
 
     PREFETCH_RELATED = [
         "dependent_alert_groups",
@@ -78,6 +80,7 @@ class AlertGroupListSerializer(EagerLoadingMixin, serializers.ModelSerializer):
             "silenced_until",
             "related_users",
             "render_for_web",
+            "render_for_classic_markdown",
             "dependent_alert_groups",
             "root_alert_group",
             "status",
@@ -85,6 +88,9 @@ class AlertGroupListSerializer(EagerLoadingMixin, serializers.ModelSerializer):
 
     def get_render_for_web(self, obj):
         return AlertGroupWebRenderer(obj, obj.last_alert).render()
+
+    def get_render_for_classic_markdown(self, obj):
+        return AlertGroupClassicMarkdownRenderer(obj).render()
 
     def get_related_users(self, obj):
         users_ids = set()

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -101,7 +101,11 @@ class UserView(
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):
-    authentication_classes = (PluginAuthentication,)
+    authentication_classes = (
+        MobileAppAuthTokenAuthentication,
+        PluginAuthentication,
+    )
+
     permission_classes = (IsAuthenticated, ActionPermission)
 
     # Non-admin users are allowed to list and retrieve users

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -36,7 +36,7 @@ django-log-request-id==1.6.0
 django-polymorphic==3.0.0
 django-rest-polymorphic==0.1.9
 pre-commit==2.15.0
-https://github.com/iskhakov/django-push-notifications/archive/refs/tags/2.0.0-hotfix-4.tar.gz
+django-push-notifications==3.0.0
 django-mirage-field==1.3.0
 django-mysql==4.6.0
 PyMySQL==1.0.2

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -405,8 +405,9 @@ PUSH_NOTIFICATIONS_SETTINGS = {
     "APNS_TOPIC": os.environ.get("APNS_TOPIC", None),
     "APNS_AUTH_KEY_ID": os.environ.get("APNS_AUTH_KEY_ID", None),
     "APNS_TEAM_ID": os.environ.get("APNS_TEAM_ID", None),
-    "APNS_USE_SANDBOX": True,
+    "APNS_USE_SANDBOX": os.environ.get("APNS_USE_SANDBOX", True),
     "USER_MODEL": "user_management.User",
+    "UPDATE_ON_DUPLICATE_REG_ID": True,
 }
 
 SELF_HOSTED_SETTINGS = {


### PR DESCRIPTION
This pr updates the mobile app functionality:
* bumps the django-push-notifications library version
* adds the field `render_for_classic_markdown` field, it is similar to render_for_web, but using markdown, instead of html. We'll consider switching the frontend to markdown too
* adds support of time-sensitive notifications