### PR TITLE
Fix empty byday in ICAL rrule

### DIFF
--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -441,7 +441,7 @@ class CustomOnCallShift(models.Model):
             rules["freq"] = [self.get_frequency_display().upper()]
             if self.event_interval is not None:
                 rules["interval"] = [self.event_interval]
-            if self.by_day is not None:
+            if self.by_day:
                 rules["byday"] = self.by_day
             if self.by_month is not None:
                 rules["bymonth"] = self.by_month


### PR DESCRIPTION
This fixes a bug when `shift.by_day` is equal to empty list and the final ICAL rrule is ending up containing `BYDAY=;` (which is parsed incorrectly)