### PR TITLE
Use stack-slug instead of org-title

### DIFF
--- a/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
+++ b/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
@@ -92,7 +92,7 @@ class GrafanaAlertingSyncManager:
         datasources, response_info = self.client.get_datasources()
         if datasources is None:
             logger.warning(
-                f"Failed to get datasource list for organization {self.alert_receive_channel.organization.org_title}, "
+                f"Failed to get datasource list for organization {self.alert_receive_channel.organization.stack_slug}, "
                 f"{response_info}"
             )
             return

--- a/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
@@ -24,7 +24,7 @@ class AlertGroupSmsRenderer(AlertGroupBaseRenderer):
             incident_link = self.alert_group.web_link
         return (
             f"You are invited to check an incident #{self.alert_group.inside_organization_number} with title "
-            f'"{title}" in Grafana OnCall organization: "{self.alert_group.channel.organization.org_title}", '
+            f'"{title}" in Grafana OnCall organization: "{self.alert_group.channel.organization.stack_slug}", '
             f"alert channel: {self.alert_group.channel.short_name}, "
             f"alerts registered: {self.alert_group.alerts.count()}, "
             f"{incident_link}\n"

--- a/engine/apps/slack/scenarios/manual_incident.py
+++ b/engine/apps/slack/scenarios/manual_incident.py
@@ -436,7 +436,7 @@ def _get_organization_select(slack_team_identity, slack_user_identity, value, in
             {
                 "text": {
                     "type": "plain_text",
-                    "text": f"{org.org_title}",
+                    "text": f"{org.stack_slug}",
                     "emoji": True,
                 },
                 "value": f"{org.pk}",

--- a/engine/apps/twilioapp/phone_manager.py
+++ b/engine/apps/twilioapp/phone_manager.py
@@ -64,7 +64,7 @@ class PhoneManager:
     def notify_about_changed_verified_phone_number(self, phone_number, connected=False):
         text = (
             f"This phone number has been {'connected to' if connected else 'disconnected from'} Grafana OnCall team "
-            f'"{self.user.organization.org_title}"\nYour Grafana OnCall <3'
+            f'"{self.user.organization.stack_slug}"\nYour Grafana OnCall <3'
         )
         try:
             twilio_client.send_message(text, phone_number)


### PR DESCRIPTION
Use of org-title is confusing, org-title is the Grafana cloud org title, users may have multiple Grafana/OnCall instances within their cloud org.  Stack slug is unique to the active OnCall installation and should be less confusing.