### PR TITLE
Use create_engine_url to add prefix to previous/next links

### DIFF
--- a/engine/apps/public_api/tests/test_incidents.py
+++ b/engine/apps/public_api/tests/test_incidents.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import patch
 
 import pytest
 from django.urls import reverse
@@ -184,6 +185,24 @@ def test_delete_incident_invalid_request(incident_public_api_setup):
     data = "delete"
     response = client.delete(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_pagination(settings, incident_public_api_setup):
+    settings.BASE_URL = "https://test.com/test/prefixed/urls"
+
+    token, incidents, _, _ = incident_public_api_setup
+    client = APIClient()
+
+    url = reverse("api-public:alert_groups-list")
+
+    with patch("common.api_helpers.paginators.PathPrefixedPagination.get_page_size", return_value=1):
+        response = client.get(url, HTTP_AUTHORIZATION=f"{token}")
+
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+
+    assert result["next"].startswith("https://test.com/test/prefixed/urls")
 
 
 # This is test from old django-based tests

--- a/engine/common/api_helpers/paginators.py
+++ b/engine/common/api_helpers/paginators.py
@@ -1,25 +1,19 @@
 from rest_framework.pagination import CursorPagination, PageNumberPagination
-from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 from common.api_helpers.utils import create_engine_url
 
 
 class PathPrefixedPagination(PageNumberPagination):
-    def get_next_link(self):
-        if not self.page.has_next():
-            return None
-        url = create_engine_url(self.request.get_full_path())
-        page_number = self.page.next_page_number()
-        return replace_query_param(url, self.page_query_param, page_number)
+    def paginate_queryset(self, queryset, request, view=None):
+        request.build_absolute_uri = lambda: create_engine_url(request.get_full_path())
+        return super().paginate_queryset(queryset, request, view)
 
-    def get_previous_link(self):
-        if not self.page.has_previous():
-            return None
-        url = create_engine_url(self.request.get_full_path())
-        page_number = self.page.previous_page_number()
-        if page_number == 1:
-            return remove_query_param(url, self.page_query_param)
-        return replace_query_param(url, self.page_query_param, page_number)
+
+class PathPrefixedCursorPagination(CursorPagination):
+    def paginate_queryset(self, queryset, request, view=None):
+        pg = super().paginate_queryset(queryset, request, view)
+        self.base_url = create_engine_url(request.get_full_path())
+        return pg
 
 
 class HundredPageSizePaginator(PathPrefixedPagination):
@@ -34,7 +28,7 @@ class TwentyFivePageSizePaginator(PathPrefixedPagination):
     page_size = 25
 
 
-class TwentyFiveCursorPaginator(CursorPagination):
+class TwentyFiveCursorPaginator(PathPrefixedCursorPagination):
     page_size = 25
     max_page_size = 100
     page_size_query_param = "perpage"

--- a/engine/common/api_helpers/paginators.py
+++ b/engine/common/api_helpers/paginators.py
@@ -11,9 +11,8 @@ class PathPrefixedPagination(PageNumberPagination):
 
 class PathPrefixedCursorPagination(CursorPagination):
     def paginate_queryset(self, queryset, request, view=None):
-        pg = super().paginate_queryset(queryset, request, view)
-        self.base_url = create_engine_url(request.get_full_path())
-        return pg
+        request.build_absolute_uri = lambda: create_engine_url(request.get_full_path())
+        return super().paginate_queryset(queryset, request, view)
 
 
 class HundredPageSizePaginator(PathPrefixedPagination):

--- a/engine/common/api_helpers/paginators.py
+++ b/engine/common/api_helpers/paginators.py
@@ -1,15 +1,46 @@
 from rest_framework.pagination import CursorPagination, PageNumberPagination
+from rest_framework.response import Response
+from rest_framework.utils.urls import remove_query_param, replace_query_param
+
+from common.api_helpers.utils import create_engine_url
 
 
-class HundredPageSizePaginator(PageNumberPagination):
+class PathPrefixedPagination(PageNumberPagination):
+    def get_next_link(self):
+        if not self.page.has_next():
+            return None
+        url = create_engine_url(self.request.get_full_path())
+        page_number = self.page.next_page_number()
+        return replace_query_param(url, self.page_query_param, page_number)
+
+    def get_previous_link(self):
+        if not self.page.has_previous():
+            return None
+        url = create_engine_url(self.request.get_full_path())
+        page_number = self.page.previous_page_number()
+        if page_number == 1:
+            return remove_query_param(url, self.page_query_param)
+        return replace_query_param(url, self.page_query_param, page_number)
+
+    def get_paginated_response(self, data):
+        return Response(
+            {
+                "links": {"next": self.get_next_link(), "previous": self.get_previous_link()},
+                "count": self.page.paginator.count,
+                "results": data,
+            }
+        )
+
+
+class HundredPageSizePaginator(PathPrefixedPagination):
     page_size = 100
 
 
-class FiftyPageSizePaginator(PageNumberPagination):
+class FiftyPageSizePaginator(PathPrefixedPagination):
     page_size = 50
 
 
-class TwentyFivePageSizePaginator(PageNumberPagination):
+class TwentyFivePageSizePaginator(PathPrefixedPagination):
     page_size = 25
 
 

--- a/engine/common/api_helpers/paginators.py
+++ b/engine/common/api_helpers/paginators.py
@@ -1,5 +1,4 @@
 from rest_framework.pagination import CursorPagination, PageNumberPagination
-from rest_framework.response import Response
 from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 from common.api_helpers.utils import create_engine_url
@@ -21,15 +20,6 @@ class PathPrefixedPagination(PageNumberPagination):
         if page_number == 1:
             return remove_query_param(url, self.page_query_param)
         return replace_query_param(url, self.page_query_param, page_number)
-
-    def get_paginated_response(self, data):
-        return Response(
-            {
-                "links": {"next": self.get_next_link(), "previous": self.get_previous_link()},
-                "count": self.page.paginator.count,
-                "results": data,
-            }
-        )
 
 
 class HundredPageSizePaginator(PathPrefixedPagination):


### PR DESCRIPTION
Fix API responses not using path prefix in links returning for previous/next pages during pagination.