### PR TITLE
Scaffolding mattermost notification backend

### DIFF
--- a/engine/apps/mattermost/alert_rendering.py
+++ b/engine/apps/mattermost/alert_rendering.py
@@ -1,0 +1,81 @@
+import humanize
+
+from apps.alerts.incident_appearance.renderers.constants import DEFAULT_BACKUP_TITLE
+from apps.alerts.incident_appearance.templaters.alert_templater import AlertTemplater
+from apps.alerts.incident_log_builder import IncidentLogBuilder
+from common.utils import str_or_backup
+
+
+class AlertMattermostTemplater(AlertTemplater):
+    RENDER_FOR_MATTERMOST = "mattermost"  # needs to match the backend id!
+
+    def _render_for(self):
+        return self.RENDER_FOR_MATTERMOST
+
+    # preformat/posformat
+
+
+def get_templated_fields(alert_group):
+    """Return title and content for the alert notification."""
+    alert = alert_group.alerts.last()
+
+    templated_alert = AlertMattermostTemplater(alert).render()
+    title = str_or_backup(templated_alert.title, DEFAULT_BACKUP_TITLE)
+    body = templated_alert.message or ""
+
+    # TODO: update to match mattermost messages rendering
+
+    status_emoji = "🔴"
+    if alert_group.resolved:
+        status_emoji = "🟢"
+    elif alert_group.acknowledged:
+        status_emoji = "🟠"
+    elif alert_group.silenced:
+        status_emoji = "⚪️"  # white circle
+
+    status_verbose = "Alerting"
+    if alert_group.resolved:
+        status_verbose = alert_group.get_resolve_text()
+    elif alert_group.acknowledged:
+        status_verbose = alert_group.get_acknowledge_text()
+    elif alert_group.silenced:
+        status_verbose = "Silenced"
+
+    message = f"{status_emoji} {status_verbose}\n{body}"
+
+    return title, message
+
+
+def build_log_message(alert_group):
+    """Return title and content for the incident log notification."""
+    from apps.alerts.models import AlertGroupLogRecord
+    from apps.base.models import UserNotificationPolicyLogRecord
+
+    log_builder = IncidentLogBuilder(alert_group=alert_group)
+    log_records = log_builder.get_log_records_list()
+
+    alert = alert_group.alerts.last()
+    templated_alert = AlertMattermostTemplater(alert).render()
+    title = f"{templated_alert.title} / log"
+
+    # TODO: update to match mattermost messages rendering
+
+    # incident log
+    message = ""
+    for log_record in log_records:
+        if isinstance(log_record, AlertGroupLogRecord):
+            log_line = log_record.rendered_incident_log_line()
+            message += "\n" + log_line
+        elif isinstance(log_record, UserNotificationPolicyLogRecord):
+            log_line = log_record.rendered_notification_log_line()
+            message += "\n" + log_line
+
+    # alert plan
+    if not (alert_group.resolved or alert_group.is_archived or alert_group.wiped_at or alert_group.root_alert_group):
+        escalation_policies_plan = log_builder.get_incident_escalation_plan(for_slack=False)
+        message += "\n---------------\n"
+        for time in sorted(escalation_policies_plan):
+            for plan_line in escalation_policies_plan[time]:
+                message += f"*{humanize.naturaldelta(time)}:* {plan_line}"
+
+    return title, message

--- a/engine/apps/mattermost/apps.py
+++ b/engine/apps/mattermost/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class MattermostConfig(AppConfig):
+    name = "apps.mattermost"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/engine/apps/mattermost/backend.py
+++ b/engine/apps/mattermost/backend.py
@@ -1,0 +1,29 @@
+from apps.base.messaging import BaseMessagingBackend
+
+BACKEND_ID = "MATTERMOST"
+
+
+class MattermostBackend(BaseMessagingBackend):
+    backend_id = BACKEND_ID
+    label = "Mattermost"
+    short_label = "Mattermost"
+    available_for_use = True
+    templater = "apps.mattermost.alert_rendering.AlertMattermostTemplater"
+
+    def validate_channel_filter_data(self, organization, data):
+        """Validate channel route selection updates."""
+        # TODO: check this is a valid channel for organization
+        return data
+
+    def serialize_user(self, user):
+        """Return serialized representation of the backend user."""
+        # TODO: return a mattermost user representation
+        # (it will be used by frontend, in the user profile)
+        return {"username": ""}
+
+    def notify_user(self, user, alert_group, notification_policy):
+        """Trigger async task to notify user about alert."""
+        # TODO: check this is a backend user
+        from .tasks import notify_user_async
+
+        notify_user_async.apply_async((alert_group.pk, user.pk))

