### PR TITLE
Increase num of `getPluginSyncStatus` retries to 10

### DIFF
--- a/grafana-plugin/src/state/rootBaseStore.ts
+++ b/grafana-plugin/src/state/rootBaseStore.ts
@@ -219,7 +219,7 @@ export class RootBaseStore {
           this.handleSyncException(e);
         });
 
-      if (counter >= 5) {
+      if (counter >= 10) {
         clearInterval(interval);
         this.retrySync = true;
       }


### PR DESCRIPTION
Already 5 retries (5 * 2 sec = 10 sec) is not enough in our cases. Usually, we have 15 seconds of latency.