### PR TITLE
Handle a exceptions on some retrying tasks

### DIFF
--- a/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
@@ -7,6 +7,7 @@ from dateutil.parser import parse
 from django.apps import apps
 from django.utils import timezone
 from django.utils.functional import cached_property
+from rest_framework.exceptions import ValidationError
 
 from apps.alerts.constants import NEXT_ESCALATION_DELAY
 from apps.alerts.escalation_snapshot.snapshot_classes import (
@@ -189,7 +190,10 @@ class EscalationSnapshotMixin:
         escalation_snapshot_object = None
         raw_escalation_snapshot = self.raw_escalation_snapshot
         if raw_escalation_snapshot is not None:
-            escalation_snapshot_object = self._deserialize_escalation_snapshot(raw_escalation_snapshot)
+            try:
+                escalation_snapshot_object = self._deserialize_escalation_snapshot(raw_escalation_snapshot)
+            except ValidationError as e:
+                logger.error(f"Error trying to deserialize raw escalation snapshot: {e}")
         return escalation_snapshot_object
 
     def _deserialize_escalation_snapshot(self, raw_escalation_snapshot) -> EscalationSnapshot:

--- a/engine/apps/base/models/user_notification_policy_log_record.py
+++ b/engine/apps/base/models/user_notification_policy_log_record.py
@@ -69,7 +69,8 @@ class UserNotificationPolicyLogRecord(models.Model):
         ERROR_NOTIFICATION_IN_SLACK_RATELIMIT,
         ERROR_NOTIFICATION_MESSAGING_BACKEND_ERROR,
         ERROR_NOTIFICATION_NOT_ALLOWED_USER_ROLE,
-    ) = range(26)
+        ERROR_NOTIFICATION_TELEGRAM_USER_IS_DEACTIVATED,
+    ) = range(27)
 
     # for this errors we want to send message to general log channel
     ERRORS_TO_SEND_IN_SLACK_CHANNEL = [
@@ -272,6 +273,11 @@ class UserNotificationPolicyLogRecord(models.Model):
                 self.notification_error_code == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_NOT_ALLOWED_USER_ROLE
             ):
                 result += f"failed to notify {user_verbal}, not allowed role"
+            elif (
+                self.notification_error_code
+                == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_TELEGRAM_USER_IS_DEACTIVATED
+            ):
+                result += f"failed to send telegram message to {user_verbal} because user has been deactivated"
             else:
                 # TODO: handle specific backend errors
                 try:

--- a/engine/apps/slack/scenarios/notification_delivery.py
+++ b/engine/apps/slack/scenarios/notification_delivery.py
@@ -87,12 +87,3 @@ class NotificationDeliveryStep(scenario_step.ScenarioStep):
                 print(e)
             else:
                 raise e
-
-    def get_color_id(self, color):
-        if color == "red":
-            color_id = "#FF0000"
-        elif color == "yellow":
-            color_id = "#c6c000"
-        else:
-            color_id = color
-        return color_id

--- a/engine/apps/telegram/models/connectors/personal.py
+++ b/engine/apps/telegram/models/connectors/personal.py
@@ -111,6 +111,13 @@ class TelegramToUserConnector(models.Model):
                         notification_policy,
                         UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_TELEGRAM_TOKEN_ERROR,
                     )
+                elif e.message == "Forbidden: user is deactivated":
+                    TelegramToUserConnector.create_telegram_notification_error(
+                        alert_group,
+                        self.user,
+                        notification_policy,
+                        UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_TELEGRAM_USER_IS_DEACTIVATED,
+                    )
                 else:
                     raise e
         else:

