### PR TITLE
Generate unique distinction for alert groups with broken templates / unrenderable distinction

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -196,8 +196,8 @@ class Alert(models.Model):
         if grouping_id_template is not None:
             group_distinction, _ = apply_jinja_template(grouping_id_template, raw_request_data)
 
-        # Insert demo uuid to prevent grouping of demo alerts.
-        if is_demo:
+        # Insert demo uuid to prevent grouping of demo alerts or alerts with group_distinction=None
+        if is_demo or not group_distinction:
             group_distinction = cls.insert_demo_uuid(group_distinction)
 
         if group_distinction is not None:

--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -196,9 +196,9 @@ class Alert(models.Model):
         if grouping_id_template is not None:
             group_distinction, _ = apply_jinja_template(grouping_id_template, raw_request_data)
 
-        # Insert demo uuid to prevent grouping of demo alerts or alerts with group_distinction=None
+        # Insert random uuid to prevent grouping of demo alerts or alerts with group_distinction=None
         if is_demo or not group_distinction:
-            group_distinction = cls.insert_demo_uuid(group_distinction)
+            group_distinction = cls.insert_random_uuid(group_distinction)
 
         if group_distinction is not None:
             group_distinction = hashlib.md5(str(group_distinction).encode()).hexdigest()
@@ -224,7 +224,7 @@ class Alert(models.Model):
         )
 
     @staticmethod
-    def insert_demo_uuid(distinction):
+    def insert_random_uuid(distinction):
         if distinction is not None:
             distinction += str(uuid4())
         else:


### PR DESCRIPTION
There's a `unique_together` constraint on the `AlertGroup` model for fields (`channel_id`, `channel_filter_id`, `distinction`, `is_open_for_grouping`). We rely on this uniqueness when grouping the alert groups, but in some cases when the distinction cannot be rendered due to the templating errors, the `distinction` field is set to `None`. In this case there could exist multiple alert groups with `distinction=None` and it breaks the expectation of uniqueness for this list of fields.
This PR makes sure that every alert group has a distinction not equal to `None`. In case there's an error in templating, a unique distinction will be generated, so every alert will end up in different alert groups for channels with broken templates / unrenderable distinction.