### PR TITLE
Fully specify ingressClassName

### DIFF
--- a/helm/oncall/templates/ingress-regular.yaml
+++ b/helm/oncall/templates/ingress-regular.yaml
@@ -25,7 +25,7 @@ metadata:
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.ingress.className }}
-  {{- end}}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
       {{- tpl (toYaml .Values.ingress.tls) . | nindent 4 }}

--- a/helm/oncall/templates/ingress-regular.yaml
+++ b/helm/oncall/templates/ingress-regular.yaml
@@ -23,7 +23,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.tls }} 
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end}}
+  {{- if .Values.ingress.tls }}
   tls:
       {{- tpl (toYaml .Values.ingress.tls) . | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
As per [here](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation), the annotation-based approach of setting Ingress Class was deprecated in Kubernetes v1.18, which is presumably why there is a [check](https://github.com/grafana/oncall/blob/7deb6fb9206f7372be36c7f0c1e06880dbe83772/helm/oncall/templates/ingress-regular.yaml#L4) to only add the annotation for Kubernetes versions lower than this. However, there was no corresponding logic to add an explicit `ingressClassName` for later versions. This change adds that.