### PR TITLE
Feat 549 - add telegram permalink to alert groups http response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-## v1.0.37 (2022-09-23)
+## v1.0.38 (2022-09-22)
+
+- Add `telegram` key to `permalinks` property in `AlertGroup` public API response schema
+
+## v1.0.37 (2022-09-21)
 
 - Improve API token creation form
 - Fix alert group bulk action bugs

--- a/docs/sources/oncall-api-reference/alertgroups.md
+++ b/docs/sources/oncall-api-reference/alertgroups.md
@@ -35,7 +35,8 @@ The above command returns JSON structured in the following way:
       "acknowledged_at": null,
       "title": "Memory above 90% threshold",
       "permalinks": {
-        "slack": null
+        "slack": "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+        "telegram": "https://t.me/c/5354/1234?thread=1234"
       }
     }
   ]

--- a/engine/apps/alerts/incident_appearance/renderers/email_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/email_renderer.py
@@ -29,7 +29,7 @@ class AlertGroupEmailRenderer(AlertGroupBaseRenderer):
         content = render_to_string(
             "email_notification.html",
             {
-                "url": self.alert_group.permalink or self.alert_group.web_link,
+                "url": self.alert_group.slack_permalink or self.alert_group.web_link,
                 "title": str_or_backup(templated_alert.title, title_fallback),
                 "message": str_or_backup(templated_alert.message, ""),  # not render message it all if smth go wrong
                 "amixr_team": self.alert_group.channel.organization,

--- a/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
@@ -18,7 +18,9 @@ class AlertGroupSmsRenderer(AlertGroupBaseRenderer):
     def render(self):
         templated_alert = self.alert_renderer.templated_alert
         title = str_or_backup(templated_alert.title, DEFAULT_BACKUP_TITLE)
-        if self.alert_group.channel.organization.slack_team_identity and (permalink := self.alert_group.permalink):
+        if self.alert_group.channel.organization.slack_team_identity and (
+            permalink := self.alert_group.slack_permalink
+        ):
             incident_link = permalink
         else:
             incident_link = self.alert_group.web_link

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -407,10 +407,8 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
 
     @property
     def telegram_permalink(self) -> typing.Optional[str]:
-        main_telegram_message = self.telegram_messages.all()
-
-        if main_telegram_message:
-            return main_telegram_message[0].link
+        if hasattr(self, "prefetched_telegram_messages"):
+            return self.prefetched_telegram_messages[0].link if self.prefetched_telegram_messages else None
         return None
 
     @property

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -406,9 +406,18 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
             return self.slack_message.permalink
 
     @property
+    def telegram_permalink(self) -> typing.Optional[str]:
+        main_telegram_message = self.telegram_messages.all()
+
+        if main_telegram_message:
+            return main_telegram_message[0].link
+        return None
+
+    @property
     def permalinks(self) -> Permalinks:
         return {
             "slack": self.slack_permalink,
+            "telegram": self.telegram_permalink,
         }
 
     @property

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -401,15 +401,14 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         raise NotImplementedError
 
     @property
-    def permalink(self):
+    def slack_permalink(self):
         if self.slack_message is not None:
             return self.slack_message.permalink
 
     @property
     def permalinks(self) -> Permalinks:
-        # TODO: refactor 'permalink' property (maybe 'slack_permalink'?) once we add the next permalink
         return {
-            "slack": self.permalink,
+            "slack": self.slack_permalink,
         }
 
     @property

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -408,19 +408,21 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
     @property
     def telegram_permalink(self) -> typing.Optional[str]:
         """
-            This property will attempt to access an attribute, `prefetched_telegram_messages`, representing a list of
-            prefetched telegram messages. If this attribute does not exist, it falls back to performing a query.
+        This property will attempt to access an attribute, `prefetched_telegram_messages`, representing a list of
+        prefetched telegram messages. If this attribute does not exist, it falls back to performing a query.
 
-            See `apps.public_api.serializers.incidents.IncidentSerializer.PREFETCH_RELATED` as an example.
+        See `apps.public_api.serializers.incidents.IncidentSerializer.PREFETCH_RELATED` as an example.
         """
         from apps.telegram.models.message import TelegramMessage
 
         if hasattr(self, "prefetched_telegram_messages"):
             return self.prefetched_telegram_messages[0].link if self.prefetched_telegram_messages else None
 
-        main_telegram_messages = self.telegram_messages.filter(chat_id__startswith="-", message_type=TelegramMessage.ALERT_GROUP_MESSAGE)
+        main_telegram_message = self.telegram_messages.filter(
+            chat_id__startswith="-", message_type=TelegramMessage.ALERT_GROUP_MESSAGE
+        ).first()
 
-        return main_telegram_messages[0].link if main_telegram_messages else None
+        return main_telegram_message.link if main_telegram_message else None
 
     @property
     def permalinks(self) -> Permalinks:

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -407,9 +407,20 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
 
     @property
     def telegram_permalink(self) -> typing.Optional[str]:
+        """
+            This property will attempt to access an attribute, `prefetched_telegram_messages`, representing a list of
+            prefetched telegram messages. If this attribute does not exist, it falls back to performing a query.
+
+            See `apps.public_api.serializers.incidents.IncidentSerializer.PREFETCH_RELATED` as an example.
+        """
+        from apps.telegram.models.message import TelegramMessage
+
         if hasattr(self, "prefetched_telegram_messages"):
             return self.prefetched_telegram_messages[0].link if self.prefetched_telegram_messages else None
-        return None
+
+        main_telegram_messages = self.telegram_messages.filter(chat_id__startswith="-", message_type=TelegramMessage.ALERT_GROUP_MESSAGE)
+
+        return main_telegram_messages[0].link if main_telegram_messages else None
 
     @property
     def permalinks(self) -> Permalinks:

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -132,7 +132,7 @@ class AlertGroupSerializer(AlertGroupListSerializer):
         fields = AlertGroupListSerializer.Meta.fields + [
             "alerts",
             "render_after_resolve_report_json",
-            "permalink",
+            "slack_permalink",
             "last_alert_at",
         ]
 

--- a/engine/apps/public_api/serializers/incidents.py
+++ b/engine/apps/public_api/serializers/incidents.py
@@ -1,6 +1,8 @@
+from django.db.models import Prefetch
 from rest_framework import serializers
 
 from apps.alerts.models import AlertGroup
+from apps.telegram.models.message import TelegramMessage
 from common.api_helpers.mixins import EagerLoadingMixin
 
 
@@ -15,7 +17,13 @@ class IncidentSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     state = serializers.SerializerMethodField()
 
     SELECT_RELATED = ["channel", "channel_filter", "slack_message"]
-    PREFETCH_RELATED = ["alerts"]
+    PREFETCH_RELATED = [
+        "alerts",
+        Prefetch(
+            "telegram_messages",
+            TelegramMessage.objects.filter(chat_id__startswith="-", message_type=TelegramMessage.ALERT_GROUP_MESSAGE),
+        ),
+    ]
 
     class Meta:
         model = AlertGroup

--- a/engine/apps/public_api/serializers/incidents.py
+++ b/engine/apps/public_api/serializers/incidents.py
@@ -22,6 +22,7 @@ class IncidentSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         Prefetch(
             "telegram_messages",
             TelegramMessage.objects.filter(chat_id__startswith="-", message_type=TelegramMessage.ALERT_GROUP_MESSAGE),
+            to_attr="prefetched_telegram_messages",
         ),
     ]
 

--- a/engine/apps/public_api/tests/test_incidents.py
+++ b/engine/apps/public_api/tests/test_incidents.py
@@ -41,6 +41,7 @@ def construct_expected_response_from_incidents(incidents):
                 "title": None,
                 "permalinks": {
                     "slack": None,
+                    "telegram": None,
                 },
             }
         )

