### PR TITLE
Improve Plugin Initialization Latency

### DIFF
--- a/grafana-plugin/src/state/plugin.ts
+++ b/grafana-plugin/src/state/plugin.ts
@@ -31,6 +31,11 @@ export async function startPluginSync() {
   return await makeRequest('/plugin/sync', { method: 'POST' });
 }
 
+
+export const SYNC_STATUS_RETRY_LIMIT = 10;
+
+export const syncStatusDelay = retryCount => new Promise(resolve => setTimeout(resolve, 10 * 2 ** retryCount));
+
 export async function getPluginSyncStatus() {
   return await makeRequest(`/plugin/sync`, { method: 'GET' });
 }

--- a/grafana-plugin/src/state/rootBaseStore.ts
+++ b/grafana-plugin/src/state/rootBaseStore.ts
@@ -31,7 +31,14 @@ import { UserGroupStore } from 'models/user_group/user_group';
 import { makeRequest } from 'network';
 
 import { AppFeature } from './features';
-import { createGrafanaToken, getPluginSyncStatus, installPlugin, startPluginSync, updateGrafanaToken } from './plugin';
+import {
+  createGrafanaToken,
+  getPluginSyncStatus,
+  installPlugin,
+  startPluginSync,
+  SYNC_STATUS_RETRY_LIMIT, syncStatusDelay,
+  updateGrafanaToken
+} from './plugin';
 import { UserAction } from './userAction';
 
 // ------ Dashboard ------ //
@@ -182,6 +189,26 @@ export class RootBaseStore {
     this.isUserAnonymous = false;
   }
 
+  async waitForSyncStatus(retryCount = 0) {
+
+    if (retryCount > SYNC_STATUS_RETRY_LIMIT) {
+      this.retrySync = true;
+      return;
+    }
+
+    getPluginSyncStatus().then((get_sync_response) => {
+      if (get_sync_response.hasOwnProperty('token_ok')) {
+        this.finishSync(get_sync_response);
+      } else {
+        syncStatusDelay(retryCount + 1)
+            .then(() => this.waitForSyncStatus(retryCount + 1))
+      }
+      }).catch((e) => {
+        this.handleSyncException(e);
+      });
+
+  }
+
   async setupPlugin(meta: AppPluginMeta<OnCallAppSettings>) {
     this.resetStatusToDefault();
 
@@ -208,28 +235,7 @@ export class RootBaseStore {
       }
       await installPlugin();
     }
-
-    let counter = 0;
-    const interval = setInterval(() => {
-      counter++;
-
-      getPluginSyncStatus()
-        .then((get_sync_response) => {
-          if (get_sync_response.hasOwnProperty('token_ok')) {
-            clearInterval(interval);
-            this.finishSync(get_sync_response);
-          }
-        })
-        .catch((e) => {
-          clearInterval(interval);
-          this.handleSyncException(e);
-        });
-
-      if (counter >= 10) {
-        clearInterval(interval);
-        this.retrySync = true;
-      }
-    }, 2000);
+    await this.waitForSyncStatus();
   }
 
   isUserActionAllowed(action: UserAction) {


### PR DESCRIPTION
For https://github.com/grafana/oncall/issues/249

Use exponential backoff for wait times between attempts when syncing during configuration or loading instead of a fixed 2 seconds.  This will result in much quicker response when loading.  This will also cover cases where you have longer latency as the later steps will wait much longer (For https://github.com/grafana/oncall/pull/529).