### PR TITLE
Install ca-certificates package into engine container

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.9-alpine
-RUN apk add bash python3-dev build-base linux-headers pcre-dev mariadb-connector-c-dev openssl-dev libffi-dev git
+RUN apk add bash python3-dev build-base linux-headers pcre-dev mariadb-connector-c-dev openssl-dev libffi-dev git ca-certificates
 RUN pip install uwsgi
 
 WORKDIR /etc/app


### PR DESCRIPTION
I faced an issue when tried to connect Oncall plugin to self-hosted Grafana instance:

> 2022-08-25 10:40:51 source=engine:app google_trace_id=none logger=apps.grafana_plugin.helpers.client Error connecting to api instance HTTPSConnectionPool(host='grafana.example.net', port=443): Max retries exceeded with url: /grafana/api/org/users (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))

My Grafana is using TLS certificate issued by Thawte RSA CA 2018 and it should be trusted. I guess the reason is outdated ca-certificates package bundled in oncall container:

> bash-5.1# apk list | grep ca-cert
> ca-certificates-doc-**20211220**-r0 x86_64 {ca-certificates} (MPL-2.0 AND MIT)
> ca-certificates-**20211220**-r0 x86_64 {ca-certificates} (MPL-2.0 AND MIT) [installed]
> ca-certificates-bundle-**20211220**-r0 x86_64 {ca-certificates} (MPL-2.0 AND MIT) [installed]

Similar issue: #153

If this PR will be accepted, the `ca-certificates` package in container will be always up-to-date