--- a/engine/apps/mattermost/listeners.py
+++ b/engine/apps/mattermost/listeners.py
@@ -1,0 +1,32 @@
+import logging
+
+from django.apps import apps
+
+from apps.alerts.models import AlertGroup
+
+from .tasks import on_create_alert_async, on_update_alert_async, on_update_log_record_async
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+def on_alert_created(**kwargs):
+    alert_pk = kwargs["alert"]
+    on_create_alert_async.apply_async((alert_pk,))
+
+
+def on_action_triggered(**kwargs):
+    AlertGroupLogRecord = apps.get_model("alerts", "AlertGroupLogRecord")
+    log_record = kwargs["log_record"]
+    if not isinstance(log_record, AlertGroupLogRecord):
+        log_record = AlertGroupLogRecord.objects.get(pk=log_record)
+    on_update_alert_async.apply_async((log_record.alert_group.pk,))
+
+
+def on_update_log_report(**kwargs):
+    alert_group = kwargs["alert_group"]
+
+    if not isinstance(alert_group, AlertGroup):
+        alert_group = AlertGroup.all_objects.get(pk=alert_group)
+
+    on_update_log_record_async.apply_async((alert_group.pk,))

--- a/engine/apps/mattermost/signals.py
+++ b/engine/apps/mattermost/signals.py
@@ -1,0 +1,11 @@
+from apps.alerts.signals import (
+    alert_create_signal,
+    alert_group_action_triggered_signal,
+    alert_group_update_log_report_signal,
+)
+
+from .listeners import on_action_triggered, on_alert_created, on_update_log_report
+
+alert_create_signal.connect(on_alert_created)
+alert_group_action_triggered_signal.connect(on_action_triggered)
+alert_group_update_log_report_signal.connect(on_update_log_report)

