### PR TITLE
Add task to delete organizations if their stack has been deleted in gcom

### DIFF
--- a/engine/apps/grafana_plugin/helpers/client.py
+++ b/engine/apps/grafana_plugin/helpers/client.py
@@ -121,6 +121,8 @@ class GrafanaAPIClient(APIClient):
 
 
 class GcomAPIClient(APIClient):
+    ACTIVE_INSTANCE_QUERY = "instances?status=active"
+    DELETED_INSTANCE_QUERY = "instances?status=deleted&includeDeleted=true"
     STACK_STATUS_DELETED = "deleted"
 
     def __init__(self, api_token: str):
@@ -132,8 +134,8 @@ class GcomAPIClient(APIClient):
     def get_instance_info(self, stack_id: str):
         return self.api_get(f"instances/{stack_id}")
 
-    def get_active_instances(self):
-        return self.api_get("instances?status=active")
+    def get_instances(self, query: str):
+        return self.api_get(query)
 
     def is_stack_deleted(self, stack_id: str) -> bool:
         instance_info, call_status = self.get_instance_info(stack_id)

--- a/engine/apps/grafana_plugin/helpers/gcom.py
+++ b/engine/apps/grafana_plugin/helpers/gcom.py
@@ -99,8 +99,8 @@ def get_instance_ids(query: str) -> Tuple[Optional[set], bool]:
     if not instances:
         return None, True
 
-    active_ids = set(i["id"] for i in instances["items"])
-    return active_ids, True
+    ids = set(i["id"] for i in instances["items"])
+    return ids, True
 
 
 def get_active_instance_ids() -> Tuple[Optional[set], bool]:

--- a/engine/apps/grafana_plugin/helpers/gcom.py
+++ b/engine/apps/grafana_plugin/helpers/gcom.py
@@ -89,15 +89,23 @@ def check_token(token_string: str, context: dict):
         return PluginAuthToken.validate_token_string(token_string, context=context)
 
 
-def get_active_instance_ids() -> Tuple[Optional[set], bool]:
+def get_instance_ids(query: str) -> Tuple[Optional[set], bool]:
     if not settings.GRAFANA_COM_API_TOKEN or settings.LICENSE != settings.CLOUD_LICENSE_NAME:
         return None, False
 
     client = GcomAPIClient(settings.GRAFANA_COM_API_TOKEN)
-    active_instances, status = client.get_active_instances()
+    instances, status = client.get_instances(query)
 
-    if not active_instances:
+    if not instances:
         return None, True
 
-    active_ids = set(i["id"] for i in active_instances["items"])
+    active_ids = set(i["id"] for i in instances["items"])
     return active_ids, True
+
+
+def get_active_instance_ids() -> Tuple[Optional[set], bool]:
+    return get_instance_ids(GcomAPIClient.ACTIVE_INSTANCE_QUERY)
+
+
+def get_deleted_instance_ids() -> Tuple[Optional[set], bool]:
+    return get_instance_ids(GcomAPIClient.DELETED_INSTANCE_QUERY)

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -1,8 +1,8 @@
 import logging
 
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from django.utils import timezone
-from rest_framework import status
 
 from apps.grafana_plugin.helpers.client import GcomAPIClient, GrafanaAPIClient
 from apps.user_management.models import Organization, Team, User
@@ -15,13 +15,6 @@ def sync_organization(organization):
     client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
 
     api_users, call_status = client.get_users()
-    status_code = call_status["status_code"]
-
-    # if stack is 404ing, delete the organization in case gcom stack is deleted.
-    if status_code == status.HTTP_404_NOT_FOUND:
-        is_deleted = delete_organization_if_needed(organization)
-        if is_deleted:
-            return
 
     sync_instance_info(organization)
 
@@ -82,19 +75,31 @@ def sync_users_and_teams(client, api_users, organization):
 
 
 def delete_organization_if_needed(organization):
+    # Organization has a manually set API token, it will not be found within GCOM
+    # and would need to be deleted manually.
     if organization.gcom_token is None:
         return False
 
-    gcom_client = GcomAPIClient(organization.gcom_token)
-    is_stack_deleted = gcom_client.is_stack_deleted(organization.stack_id)
-
+    # Use common token as organization.gcom_token could be already revoked
+    client = GcomAPIClient(settings.GRAFANA_COM_API_TOKEN)
+    is_stack_deleted = client.is_stack_deleted(organization.stack_id)
     if not is_stack_deleted:
         return False
 
