### PR TITLE
Allow ingress TLS to be configured

### DIFF
--- a/helm/oncall/templates/ingress-regular.yaml
+++ b/helm/oncall/templates/ingress-regular.yaml
@@ -23,10 +23,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.tls }} 
   tls:
-  - hosts:
-    - {{ .Values.base_url | quote }}
-    secretName: certificate-tls
+      {{- tpl (toYaml .Values.ingress.tls) . | nindent 4 }}
+  {{- end }}
   rules:
   - host: {{ .Values.base_url | quote }}
     http:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -54,6 +54,10 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/issuer: "letsencrypt-prod"
+  tls: 
+    - hosts:
+        - "{{ .Values.base_url }}"
+      secretName: certificate-tls
 
 # Whether to install ingress controller
 ingress-nginx:


### PR DESCRIPTION
This will let the ingress work with more than just the nginx/cert-manager combination installed as part of the chart.

The default values render in a way that makes this backwards compatible, so no major version change is required.

---

With default:

Renders:
```yaml
# Source: oncall/templates/ingress-regular.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-oncall
  labels:
    helm.sh/chart: oncall-1.0.2
    app.kubernetes.io/name: oncall
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v1.0.3"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
spec:
  tls:
    - hosts:
      - 'example.com'
      secretName: certificate-tls
  rules:
  - host: "example.com"
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: test-oncall-engine
            port:
              number: 8080

```

With values file:

```yaml
ingress:
  tls: []
```
Renders:

```yaml
# Source: oncall/templates/ingress-regular.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-oncall
  labels:
    helm.sh/chart: oncall-1.0.2
    app.kubernetes.io/name: oncall
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v1.0.3"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
spec:
  rules:
  - host: "example.com"
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: test-oncall-engine
            port:
              number: 8080
```