### PR TITLE
1206 - Hide active incident from the attach incident list

### DIFF
--- a/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
+++ b/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
@@ -88,7 +88,7 @@ const AttachIncidentForm = observer((props: AttachIncidentFormProps) => {
             displayField="render_for_web.title"
             placeholder="Select Incident"
             className={cx('select', 'control')}
-            filterOptions={id => id !== props.id}
+            filterOptions={(id) => id !== props.id}
             value={selected}
             onChange={getChangeHandler}
             getDescription={(item: Alert) => moment(item.started_at).format('MMM DD, YYYY hh:mm A')}

--- a/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
+++ b/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
@@ -88,7 +88,7 @@ const AttachIncidentForm = observer((props: AttachIncidentFormProps) => {
             displayField="render_for_web.title"
             placeholder="Select Incident"
             className={cx('select', 'control')}
-            hiddenIdList={[props.id]}
+            excludedOptionsIdList={[props.id]}
             value={selected}
             onChange={getChangeHandler}
             getDescription={(item: Alert) => moment(item.started_at).format('MMM DD, YYYY hh:mm A')}

--- a/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
+++ b/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
@@ -88,6 +88,7 @@ const AttachIncidentForm = observer((props: AttachIncidentFormProps) => {
             displayField="render_for_web.title"
             placeholder="Select Incident"
             className={cx('select', 'control')}
+            hiddenIdList={[props.id]}
             value={selected}
             onChange={getChangeHandler}
             getDescription={(item: Alert) => moment(item.started_at).format('MMM DD, YYYY hh:mm A')}

--- a/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
+++ b/grafana-plugin/src/containers/AttachIncidentForm/AttachIncidentForm.tsx
@@ -88,7 +88,7 @@ const AttachIncidentForm = observer((props: AttachIncidentFormProps) => {
             displayField="render_for_web.title"
             placeholder="Select Incident"
             className={cx('select', 'control')}
-            excludedOptionsIdList={[props.id]}
+            filterOptions={id => id !== props.id}
             value={selected}
             onChange={getChangeHandler}
             getDescription={(item: Alert) => moment(item.started_at).format('MMM DD, YYYY hh:mm A')}

--- a/grafana-plugin/src/containers/GSelect/GSelect.tsx
+++ b/grafana-plugin/src/containers/GSelect/GSelect.tsx
@@ -32,7 +32,7 @@ interface GSelectProps {
   showWarningIfEmptyValue?: boolean;
   showError?: boolean;
   nullItemName?: string;
-  excludedOptionsIdList?: string[];
+  filterOptions?: (item: any) => boolean;
   dropdownRender?: (menu: ReactElement) => ReactElement;
   getOptionLabel?: <T>(item: SelectableValue<T>) => React.ReactNode;
   getDescription?: (item: any) => React.ReactNode;
@@ -58,7 +58,7 @@ const GSelect = observer((props: GSelectProps) => {
     getOptionLabel,
     showWarningIfEmptyValue = false,
     getDescription,
-    excludedOptionsIdList,
+    filterOptions,
   } = props;
 
   const store = useStore();
@@ -87,20 +87,18 @@ const GSelect = observer((props: GSelectProps) => {
   const loadOptions = (query: string) => {
     return model.updateItems(query).then(() => {
       const searchResult = model.getSearchResult(query);
-      const items = Array.isArray(searchResult.results) ? searchResult.results : searchResult;
+      let items = Array.isArray(searchResult.results) ? searchResult.results : searchResult;
 
-      return items.reduce((options: any[], item: any) => {
-        const isItemExcludedFromList = excludedOptionsIdList?.includes(item[valueField]);
-        if (!isItemExcludedFromList) {
-          options.push({
-            value: item[valueField],
-            label: get(item, displayField),
-            imgUrl: item.avatar_url,
-            description: getDescription && getDescription(item),
-          });
-        }
-        return options;
-      }, []);
+      if (filterOptions) {
+        items = items.filter((opt: any) => filterOptions(opt[valueField]));
+      }
+
+      return items.map((item: any) => ({
+        value: item[valueField],
+        label: get(item, displayField),
+        imgUrl: item.avatar_url,
+        description: getDescription && getDescription(item),
+      }));
     });
   };
 

--- a/grafana-plugin/src/containers/GSelect/GSelect.tsx
+++ b/grafana-plugin/src/containers/GSelect/GSelect.tsx
@@ -32,7 +32,7 @@ interface GSelectProps {
   showWarningIfEmptyValue?: boolean;
   showError?: boolean;
   nullItemName?: string;
-  hiddenIdList?: string[]
+  excludedOptionsIdList?: string[];
   dropdownRender?: (menu: ReactElement) => ReactElement;
   getOptionLabel?: <T>(item: SelectableValue<T>) => React.ReactNode;
   getDescription?: (item: any) => React.ReactNode;
@@ -58,7 +58,7 @@ const GSelect = observer((props: GSelectProps) => {
     getOptionLabel,
     showWarningIfEmptyValue = false,
     getDescription,
-    hiddenIdList
+    excludedOptionsIdList,
   } = props;
 
   const store = useStore();
@@ -90,18 +90,18 @@ const GSelect = observer((props: GSelectProps) => {
       const items = Array.isArray(searchResult.results) ? searchResult.results : searchResult;
 
       const options = items.reduce((options: any[], item: any) => {
-        const isItemExcludedFromList = props.hiddenIdList?.includes(item[valueField])        
+        const isItemExcludedFromList = excludedOptionsIdList?.includes(item[valueField]);
         if (!isItemExcludedFromList) {
           options.push({
             value: item[valueField],
             label: get(item, displayField),
             imgUrl: item.avatar_url,
             description: getDescription && getDescription(item),
-          })
+          });
         }
 
-        return options
-      }, [])
+        return options;
+      }, []);
 
       return options;
     });

--- a/grafana-plugin/src/containers/GSelect/GSelect.tsx
+++ b/grafana-plugin/src/containers/GSelect/GSelect.tsx
@@ -32,6 +32,7 @@ interface GSelectProps {
   showWarningIfEmptyValue?: boolean;
   showError?: boolean;
   nullItemName?: string;
+  hiddenIdList?: string[]
   dropdownRender?: (menu: ReactElement) => ReactElement;
   getOptionLabel?: <T>(item: SelectableValue<T>) => React.ReactNode;
   getDescription?: (item: any) => React.ReactNode;
@@ -54,17 +55,14 @@ const GSelect = observer((props: GSelectProps) => {
     displayField = 'display_name',
     valueField = 'id',
     isMulti = false,
-    nullItemName,
-    dropdownRender,
     getOptionLabel,
     showWarningIfEmptyValue = false,
     getDescription,
+    hiddenIdList
   } = props;
 
   const store = useStore();
   const model = (store as any)[modelName];
-
-  const [query, setQuery] = useState<any>('');
 
   const onChangeCallback = useCallback(
     (option) => {
@@ -91,12 +89,20 @@ const GSelect = observer((props: GSelectProps) => {
       const searchResult = model.getSearchResult(query);
       const items = Array.isArray(searchResult.results) ? searchResult.results : searchResult;
 
-      const options = items.map((item: any) => ({
-        value: item[valueField],
-        label: get(item, displayField),
-        imgUrl: item.avatar_url,
-        description: getDescription && getDescription(item),
-      }));
+      const options = items.reduce((options: any[], item: any) => {
+        const isItemExcludedFromList = props.hiddenIdList?.includes(item[valueField])        
+        if (!isItemExcludedFromList) {
+          options.push({
+            value: item[valueField],
+            label: get(item, displayField),
+            imgUrl: item.avatar_url,
+            description: getDescription && getDescription(item),
+          })
+        }
+
+        return options
+      }, [])
+
       return options;
     });
   };

--- a/grafana-plugin/src/containers/GSelect/GSelect.tsx
+++ b/grafana-plugin/src/containers/GSelect/GSelect.tsx
@@ -89,7 +89,7 @@ const GSelect = observer((props: GSelectProps) => {
       const searchResult = model.getSearchResult(query);
       const items = Array.isArray(searchResult.results) ? searchResult.results : searchResult;
 
-      const options = items.reduce((options: any[], item: any) => {
+      return items.reduce((options: any[], item: any) => {
         const isItemExcludedFromList = excludedOptionsIdList?.includes(item[valueField]);
         if (!isItemExcludedFromList) {
           options.push({
@@ -99,11 +99,8 @@ const GSelect = observer((props: GSelectProps) => {
             description: getDescription && getDescription(item),
           });
         }
-
         return options;
       }, []);
-
-      return options;
     });
   };
 

--- a/grafana-plugin/src/containers/GSelect/GSelect.tsx
+++ b/grafana-plugin/src/containers/GSelect/GSelect.tsx
@@ -32,7 +32,7 @@ interface GSelectProps {
   showWarningIfEmptyValue?: boolean;
   showError?: boolean;
   nullItemName?: string;
-  filterOptions?: (item: any) => boolean;
+  filterOptions?: (id: any) => boolean;
   dropdownRender?: (menu: ReactElement) => ReactElement;
   getOptionLabel?: <T>(item: SelectableValue<T>) => React.ReactNode;
   getDescription?: (item: any) => React.ReactNode;


### PR DESCRIPTION
Fix for [#1206](https://github.com/grafana/oncall-private/issues/1206)

Changes:
- Added new `excludedOptionsIdList` option to `GSelect` component to allow excluding ids from the selection
- Hide active incident from the attach incident list