--- a/engine/apps/mattermost/tasks.py
+++ b/engine/apps/mattermost/tasks.py
@@ -1,0 +1,115 @@
+from django.apps import apps
+from django.conf import settings
+
+from apps.mattermost.alert_rendering import build_log_message, get_templated_fields
+from apps.mattermost.backend import BACKEND_ID
+from common.custom_celery_tasks import shared_dedicated_queue_retry_task
+
+
+def check_backend_enabled(alert_group):
+    channel_info = None
+    if alert_group.channel_filter and alert_group.channel_filter.notification_backends is not None:
+        channel_info = alert_group.channel_filter.notification_backends.get(BACKEND_ID)
+
+    if channel_info is None or not channel_info.get("enabled"):
+        return False, None
+
+    return True, channel_info.get("channel")
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
+)
+def notify_user_async(self, alert_group_pk, user_pk):
+    AlertGroup = apps.get_model("alerts", "AlertGroup")
+    alert_group = AlertGroup.all_objects.get(pk=alert_group_pk)
+    # TODO: get backend user information
+    User = apps.get_model("user_management", "User")
+    user = User.objects.get(pk=user_pk)
+
+    # TODO: if there is a channel message for this alert group, ping the user there
+    # otherwise, send a DM with the alert details
+
+    title, message = get_templated_fields(alert_group)
+    # mention user
+    message += f"\n Inviting *{user.username}* to look at the incident"
+
+    # TODO: send user notification
+    # (channel or DM, using mattermost interactive messages; track messages for pushing status updates)
+    print(title)
+    print(message)
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
+)
+def on_create_alert_async(self, alert_pk):
+    Alert = apps.get_model("alerts", "Alert")
+    alert = Alert.objects.get(pk=alert_pk)
+    alert_group = alert.group
+
+    # potentially get channel filter information indicating where to post the alert message
+    # check backend enabled
+    enabled, channel = check_backend_enabled(alert_group)
+    if not enabled:
+        return
+
+    # TODO: post to expected channel
+    # (using mattermost interactive messages; track messages for pushing status updates)
+    title, message = get_templated_fields(alert_group)
+    print(title)
+    print(message)
+
+    post_alert_logs_async.apply_async((alert_group.pk,))
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
+)
+def on_update_alert_async(self, alert_group_pk):
+    AlertGroup = apps.get_model("alerts", "AlertGroup")
+    alert_group = AlertGroup.all_objects.get(pk=alert_group_pk)
+
+    enabled, channel = check_backend_enabled(alert_group)
+    if not enabled:
+        return
+
+    # TODO: rebuild message and update existing alert messages (if there are)
+    title, message = get_templated_fields(alert_group)
+    print(title)
+    print(message)
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
+)
+def post_alert_logs_async(self, alert_group_pk):
+    AlertGroup = apps.get_model("alerts", "AlertGroup")
+    alert_group = AlertGroup.all_objects.get(pk=alert_group_pk)
+
+    enabled, channel = check_backend_enabled(alert_group)
+    if not enabled:
+        return
+
+    # TODO: get previous alert group sent message, reply to it
+    # build log message and send as a reply to the alert messages (if there are)
+    title, message = build_log_message(alert_group)
+    print(title)
+    print(message)
+
+
+@shared_dedicated_queue_retry_task(
+    bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
+)
+def on_update_log_record_async(self, alert_group_pk):
+    AlertGroup = apps.get_model("alerts", "AlertGroup")
+    alert_group = AlertGroup.all_objects.get(pk=alert_group_pk)
+
+    enabled, channel = check_backend_enabled(alert_group)
+    if not enabled:
+        return
+
+    # rebuild log message and update existing log messages
+    title, message = build_log_message(alert_group)
+    print(title)
+    print(message)

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -121,6 +121,7 @@ INSTALLED_APPS = [
     "apps.integrations",
     "apps.schedules",
     "apps.heartbeat",
+    "apps.mattermost",
     "apps.slack",
     "apps.telegram",
     "apps.twilioapp",

--- a/engine/settings/dev.py
+++ b/engine/settings/dev.py
@@ -92,6 +92,8 @@ SWAGGER_SETTINGS = {
     "SUPPORTED_SUBMIT_METHODS": ["get", "post", "put", "delete", "options"],
 }
 
+EXTRA_MESSAGING_BACKENDS = [("apps.mattermost.backend.MattermostBackend", 11)]
+
 if TESTING:
     EXTRA_MESSAGING_BACKENDS = [("apps.base.tests.messaging_backend.TestOnlyBackend", 42)]
     TELEGRAM_TOKEN = "0000000000:XXXXXXXXXXXXXXXXXXXXXXXXXXXX-XXXXXX"

--- a/grafana-plugin/src/containers/AlertRules/parts/connectors/MattermostConnector.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/connectors/MattermostConnector.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from 'react';
+
+import { HorizontalGroup, InlineSwitch } from '@grafana/ui';
+import cn from 'classnames/bind';
+
+import { WithPermissionControl } from 'containers/WithPermissionControl/WithPermissionControl';
+import { ChannelFilter } from 'models/channel_filter/channel_filter.types';
+import { useStore } from 'state/useStore';
+import { UserAction } from 'state/userAction';
+
+import styles from 'containers/AlertRules/parts/connectors/index.module.css';
+
+const cx = cn.bind(styles);
+
+interface MattermostConnectorProps {
+  channelFilterId: ChannelFilter['id'];
+}
+
+const MattermostConnector = (props: MattermostConnectorProps) => {
+  const { channelFilterId } = props;
+
+  const store = useStore();
+  const { alertReceiveChannelStore } = store;
+
+  const channelFilter = store.alertReceiveChannelStore.channelFilters[channelFilterId];
+
+  const handleChannelFilterNotifyInMattermostChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    alertReceiveChannelStore.saveChannelFilter(channelFilterId, { notification_backends: { MATTERMOST: { enabled: event.target.checked } } });
+  }, []);
+
+
+  return (
+    <div className={cx('root')}>
+      <HorizontalGroup wrap spacing="sm">
+          <div className={cx('slack-channel-switch')}>
+            <WithPermissionControl userAction={UserAction.UpdateAlertReceiveChannels}>
+              <InlineSwitch
+                value={channelFilter.notification_backends?.MATTERMOST?.enabled}
+                onChange={handleChannelFilterNotifyInMattermostChange}
+                transparent
+              />
+            </WithPermissionControl>
+          </div>
+          Post to Mattermost
+      </HorizontalGroup>
+    </div>
+  );
+};
+
+export default MattermostConnector;

