### PR TITLE
Allow chart user to add extra ingress paths

### DIFF
--- a/helm/oncall/templates/ingress-regular.yaml
+++ b/helm/oncall/templates/ingress-regular.yaml
@@ -23,10 +23,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.ingress.tls }} 
   tls:
-  - hosts:
-    - {{ .Values.base_url | quote }}
-    secretName: certificate-tls
+      {{- tpl (toYaml .Values.ingress.tls) . | nindent 4 }}
+  {{- end }}
   rules:
   - host: {{ .Values.base_url | quote }}
     http:

--- a/helm/oncall/templates/ingress-regular.yaml
+++ b/helm/oncall/templates/ingress-regular.yaml
@@ -31,6 +31,9 @@ spec:
   - host: {{ .Values.base_url | quote }}
     http:
       paths:
+{{- if .Values.ingress.extraPaths }}
+{{ toYaml .Values.ingress.extraPaths | indent 6}}
+{{- end }}
       - path: /
         pathType: Prefix
         backend:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -54,6 +54,10 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/issuer: "letsencrypt-prod"
+  tls: 
+    - hosts:
+        - "{{ .Values.base_url }}"
+      secretName: certificate-tls
 
 # Whether to install ingress controller
 ingress-nginx:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -58,6 +58,21 @@ ingress:
     - hosts:
         - "{{ .Values.base_url }}"
       secretName: certificate-tls
+  # Extra paths to prepend to the host configuration. If using something 
+  # like an ALB ingress controller, you may want to configure SSL redirects 
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
 
 # Whether to install ingress controller
 ingress-nginx:


### PR DESCRIPTION
**This is stacked on top of #314 -- ignore the first commit in this PR**

This supports adding paths to the oncall host so the ingress can be
configured to work with annotation-based ingress controllers (for
example, the ALB ingress controller).

By default no extra paths are added, and this change should be backwards
compatible.

---

With the "default" values (I've disabled the grafana deploy to cut down on overall output):

```yaml
# Source: oncall/templates/ingress-regular.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-oncall
  labels:
    helm.sh/chart: oncall-1.0.2
    app.kubernetes.io/name: oncall
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v1.0.3"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
spec:
  tls:
    - hosts:
      - 'example.com'
      secretName: certificate-tls
  rules:
  - host: "example.com"
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: test-oncall-engine
            port:
              number: 8080
```

With the following:

```yaml
ingress:
  extraPaths:
    - path: /*
      pathType: Prefix
      backend:
        service:
          name: ssl-redirect
          port:
            name: use-annotation
```

Renders:

```yaml
# Source: oncall/templates/ingress-regular.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: test-oncall
  labels:
    helm.sh/chart: oncall-1.0.2
    app.kubernetes.io/name: oncall
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v1.0.3"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/issuer: letsencrypt-prod
    kubernetes.io/ingress.class: nginx
spec:
  tls:
    - hosts:
      - 'example.com'
      secretName: certificate-tls
  rules:
  - host: "example.com"
    http:
      paths:
      - backend:
          service:
            name: ssl-redirect
            port:
              name: use-annotation
        path: /*
        pathType: Prefix
      - path: /
        pathType: Prefix
        backend:
          service:
            name: test-oncall-engine
            port:
              number: 8080
```