-    logger.info(
-        f"Deleting organization due to stack deletion. "
-        f"pk: {organization.pk}, stack_id: {organization.stack_id}, org_id: {organization.org_id}"
-    )
     organization.delete()
-
     return True
+
+
+def cleanup_organization(organization_pk):
+    logger.info(f"Start cleanup Organization {organization_pk}")
+    try:
+        organization = Organization.objects.get(pk=organization_pk)
+        if delete_organization_if_needed(organization):
+            logger.info(
+                f"Deleting organization due to stack deletion. "
+                f"pk: {organization.pk}, stack_id: {organization.stack_id}, org_id: {organization.org_id}"
+            )
+        else:
+            logger.info(f"Organization {organization_pk} not deleted in gcom, no action taken")
+    except Organization.DoesNotExist:
+        logger.info(f"Organization {organization_pk} was not found")

--- a/engine/apps/user_management/tests/test_sync.py
+++ b/engine/apps/user_management/tests/test_sync.py
@@ -191,7 +191,7 @@ def test_cleanup_organization_deleted(make_organization):
     organization = make_organization(gcom_token="TEST_GCOM_TOKEN")
 
     with patch.object(GcomAPIClient, "get_instance_info", return_value=({"status": "deleted"}, None)):
-        cleanup_organization(organization)
+        cleanup_organization(organization.id)
 
     with pytest.raises(ObjectDoesNotExist):
         organization.refresh_from_db()

--- a/engine/apps/user_management/tests/test_sync.py
+++ b/engine/apps/user_management/tests/test_sync.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist
 
 from apps.grafana_plugin.helpers.client import GcomAPIClient, GrafanaAPIClient
 from apps.user_management.models import Team, User
-from apps.user_management.sync import sync_organization
+from apps.user_management.sync import cleanup_organization, sync_organization
 
 
 @pytest.mark.django_db
@@ -187,12 +187,11 @@ def test_duplicate_user_ids(make_organization, make_user_for_organization):
 
 
 @pytest.mark.django_db
-def test_sync_organization_deleted(make_organization):
+def test_cleanup_organization_deleted(make_organization):
     organization = make_organization(gcom_token="TEST_GCOM_TOKEN")
 
-    with patch.object(GrafanaAPIClient, "get_users", return_value=(None, {"status_code": 404})):
-        with patch.object(GcomAPIClient, "get_instance_info", return_value=({"status": "deleted"}, None)):
-            sync_organization(organization)
+    with patch.object(GcomAPIClient, "get_instance_info", return_value=({"status": "deleted"}, None)):
+        cleanup_organization(organization)
 
     with pytest.raises(ObjectDoesNotExist):
         organization.refresh_from_db()

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -335,6 +335,11 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute="*/30"),
         "args": (),
     },
+    "start_cleanup_deleted_organizations": {
+        "task": "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_organizations",
+        "schedule": crontab(hour="*", minute=15),
+        "args": (),
+    },
     "process_failed_to_invoke_celery_tasks": {
         "task": "apps.base.tasks.process_failed_to_invoke_celery_tasks",
         "schedule": 60 * 10,

--- a/engine/settings/prod_without_db.py
+++ b/engine/settings/prod_without_db.py
@@ -140,6 +140,8 @@ CELERY_TASK_ROUTES = {
     "apps.schedules.tasks.drop_cached_ical.drop_cached_ical_task": {"queue": "critical"},
     # LONG
     "apps.alerts.tasks.check_escalation_finished.check_escalation_finished_task": {"queue": "long"},
+    "apps.grafana_plugin.tasks.sync.cleanup_organization_async": {"queue": "long"},
+    "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_organizations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_sync_organizations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.sync_organization_async": {"queue": "long"},
     # SLACK


### PR DESCRIPTION
Code to delete organizations for stacks that no longer exist was not being run because we filter for active stacks in the start_sync_organizations task.   Deleted stacks will never be active so they are always being skipped.

This adds a task to get deleted instances from gcom and match with organizations that have not synchronized in a while and delete them if their corresponding stack has been deleted in gcom.