--- a/engine/apps/telegram/tasks.py
+++ b/engine/apps/telegram/tasks.py
@@ -119,7 +119,14 @@ def send_link_to_channel_message_or_fallback_to_full_incident(
 @ignore_bot_deleted
 def send_log_and_actions_message(self, channel_chat_id, group_chat_id, channel_message_id, reply_to_message_id):
     with OkToRetry(task=self, exc=TelegramMessage.DoesNotExist, num_retries=5):
-        channel_message = TelegramMessage.objects.get(chat_id=channel_chat_id, message_id=channel_message_id)
+        try:
+            channel_message = TelegramMessage.objects.get(chat_id=channel_chat_id, message_id=channel_message_id)
+        except TelegramMessage.DoesNotExist:
+            logger.warning(
+                f"Could not send log and actions message, telegram message does not exit "
+                f" chat_id={channel_chat_id} message_id={channel_message_id}"
+            )
+            return
 
         if channel_message.discussion_group_message_id is None:
             channel_message.discussion_group_message_id = reply_to_message_id

--- a/engine/apps/telegram/tasks.py
+++ b/engine/apps/telegram/tasks.py
@@ -123,7 +123,7 @@ def send_log_and_actions_message(self, channel_chat_id, group_chat_id, channel_m
             channel_message = TelegramMessage.objects.get(chat_id=channel_chat_id, message_id=channel_message_id)
         except TelegramMessage.DoesNotExist:
             logger.warning(
-                f"Could not send log and actions message, telegram message does not exit "
+                f"Could not send log and actions message, telegram message does not exist "
                 f" chat_id={channel_chat_id} message_id={channel_message_id}"
             )
             return


### PR DESCRIPTION
Fixes for a few tasks retrying due to exceptions:

apps.telegram.tasks.send_log_and_actions_message
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/etc/app/apps/telegram/decorators.py", line 23, in decorated
    return f(*args, **kwargs)
  File "/etc/app/apps/telegram/decorators.py", line 76, in decorated
    return f(*args, **kwargs)
  File "/etc/app/apps/telegram/decorators.py", line 32, in decorated
    return f(*args, **kwargs)
  File "/etc/app/apps/telegram/tasks.py", line 122, in send_log_and_actions_message
    channel_message = TelegramMessage.objects.get(chat_id=channel_chat_id, message_id=channel_message_id)
  File "/usr/local/lib/python3.9/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/db/models/query.py", line 435, in get
    raise self.model.DoesNotExist(
apps.telegram.models.message.TelegramMessage.DoesNotExist: TelegramMessage matching query does not exist.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 54, in run
    ret = task.retry(exc=exc, **retry_kwargs)
  File "/etc/app/common/custom_celery_tasks/dedicated_queue_retry_task.py", line 16, in retry
    return super().retry(
  File "/usr/local/lib/python3.9/site-packages/celery/app/task.py", line 738, in retry
    raise ret
celery.exceptions.Retry: Retry in 509s: DoesNotExist('TelegramMessage matching query does not exist.')
```

apps.alerts.tasks.calculcate_escalation_finish_time.calculate_escalation_finish_time
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/etc/app/apps/alerts/tasks/calculcate_escalation_finish_time.py", line 13, in calculate_escalation_finish_time
    if alert_group.escalation_snapshot:
  File "/usr/local/lib/python3.9/site-packages/django/utils/functional.py", line 48, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/etc/app/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py", line 192, in escalation_snapshot
    escalation_snapshot_object = self._deserialize_escalation_snapshot(raw_escalation_snapshot)
  File "/etc/app/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py", line 202, in _deserialize_escalation_snapshot
    deserialized_escalation_snapshot = EscalationSnapshot.serializer().to_internal_value(raw_escalation_snapshot)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 489, in to_internal_value
    raise ValidationError(errors)
rest_framework.exceptions.ValidationError: {'escalation_policies_snapshots': [{}, {'last_notified_user': [ErrorDetail(string='Invalid pk "952445" - object does not exist.', code='does_not_exist')]}]}

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 54, in run
    ret = task.retry(exc=exc, **retry_kwargs)
  File "/etc/app/common/custom_celery_tasks/dedicated_queue_retry_task.py", line 16, in retry
    return super().retry(
  File "/usr/local/lib/python3.9/site-packages/celery/app/task.py", line 738, in retry
    raise ret
celery.exceptions.Retry: Retry in 482s: ValidationError(OrderedDict([('escalation_policies_snapshots', [{}, {'last_notified_user': [ErrorDetail(string='Invalid pk "952445" - object does not exist.', code='does_not_exist')]}])]))
```

apps.alerts.tasks.notify_user.perform_notification
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/etc/app/apps/alerts/tasks/notify_user.py", line 281, in perform_notification
    TelegramToUserConnector.notify_user(user, alert_group, notification_policy)
  File "/etc/app/apps/telegram/models/connectors/personal.py", line 29, in notify_user
    user_connector.notify(alert_group=alert_group, notification_policy=notification_policy)
  File "/etc/app/apps/telegram/models/connectors/personal.py", line 48, in notify
    self.send_full_incident(alert_group=alert_group, notification_policy=notification_policy)
  File "/etc/app/apps/telegram/models/connectors/personal.py", line 115, in send_full_incident
    raise e
  File "/etc/app/apps/telegram/models/connectors/personal.py", line 88, in send_full_incident
    telegram_client.send_message(
  File "/etc/app/apps/telegram/client.py", line 57, in send_message
    raw_message = self.send_raw_message(
  File "/etc/app/apps/telegram/client.py", line 74, in send_raw_message
    message = self.api_client.send_message(
  File "/usr/local/lib/python3.9/site-packages/telegram/bot.py", line 133, in decorator
    result = func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/telegram/bot.py", line 525, in send_message
    return self._message(  # type: ignore[return-value]
  File "/usr/local/lib/python3.9/site-packages/telegram/bot.py", line 339, in _message
    result = self._post(endpoint, data, timeout=timeout, api_kwargs=api_kwargs)
  File "/usr/local/lib/python3.9/site-packages/telegram/bot.py", line 298, in _post
    return self.request.post(
  File "/usr/local/lib/python3.9/site-packages/telegram/utils/request.py", line 361, in post
    result = self._request_wrapper(
  File "/usr/local/lib/python3.9/site-packages/telegram/utils/request.py", line 277, in _request_wrapper
    raise Unauthorized(message)
telegram.error.Unauthorized: Forbidden: user is deactivated

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 54, in run
    ret = task.retry(exc=exc, **retry_kwargs)
  File "/etc/app/common/custom_celery_tasks/dedicated_queue_retry_task.py", line 16, in retry
    return super().retry(
  File "/usr/local/lib/python3.9/site-packages/celery/app/task.py", line 738, in retry
    raise ret
celery.exceptions.Retry: Retry in 442s: Unauthorized()
```