### PR TITLE
Remove auto-recreating logic for UserNotificationPolicy

### DIFF
--- a/engine/apps/alerts/incident_log_builder/incident_log_builder.py
+++ b/engine/apps/alerts/incident_log_builder/incident_log_builder.py
@@ -659,7 +659,7 @@ class IncidentLogBuilder:
                     # last passed step order + 1
                     notification_policy_order = last_user_log.notification_policy.order + 1
 
-        notification_policies = UserNotificationPolicy.objects.get_or_create_for_user(
+        notification_policies = UserNotificationPolicy.objects.get_user_policies(
             user=user_to_notify, important=important
         )
 

--- a/engine/apps/alerts/incident_log_builder/incident_log_builder.py
+++ b/engine/apps/alerts/incident_log_builder/incident_log_builder.py
@@ -659,9 +659,7 @@ class IncidentLogBuilder:
                     # last passed step order + 1
                     notification_policy_order = last_user_log.notification_policy.order + 1
 
-        notification_policies = UserNotificationPolicy.objects.get_user_policies(
-            user=user_to_notify, important=important
-        )
+        notification_policies = UserNotificationPolicy.objects.filter(user=user_to_notify, important=important)
 
         for notification_policy in notification_policies:
             future_notification = notification_policy.order >= notification_policy_order

--- a/engine/apps/alerts/tasks/notify_group.py
+++ b/engine/apps/alerts/tasks/notify_group.py
@@ -58,7 +58,7 @@ def notify_group_task(alert_group_pk, escalation_policy_snapshot_order=None):
             if not user.is_notification_allowed:
                 continue
 
-            notification_policies = UserNotificationPolicy.objects.get_or_create_for_user(
+            notification_policies = UserNotificationPolicy.objects.get_user_policies(
                 user=user,
                 important=escalation_policy_step == EscalationPolicy.STEP_NOTIFY_GROUP_IMPORTANT,
             )

--- a/engine/apps/alerts/tasks/notify_group.py
+++ b/engine/apps/alerts/tasks/notify_group.py
@@ -58,7 +58,7 @@ def notify_group_task(alert_group_pk, escalation_policy_snapshot_order=None):
             if not user.is_notification_allowed:
                 continue
 
-            notification_policies = UserNotificationPolicy.objects.get_user_policies(
+            notification_policies = UserNotificationPolicy.objects.filter(
                 user=user,
                 important=escalation_policy_step == EscalationPolicy.STEP_NOTIFY_GROUP_IMPORTANT,
             )

--- a/engine/apps/alerts/tasks/notify_user.py
+++ b/engine/apps/alerts/tasks/notify_user.py
@@ -73,9 +73,7 @@ def notify_user_task(
         user_has_notification = UserHasNotification.objects.filter(pk=user_has_notification.pk).select_for_update()[0]
 
         if previous_notification_policy_pk is None:
-            notification_policy = UserNotificationPolicy.objects.get_user_policies(
-                user=user, important=important
-            ).first()
+            notification_policy = UserNotificationPolicy.objects.filter(user=user, important=important).first()
             # Here we collect a brief overview of notification steps configured for user to send it to thread.
             collected_steps_ids = []
             next_notification_policy = notification_policy.next()

--- a/engine/apps/alerts/tasks/notify_user.py
+++ b/engine/apps/alerts/tasks/notify_user.py
@@ -73,7 +73,7 @@ def notify_user_task(
         user_has_notification = UserHasNotification.objects.filter(pk=user_has_notification.pk).select_for_update()[0]
 
         if previous_notification_policy_pk is None:
-            notification_policy = UserNotificationPolicy.objects.get_or_create_for_user(
+            notification_policy = UserNotificationPolicy.objects.get_user_policies(
                 user=user, important=important
             ).first()
             # Here we collect a brief overview of notification steps configured for user to send it to thread.

--- a/engine/apps/base/models/user_notification_policy.py
+++ b/engine/apps/base/models/user_notification_policy.py
@@ -184,7 +184,7 @@ class UserNotificationPolicy(OrderedModel):
             return "Not set"
 
     def delete(self):
-        if self.order == 0:
+        if UserNotificationPolicy.objects.filter(important=self.important, user=self.user).count() == 1:
             raise UserNotificationPolicyCouldNotBeDeleted("Can't delete last user notification policy")
         else:
             super().delete()

--- a/engine/apps/base/models/user_notification_policy.py
+++ b/engine/apps/base/models/user_notification_policy.py
@@ -4,13 +4,14 @@ from typing import Tuple
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
-from django.db import models, transaction
+from django.db import models
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 from ordered_model.models import OrderedModel
 
 from apps.base.messaging import get_messaging_backends
 from apps.user_management.models import User
+from common.exceptions import UserNotificationPolicyCouldNotBeDeleted
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
 
@@ -69,23 +70,8 @@ def validate_channel_choice(value):
 
 
 class UserNotificationPolicyQuerySet(models.QuerySet):
-    def get_or_create_for_user(self, user: User, important: bool) -> "QuerySet[UserNotificationPolicy]":
-        with transaction.atomic():
-            User.objects.select_for_update().get(pk=user.pk)
-            return self._get_or_create_for_user(user, important)
-
-    def _get_or_create_for_user(self, user: User, important: bool) -> "QuerySet[UserNotificationPolicy]":
-        notification_policies = super().filter(user=user, important=important)
-
-        if notification_policies.exists():
-            return notification_policies
-
-        if important:
-            policies = self.create_important_policies_for_user(user)
-        else:
-            policies = self.create_default_policies_for_user(user)
-
-        return policies
+    def get_user_policies(self, user: User, important: bool) -> "QuerySet[UserNotificationPolicy]":
+        return self.filter(user=user, important=important)
 
     def create_default_policies_for_user(self, user: User) -> "QuerySet[UserNotificationPolicy]":
         model = self.model
@@ -196,6 +182,12 @@ class UserNotificationPolicy(OrderedModel):
                 return self.get_wait_delay_display()
         else:
             return "Not set"
+
+    def delete(self):
+        if self.order == 0:
+            raise UserNotificationPolicyCouldNotBeDeleted("Can't delete last user notification policy")
+        else:
+            super().delete()
 
 
 class NotificationChannelOptions:

--- a/engine/apps/base/models/user_notification_policy.py
+++ b/engine/apps/base/models/user_notification_policy.py
@@ -70,9 +70,6 @@ def validate_channel_choice(value):
 
 
 class UserNotificationPolicyQuerySet(models.QuerySet):
-    def get_user_policies(self, user: User, important: bool) -> "QuerySet[UserNotificationPolicy]":
-        return self.filter(user=user, important=important)
-
     def create_default_policies_for_user(self, user: User) -> "QuerySet[UserNotificationPolicy]":
         model = self.model
 

--- a/engine/apps/user_management/models/user.py
+++ b/engine/apps/user_management/models/user.py
@@ -261,8 +261,8 @@ class User(models.Model):
 @receiver(post_save, sender=User)
 def listen_for_user_model_save(sender, instance, created, *args, **kwargs):
     if created:
-        instance.notification_policies.create_default_policies_for_user()
-        instance.notification_policies.create_important_policies_for_user()
+        instance.notification_policies.create_default_policies_for_user(instance)
+        instance.notification_policies.create_important_policies_for_user(instance)
     drop_cached_ical_for_custom_events_for_organization.apply_async(
         (instance.organization_id,),
     )

--- a/engine/apps/user_management/models/user.py
+++ b/engine/apps/user_management/models/user.py
@@ -260,6 +260,9 @@ class User(models.Model):
 # TODO: check whether this signal can be moved to save method of the model
 @receiver(post_save, sender=User)
 def listen_for_user_model_save(sender, instance, created, *args, **kwargs):
+    if created:
+        instance.notification_policies.create_default_policies_for_user()
+        instance.notification_policies.create_important_policies_for_user()
     drop_cached_ical_for_custom_events_for_organization.apply_async(
         (instance.organization_id,),
     )

--- a/engine/common/exceptions/__init__.py
+++ b/engine/common/exceptions/__init__.py
@@ -1,1 +1,6 @@
-from .exceptions import MaintenanceCouldNotBeStartedError, TeamCanNotBeChangedError, UnableToSendDemoAlert  # noqa: F401
+from .exceptions import (  # noqa: F401
+    MaintenanceCouldNotBeStartedError,
+    TeamCanNotBeChangedError,
+    UnableToSendDemoAlert,
+    UserNotificationPolicyCouldNotBeDeleted,
+)

--- a/engine/common/exceptions/exceptions.py
+++ b/engine/common/exceptions/exceptions.py
@@ -17,3 +17,7 @@ class TeamCanNotBeChangedError(OperationCouldNotBePerformedError):
 
 class UnableToSendDemoAlert(OperationCouldNotBePerformedError):
     pass
+
+
+class UserNotificationPolicyCouldNotBeDeleted(OperationCouldNotBePerformedError):
+    pass

--- a/engine/conftest.py
+++ b/engine/conftest.py
@@ -68,6 +68,7 @@ from apps.telegram.tests.factories import (
     TelegramVerificationCodeFactory,
 )
 from apps.twilioapp.tests.factories import PhoneCallFactory, SMSFactory
+from apps.user_management.models.user import User, listen_for_user_model_save
 from apps.user_management.tests.factories import OrganizationFactory, TeamFactory, UserFactory
 from common.constants.role import Role
 
@@ -150,7 +151,9 @@ def make_organization():
 @pytest.fixture
 def make_user_for_organization():
     def _make_user_for_organization(organization, role=Role.ADMIN, **kwargs):
+        post_save.disconnect(listen_for_user_model_save, sender=User)
         user = UserFactory(organization=organization, role=role, **kwargs)
+        post_save.disconnect(listen_for_user_model_save, sender=User)
         return user
 
     return _make_user_for_organization


### PR DESCRIPTION
It's removed to get rid of select_for_update on User on each notify_user_task.

Now we checking presence of UserNotificationPolicies on each notification and if they are deleted we create set of default ones. For that logic select_for_update is needed to prevent duplicates of these sets, but it causes Deadlocks. (31 last day) So, I decided to remove this logic and just forbid to delete last UserNotificationPolicy.