### PR TITLE
Fix failure of "Format Alert" button on Slack.

### DIFF
--- a/engine/apps/slack/scenarios/alertgroup_appearance.py
+++ b/engine/apps/slack/scenarios/alertgroup_appearance.py
@@ -58,7 +58,6 @@ class OpenAlertAppearanceDialogStep(
         # This is a special case for amazon sns notifications in str format CHEKED
         if (
             hasattr(AlertReceiveChannel, "INTEGRATION_AMAZON_SNS")
-            and AlertReceiveChannel.INTEGRATION_AMAZON_SNS is not None
             and alert_group.channel.integration == AlertReceiveChannel.INTEGRATION_AMAZON_SNS
             and raw_request_data == "{}"
         ):

--- a/engine/apps/slack/scenarios/alertgroup_appearance.py
+++ b/engine/apps/slack/scenarios/alertgroup_appearance.py
@@ -57,7 +57,8 @@ class OpenAlertAppearanceDialogStep(
 
         # This is a special case for amazon sns notifications in str format CHEKED
         if (
-            AlertReceiveChannel.INTEGRATION_AMAZON_SNS is not None
+            hasattr(AlertReceiveChannel, "INTEGRATION_AMAZON_SNS")
+            and AlertReceiveChannel.INTEGRATION_AMAZON_SNS is not None
             and alert_group.channel.integration == AlertReceiveChannel.INTEGRATION_AMAZON_SNS
             and raw_request_data == "{}"
         ):


### PR DESCRIPTION
## Summary

close #596

Add checking that object has attribute before access to attribute.
But not defined Amazon SNS [here](https://github.com/grafana/oncall/blob/2bfb834e92f4e7eb02760bcda33daa3f1fff67f3/engine/settings/base.py#L468-L481), so always false this block probably. ([refs](https://github.com/grafana/oncall/blob/2bfb834e92f4e7eb02760bcda33daa3f1fff67f3/engine/apps/alerts/integration_options_mixin.py#L26))

## Testing

I confirmed showing a dialog after clicking "Format Alert" button.

<details>
<summary> capture </summary>

<img width="514" alt="image" src="https://user-images.githubusercontent.com/20720712/193429988-87d9a3e2-8283-4fc1-8743-4707812d41f9.png">

</details>

## Note

The Amazon SNS Integration seems to be not supported from #37.
If the Amazon SNS Integration removed permanently, I think that need to remove below block (and some codes).
https://github.com/grafana/oncall/blob/2bfb834e92f4e7eb02760bcda33daa3f1fff67f3/engine/apps/slack/scenarios/alertgroup_appearance.py#L58-L64
