### PR TITLE
Fix wrong env var for mobile app settings

### DIFF
--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -405,7 +405,7 @@ PUSH_NOTIFICATIONS_SETTINGS = {
     "APNS_TOPIC": os.environ.get("APNS_TOPIC", None),
     "APNS_AUTH_KEY_ID": os.environ.get("APNS_AUTH_KEY_ID", None),
     "APNS_TEAM_ID": os.environ.get("APNS_TEAM_ID", None),
-    "APNS_USE_SANDBOX": os.environ.get("APNS_USE_SANDBOX", True),
+    "APNS_USE_SANDBOX": getenv_boolean("APNS_USE_SANDBOX", True),
     "USER_MODEL": "user_management.User",
     "UPDATE_ON_DUPLICATE_REG_ID": True,
 }


### PR DESCRIPTION
Always use the correct method to read Bol from env variables otherwise you can get into the following situation:
```
>>> settings.PUSH_NOTIFICATIONS_SETTINGS.get("APNS_USE_SANDBOX")
'False'
>>> bool(settings.PUSH_NOTIFICATIONS_SETTINGS.get("APNS_USE_SANDBOX"))
True
```