### PR TITLE
Allow customized SMS message, fix #197

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
@@ -18,15 +18,6 @@ class AlertGroupSmsRenderer(AlertGroupBaseRenderer):
     def render(self):
         templated_alert = self.alert_renderer.templated_alert
         title = str_or_backup(templated_alert.title, DEFAULT_BACKUP_TITLE)
-        if self.alert_group.channel.organization.slack_team_identity and (permalink := self.alert_group.permalink):
-            incident_link = permalink
-        else:
-            incident_link = self.alert_group.web_link
         return (
-            f"You are invited to check an incident #{self.alert_group.inside_organization_number} with title "
-            f'"{title}" in Grafana OnCall organization: "{self.alert_group.channel.organization.stack_slug}", '
-            f"alert channel: {self.alert_group.channel.short_name}, "
-            f"alerts registered: {self.alert_group.alerts.count()}, "
-            f"{incident_link}\n"
-            f"Your Grafana OnCall <3"
+            f"Grafana OnCall alert : {title}"
         )

--- a/engine/apps/alerts/incident_appearance/templaters/alert_templater.py
+++ b/engine/apps/alerts/incident_appearance/templaters/alert_templater.py
@@ -167,6 +167,7 @@ class AlertTemplater(ABC):
             context = {
                 "grafana_oncall_incident_id": self.incident_id,
                 "grafana_oncall_link": self.link,
+                "grafana_oncall_organization": channel.organization.stack_slug,
                 "integration_name": channel.verbal_name,
                 "source_link": templated_alert.source_link,
                 "amixr_incident_id": self.incident_id,  # TODO: decide on variable names

--- a/engine/config_integrations/webhook.py
+++ b/engine/config_integrations/webhook.py
@@ -32,7 +32,18 @@ web_message = """\
 
 web_image_url = slack_image_url
 
-sms_title = web_title
+sms_title = """\
+{{ payload.message }}, 
+Incident #
+{{ grafana_oncall_incident_id }}, 
+Organization: 
+{{ grafana_oncall_organization }}, 
+Alert channel: 
+{{ integration_name }},
+Link: 
+{{ grafana_oncall_link }}
+
+"""
 
 phone_call_title = sms_title
 

--- a/grafana-plugin/src/components/AlertTemplates/AlertTemplatesForm.tsx
+++ b/grafana-plugin/src/components/AlertTemplates/AlertTemplatesForm.tsx
@@ -205,9 +205,9 @@ const AlertTemplatesForm = (props: AlertTemplatesFormProps) => {
                 {activeGroup === 'telegram' && ', html'}
                 {' supported. '}
                 Reserved variables available: <Text keyboard>payload</Text>, <Text keyboard>grafana_oncall_link</Text>,{' '}
-                <Text keyboard>grafana_oncall_incident_id</Text>, <Text keyboard>integration_name</Text>,
-                <Text keyboard>source_link</Text>. Press <Text keyboard>Ctrl</Text>+<Text keyboard>Space</Text> to get
-                suggestions
+                <Text keyboard>grafana_oncall_incident_id</Text>, <Text keyboard>grafana_oncall_organization</Text>,
+                <Text keyboard>integration_name</Text>, <Text keyboard>source_link</Text>. 
+                Press <Text keyboard>Ctrl</Text>+<Text keyboard>Space</Text> to get suggestions
               </p>
             </Text>
             {groups[activeGroup].map((activeTemplate: any) => (


### PR DESCRIPTION
#### What's changed
- Allows Customized SMS messages for Oncall with a Fixed prefix - "**Grafana OnCall alert:**" as suggested by @Matvey-Kuk to avoid system misuse of any kind. 
- The default content of the sms_title is changed to a template that is very similar to the current SMS format. 
- A new `grafana_onlink_organization` variable is added to the reserved template variable to be used within a message.