--- a/grafana-plugin/src/containers/AlertRules/parts/index.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/index.tsx
@@ -4,6 +4,7 @@ import { VerticalGroup } from '@grafana/ui';
 import cn from 'classnames/bind';
 
 import Timeline from 'components/Timeline/Timeline';
+import MattermostConnector from 'containers/AlertRules/parts/connectors/MattermostConnector';
 import SlackConnector from 'containers/AlertRules/parts/connectors/SlackConnector';
 import TelegramConnector from 'containers/AlertRules/parts/connectors/TelegramConnector';
 import { ChannelFilter } from 'models/channel_filter';
@@ -23,10 +24,12 @@ export const ChatOpsConnectors = (props: ChatOpsConnectorsProps) => {
   const store = useStore();
   const { telegramChannelStore } = store;
 
+  // TODO: implement right check for Mattermost
+  const isMattermostInstalled = true;
   const isSlackInstalled = Boolean(store.teamStore.currentTeam?.slack_team_identity);
   const isTelegramInstalled = Boolean(telegramChannelStore.currentTeamToTelegramChannel?.length > 0);
 
-  if (!isSlackInstalled && !isTelegramInstalled) {
+  if (!isMattermostInstalled && !isSlackInstalled && !isTelegramInstalled) {
     return null;
   }
 
@@ -35,6 +38,7 @@ export const ChatOpsConnectors = (props: ChatOpsConnectorsProps) => {
       <VerticalGroup>
         {isSlackInstalled && <SlackConnector channelFilterId={channelFilterId} />}
         {isTelegramInstalled && <TelegramConnector channelFilterId={channelFilterId} />}
+        {isMattermostInstalled && <MattermostConnector channelFilterId={channelFilterId} />}
       </VerticalGroup>
     </Timeline.Item>
   );


### PR DESCRIPTION
Mattermost messaging backend implementation.

- [x] Initial base messaging backend app
- [ ] Update alert rendering to use Mattermost formatting/style
- [ ] Implement backend user model/linking
- [ ] Implement backend channel model/linking
- [ ] Implement tasks triggering notifications and updates
- [ ] Support interactions in the notifications (ack, resolve, silence)
- [ ] Implement frontend UI: user profile
- [ ] Implement frontend UI: chatops settings
- [ ] Implement frontend UI: integration: post to channel
- [ ] Implement Mattermost [app](https://developers.mattermost.com/integrate/apps/) (or [plugin](https://developers.mattermost.com/integrate/plugins/)?) adding slash commands for linking user and channels


References:
 - [Telegram implementation](https://github.com/grafana/oncall/tree/dev/engine/apps/telegram) (for user and channel verification)
 - [Demo backend implementation](https://github.com/grafana/oncall/pull/566) (for general ideas)
 - Mattermost [interactive messages](https://developers.mattermost.com/integrate/plugins/interactive-messages/)
 - Mattermost [slash commands](https://developers.mattermost.com/integrate/slash-commands/)
