### PR TITLE
Add simple Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+include .env.dev
+
+ENV = $(CURDIR)/venv
+CELERY = $(ENV)/bin/celery
+PRECOMMIT = $(ENV)/bin/pre-commit
+PIP = $(ENV)/bin/pip
+PYTHON3 = $(ENV)/bin/python3
+PYTEST = $(ENV)/bin/pytest
+
+DOCKER_FILE ?= docker-compose-developer.yml
+
+define setup_engine_env
+	export `grep -v '^#' .env | xargs -0` && cd engine
+endef
+
+$(ENV):
+	python3.9 -m venv venv
+
+bootstrap: $(ENV)
+	$(PIP) install -U pip wheel
+	cp .env.dev.example .env.dev
+	cd engine && $(PIP) install -r requirements.txt
+	@touch $@
+
+migrate:
+	$(setup_engine_env) && $(PYTHON3) manage.py migrate
+
+clean:
+	rm -rf $(ENV)
+
+lint: $(ENV)
+	cd engine && $(PRECOMMIT) run --all-files
+
+dbshell: $(ENV)
+	$(setup_engine_env) && $(PYTHON3) manage.py dbshell $(ARGS)
+
+shell: $(ENV)
+	$(setup_engine_env) && $(PYTHON3) manage.py shell $(ARGS)
+
+test: $(ENV)
+	$(setup_engine_env) && $(PYTEST) --ds=settings.dev $(ARGS)
+
+manage:
+	$(setup_engine_env) && $(PYTHON3) manage.py $(ARGS)
+
+run:
+	$(setup_engine_env) && $(PYTHON3) manage.py runserver
+
+start-celery:
+	. $(ENV)/bin/activate && $(setup_engine_env) && $(PYTHON3) manage.py start_celery
+
+start-celery-beat:
+	$(setup_engine_env) && $(CELERY) -A engine beat -l info
+
+purge-queues:
+	$(setup_engine_env) && $(CELERY) -A engine purge
+
+docker-services-start:
+	docker-compose -f $(DOCKER_FILE) up -d
+	@echo "Waiting for database connection..."
+	until $$(nc -z -v -w30 localhost 3306); do sleep 1; done;
+
+docker-services-restart:
+	docker-compose -f $(DOCKER_FILE) restart
+
+docker-services-stop:
+	docker-compose -f $(DOCKER_FILE) stop
+
+watch-plugin:
+	cd grafana-plugin && yarn install && yarn && yarn watch
+
+.PHONY: bootstrap grafana-plugin

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test: bootstrap
 manage: bootstrap
 	$(setup_engine_env) && $(PYTHON3) manage.py $(ARGS)
 
-run: bootstrap
+run: bootstrap migrate
 	$(setup_engine_env) && $(PYTHON3) manage.py runserver
 
 start-celery: bootstrap

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 include .env.dev
 
-ENV = $(CURDIR)/venv
+ENV_DIR ?= venv
+ENV = $(CURDIR)/$(ENV_DIR)
 CELERY = $(ENV)/bin/celery
 PRECOMMIT = $(ENV)/bin/pre-commit
 PIP = $(ENV)/bin/pip
@@ -14,11 +15,11 @@ define setup_engine_env
 endef
 
 $(ENV):
-	python3.9 -m venv venv
+	python3.9 -m venv $(ENV_DIR)
 
 bootstrap: $(ENV)
 	$(PIP) install -U pip wheel
-	cp .env.dev.example .env.dev
+	cp -n .env.dev.example .env.dev
 	cd engine && $(PIP) install -r requirements.txt
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -23,37 +23,37 @@ bootstrap: $(ENV)
 	cd engine && $(PIP) install -r requirements.txt
 	@touch $@
 
-migrate:
+migrate: bootstrap
 	$(setup_engine_env) && $(PYTHON3) manage.py migrate
 
 clean:
 	rm -rf $(ENV)
 
-lint: $(ENV)
+lint: bootstrap
 	cd engine && $(PRECOMMIT) run --all-files
 
-dbshell: $(ENV)
+dbshell: bootstrap
 	$(setup_engine_env) && $(PYTHON3) manage.py dbshell $(ARGS)
 
-shell: $(ENV)
+shell: bootstrap
 	$(setup_engine_env) && $(PYTHON3) manage.py shell $(ARGS)
 
-test: $(ENV)
+test: bootstrap
 	$(setup_engine_env) && $(PYTEST) --ds=settings.dev $(ARGS)
 
-manage:
+manage: bootstrap
 	$(setup_engine_env) && $(PYTHON3) manage.py $(ARGS)
 
-run:
+run: bootstrap
 	$(setup_engine_env) && $(PYTHON3) manage.py runserver
 
-start-celery:
+start-celery: bootstrap
 	. $(ENV)/bin/activate && $(setup_engine_env) && $(PYTHON3) manage.py start_celery
 
-start-celery-beat:
+start-celery-beat: bootstrap
 	$(setup_engine_env) && $(CELERY) -A engine beat -l info
 
-purge-queues:
+purge-queues: bootstrap
 	$(setup_engine_env) && $(CELERY) -A engine purge
 
 docker-services-start:
@@ -70,4 +70,4 @@ docker-services-stop:
 watch-plugin:
 	cd grafana-plugin && yarn install && yarn && yarn watch
 
-.PHONY: bootstrap grafana-plugin
+.PHONY: grafana-plugin


### PR DESCRIPTION
Setting up dev environment using Makefile:

```
# setup virtualenv and deps
$ make bootstrap
# start docker services (db, rabbit, etc)
$ make docker-services-start
# setup db (re-run to update when there are pending migrations)
$ make migrate
```

Running the services:
```
# run the oncall engine
$ make run
# run celery workers
$ make start-celery
# run celery beat
$ make start-celery-beat
# build and watch for plugin changes
$ make watch-plugin
```

Other available targets:
```
$ make dbshell
$ make shell
$ make test
$ make manage ARGS="<django-command> [args]"
```
