### PR TITLE
Disable gather digit step for cloud phone call

### DIFF
--- a/engine/apps/twilioapp/models/phone_call.py
+++ b/engine/apps/twilioapp/models/phone_call.py
@@ -251,7 +251,7 @@ class PhoneCall(models.Model):
         if phone_calls_left < 3:
             message_body += " {} phone calls left. Contact your admin.".format(phone_calls_left)
 
-        twilio_call = twilio_client.make_call(message_body, user.verified_phone_number)
+        twilio_call = twilio_client.make_call(message_body, user.verified_phone_number, grafana_cloud=grafana_cloud)
         if twilio_call.status and twilio_call.sid:
             phone_call.status = TwilioCallStatuses.DETERMINANT.get(twilio_call.status, None)
             phone_call.sid = twilio_call.sid

--- a/engine/apps/twilioapp/twilio_client.py
+++ b/engine/apps/twilioapp/twilio_client.py
@@ -126,19 +126,22 @@ class TwilioClient:
         )
         self.make_call(message=message, to=to)
 
-    def make_call(self, message, to):
+    def make_call(self, message, to, grafana_cloud=False):
         try:
             start_message = message.replace('"', "")
 
-            twiml_query = urllib.parse.quote(
+            gather_message = (
                 (
-                    f"<Response>"
-                    f"<Say>{start_message}</Say>"
                     f'<Gather numDigits="1" action="{get_gather_url()}" method="POST">'
                     f"<Say>{get_gather_message()}</Say>"
                     f"</Gather>"
-                    f"</Response>"
-                ),
+                )
+                if not grafana_cloud
+                else ""
+            )
+
+            twiml_query = urllib.parse.quote(
+                f"<Response><Say>{start_message}</Say>{gather_message}</Response>",
                 safe="",
             )
 


### PR DESCRIPTION
Since there is no related alert group in the cloud when making a call from an OSS installation via cloud, disable the gather digit message to update alert status (which makes the call fail if an action is tried). Eventually we should provide some way to forward the action to an on-prem installation.

This is related to: https://github.com/grafana/oncall/issues/312