### PR TITLE
Allow disabling autorestarts in helm deployment

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -58,16 +58,26 @@
 {{- end }}
 
 {{- define "snippet.celery.env" -}}
+{{- if .Values.celery.worker_queue }}
 - name: CELERY_WORKER_QUEUE
-  value: "default,critical,long,slack,telegram,webhook,celery"
+  value: {{ .Values.celery.worker_queue }}
+{{- end -}}
+{{- if .Values.celery.worker_concurrency }}
 - name: CELERY_WORKER_CONCURRENCY
-  value: "1"
+  value: {{ .Values.celery.worker_concurrency | quote }}
+{{- end -}}
+{{- if .Values.celery.worker_max_tasks_per_child }}
 - name: CELERY_WORKER_MAX_TASKS_PER_CHILD
-  value: "100"
-- name: CELERY_WORKER_SHUTDOWN_INTERVAL
-  value: "65m"
+  value: {{ .Values.celery.worker_max_tasks_per_child | quote }}
+{{- end -}}
+{{- if .Values.celery.worker_beat_enabled }}
 - name: CELERY_WORKER_BEAT_ENABLED
-  value: "True"
+  value: {{ .Values.celery.worker_beat_enabled | quote }}
+{{- end -}}
+{{- if .Values.celery.worker_shutdown_interval }}
+- name: CELERY_WORKER_SHUTDOWN_INTERVAL
+  value: {{ .Values.celery.worker_shutdown_interval }}
+{{- end -}}
 {{- end }}
 
 {{- define "snippet.mysql.env" -}}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -48,12 +48,12 @@ celery:
   worker_concurrency: "1"
   worker_max_tasks_per_child: "100"
   worker_beat_enabled: "True"
-  ## Additional restart of the celery workers once in a given interval
+  ## Restart of the celery workers once in a given interval as an additional precaution to the probes
   ## If this setting is enabled TERM signal will be sent to celery workers
   ## It will lead to warm shutdown (waiting for the tasks to complete) and restart the container
   ## If this setting is set numbers of pod restarts will increase
   ## Comment this line out if you want to remove restarts
-#  worker_shutdown_interval: "65m"
+  worker_shutdown_interval: "65m"
   resources: {}
     # limits:
     #   cpu: 100m

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -44,6 +44,16 @@ engine:
 # Celery workers pods configuration
 celery:
   replicaCount: 1
+  worker_queue: "default,critical,long,slack,telegram,webhook,celery"
+  worker_concurrency: "1"
+  worker_max_tasks_per_child: "100"
+  worker_beat_enabled: "True"
+  ## Additional restart of the celery workers once in a given interval
+  ## If this setting is enabled TERM signal will be sent to celery workers
+  ## It will lead to warm shutdown (waiting for the tasks to complete) and restart the container
+  ## If this setting is set numbers of pod restarts will increase
+  ## Comment this line out if you want to remove restarts
+#  worker_shutdown_interval: "65m"
   resources: {}
     # limits:
     #   cpu: 100m


### PR DESCRIPTION
This PR allows to disable to default restarts from values.yaml.
This feature increases the k8s pod restart counter, but we do it intentionally, as a precaution additional to probes. 