### PR TITLE
Use phonenumbers for validation instead of regex

### DIFF
--- a/engine/apps/base/utils.py
+++ b/engine/apps/base/utils.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 import phonenumbers
 from django.apps import apps
+from phonenumbers import NumberParseException
 from python_http_client import UnauthorizedError
 from sendgrid import SendGridAPIClient
 from telegram import Bot
@@ -126,8 +127,11 @@ class LiveSettingValidator:
 
     @staticmethod
     def _is_phone_number_valid(phone_number):
-        ph_num = phonenumbers.parse(phone_number)
-        return phonenumbers.is_valid_number(ph_num)
+        try:
+            ph_num = phonenumbers.parse(phone_number)
+            return phonenumbers.is_valid_number(ph_num)
+        except NumberParseException:
+            return False
 
     @staticmethod
     def _prettify_twilio_error(exc):

--- a/engine/apps/base/utils.py
+++ b/engine/apps/base/utils.py
@@ -2,6 +2,7 @@ import json
 import re
 from urllib.parse import urlparse
 
+import phonenumbers
 from django.apps import apps
 from python_http_client import UnauthorizedError
 from sendgrid import SendGridAPIClient
@@ -125,7 +126,8 @@ class LiveSettingValidator:
 
     @staticmethod
     def _is_phone_number_valid(phone_number):
-        return re.match(r"^\+\d{11}$", phone_number)
+        ph_num = phonenumbers.parse(phone_number)
+        return phonenumbers.is_valid_number(ph_num)
 
     @staticmethod
     def _prettify_twilio_error(exc):


### PR DESCRIPTION
Use phonenumbers package instead of regex to validate live settings to support EU number for Twilio