--- a/engine/apps/slack/scenarios/distribute_alerts.py
+++ b/engine/apps/slack/scenarios/distribute_alerts.py
@@ -354,9 +354,9 @@ class SelectAttachGroupStep(
                 f"attached incidents ({attached_incidents.count()}):\n"
             )
             for dependent_alert in attached_incidents:
-                if dependent_alert.permalink:
+                if dependent_alert.slack_permalink:
                     dependent_alert_text = (
-                        f"\n<{dependent_alert.permalink}|{dependent_alert.long_verbose_name_without_formatting}>"
+                        f"\n<{dependent_alert.slack_permalink}|{dependent_alert.long_verbose_name_without_formatting}>"
                     )
                 else:
                     dependent_alert_text = f"\n{dependent_alert.long_verbose_name}"

--- a/grafana-plugin/src/models/alertgroup/alertgroup.types.ts
+++ b/grafana-plugin/src/models/alertgroup/alertgroup.types.ts
@@ -55,7 +55,7 @@ export interface Alert {
   acknowledged_by_user: User;
   acknowledged_on_source: boolean;
   channel: Channel;
-  permalink?: string;
+  slack_permalink?: string;
   related_users: User[];
   render_after_resolve_report_json?: TimeLineItem[];
   render_for_slack: { attachments: any[] };

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -297,7 +297,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                   Copy Link
                 </Button>
               </CopyToClipboard>
-              <a href={incident.permalink} target="_blank" rel="noreferrer">
+              <a href={incident.slack_permalink} target="_blank" rel="noreferrer">
                 <Button variant="primary" size="sm" icon="slack">
                   View in Slack
                 </Button>


### PR DESCRIPTION
This PR closes #549.

It does the following:
- renames/refactors the `AlertGroup` model's `permalink` property to `slack_permalink`
- adds a `telegram` key to the `permalinks` object in the alert group's public API HTTP response object

**Tested locally**
![Screen Shot 2022-09-22 at 18 09 46](https://user-images.githubusercontent.com/9406895/191797943-1324d725-2872-4255-8c76-64a0aeff9489.png)


