### PR TITLE
Allow non-JSON custom webhook templates, provided they render as valid JSON

### DIFF
--- a/engine/apps/api/serializers/custom_button.py
+++ b/engine/apps/api/serializers/custom_button.py
@@ -69,7 +69,7 @@ class CustomButtonSerializer(serializers.ModelSerializer):
                     # If we instead used a `defaultdict(dict)` or `defaultdict(lambda: 1)` we
                     # would accidentally accept templates such as `{"name": {{ alert_payload.name }}}`
                     # which would then fail at the true render time due to the
-                    "alert_payload": defaultdict(lambda: ""),
+                    "alert_payload": defaultdict(str),
                     "alert_group_id": "abcd",
                 }
             )

--- a/engine/apps/api/serializers/custom_button.py
+++ b/engine/apps/api/serializers/custom_button.py
@@ -69,6 +69,8 @@ class CustomButtonSerializer(serializers.ModelSerializer):
                     # If we instead used a `defaultdict(dict)` or `defaultdict(lambda: 1)` we
                     # would accidentally accept templates such as `{"name": {{ alert_payload.name }}}`
                     # which would then fail at the true render time due to the
+                    # lack of explicit quotes around the template variable; this would render
+                    # as `{"name": some_alert_name}` which is not valid JSON.
                     "alert_payload": defaultdict(str),
                     "alert_group_id": "abcd",
                 }

--- a/engine/apps/api/serializers/custom_button.py
+++ b/engine/apps/api/serializers/custom_button.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 
 from django.core.validators import URLValidator, ValidationError
 from jinja2 import Template, TemplateError
@@ -51,14 +52,30 @@ class CustomButtonSerializer(serializers.ModelSerializer):
             return None
 
         try:
-            json.loads(data)
-        except ValueError:
-            raise serializers.ValidationError("Data has incorrect format")
-
-        try:
-            Template(data)
+            template = Template(data)
         except TemplateError:
             raise serializers.ValidationError("Data has incorrect template")
+
+        try:
+            rendered = template.render(
+                {
+                    # Validate that the template can be rendered with a JSON-ish alert payload.
+                    # We don't know what the actual payload will be, so we use a defaultdict
+                    # so that attribute access within a template will never fail
+                    # (provided it's only one level deep - we won't accept templates that attempt
+                    # to do nested attribute access).
+                    # Every attribute access should return a string to ensure that users are
+                    # correctly using `tojson` or wrapping fields in strings.
+                    # If we instead used a `defaultdict(dict)` or `defaultdict(lambda: 1)` we
+                    # would accidentally accept templates such as `{"name": {{ alert_payload.name }}}`
+                    # which would then fail at the true render time due to the
+                    "alert_payload": defaultdict(lambda: ""),
+                    "alert_group_id": "abcd",
+                }
+            )
+            json.loads(rendered)
+        except ValueError:
+            raise serializers.ValidationError("Data has incorrect format")
 
         return data
 

--- a/engine/apps/api/tests/test_custom_button.py
+++ b/engine/apps/api/tests/test_custom_button.py
@@ -129,6 +129,91 @@ def test_create_valid_data_button(custom_button_internal_api_setup, make_user_au
 
 
 @pytest.mark.django_db
+def test_create_valid_nested_data_button(custom_button_internal_api_setup, make_user_auth_headers):
+    user, token, custom_button = custom_button_internal_api_setup
+    client = APIClient()
+    url = reverse("api-internal:custom_button-list")
+
+    data = {
+        "name": "amixr_button_with_valid_data",
+        "webhook": TEST_URL,
+        # Assert that nested field access still works as long as the variable
+        # is quoted, making it valid JSON.
+        # This ensures backwards compatibility from when templates were required
+        # to be JSON.
+        "data": '{"nested_item": "{{ alert_payload.foo.bar }}"}',
+        "team": None,
+    }
+
+    response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
+    # modify initial data by adding id and None for optional fields
+    custom_button = CustomButton.objects.get(public_primary_key=response.data["id"])
+    expected_response = data | {
+        "id": custom_button.public_primary_key,
+        "user": None,
+        "password": None,
+        "authorization_header": None,
+        "forward_whole_payload": False,
+    }
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == expected_response
+
+
+@pytest.mark.django_db
+def test_create_valid_data_after_render_button(custom_button_internal_api_setup, make_user_auth_headers):
+    user, token, custom_button = custom_button_internal_api_setup
+    client = APIClient()
+    url = reverse("api-internal:custom_button-list")
+
+    data = {
+        "name": "amixr_button_with_valid_data",
+        "webhook": TEST_URL,
+        "data": '{"name": "{{ alert_payload.name }}", "labels": {{ alert_payload.labels | tojson }}}',
+        "team": None,
+    }
+
+    response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
+    # modify initial data by adding id and None for optional fields
+    custom_button = CustomButton.objects.get(public_primary_key=response.data["id"])
+    expected_response = data | {
+        "id": custom_button.public_primary_key,
+        "user": None,
+        "password": None,
+        "authorization_header": None,
+        "forward_whole_payload": False,
+    }
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == expected_response
+
+
+@pytest.mark.django_db
+def test_create_valid_data_after_render_use_all_data_button(custom_button_internal_api_setup, make_user_auth_headers):
+    user, token, custom_button = custom_button_internal_api_setup
+    client = APIClient()
+    url = reverse("api-internal:custom_button-list")
+
+    data = {
+        "name": "amixr_button_with_valid_data",
+        "webhook": TEST_URL,
+        "data": "{{ alert_payload | tojson }}",
+        "team": None,
+    }
+
+    response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
+    # modify initial data by adding id and None for optional fields
+    custom_button = CustomButton.objects.get(public_primary_key=response.data["id"])
+    expected_response = data | {
+        "id": custom_button.public_primary_key,
+        "user": None,
+        "password": None,
+        "authorization_header": None,
+        "forward_whole_payload": False,
+    }
+    assert response.status_code == status.HTTP_201_CREATED
+    assert response.json() == expected_response
+
+
+@pytest.mark.django_db
 def test_create_invalid_url_custom_button(custom_button_internal_api_setup, make_user_auth_headers):
     user, token, custom_button = custom_button_internal_api_setup
     client = APIClient()
@@ -152,6 +237,22 @@ def test_create_invalid_data_custom_button(custom_button_internal_api_setup, mak
         "name": "amixr_button_invalid_data",
         "webhook": TEST_URL,
         "data": "invalid_json",
+    }
+    response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+def test_create_invalid_templated_data_custom_button(custom_button_internal_api_setup, make_user_auth_headers):
+    user, token, custom_button = custom_button_internal_api_setup
+    client = APIClient()
+    url = reverse("api-internal:custom_button-list")
+
+    data = {
+        "name": "amixr_button_invalid_data",
+        "webhook": TEST_URL,
+        # This would need a `| tojson` or some double quotes around it to pass validation.
+        "data": "{{ alert_payload.name }}",
     }
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
     assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/engine/apps/public_api/serializers/action.py
+++ b/engine/apps/public_api/serializers/action.py
@@ -1,4 +1,5 @@
 import json
+from collections import defaultdict
 
 from django.core.validators import URLValidator, ValidationError
 from jinja2 import Template, TemplateError
@@ -55,14 +56,32 @@ class ActionCreateSerializer(serializers.ModelSerializer):
             return None
 
         try:
-            json.loads(data)
-        except ValueError:
-            raise serializers.ValidationError("Data has incorrect format")
-
-        try:
-            Template(data)
+            template = Template(data)
         except TemplateError:
             raise serializers.ValidationError("Data has incorrect template")
+
+        try:
+            rendered = template.render(
+                {
+                    # Validate that the template can be rendered with a JSON-ish alert payload.
+                    # We don't know what the actual payload will be, so we use a defaultdict
+                    # so that attribute access within a template will never fail
+                    # (provided it's only one level deep - we won't accept templates that attempt
+                    # to do nested attribute access).
+                    # Every attribute access should return a string to ensure that users are
+                    # correctly using `tojson` or wrapping fields in strings.
+                    # If we instead used a `defaultdict(dict)` or `defaultdict(lambda: 1)` we
+                    # would accidentally accept templates such as `{"name": {{ alert_payload.name }}}`
+                    # which would then fail at the true render time due to the
+                    # lack of explicit quotes around the template variable; this would render
+                    # as `{"name": some_alert_name}` which is not valid JSON.
+                    "alert_payload": defaultdict(str),
+                    "alert_group_id": "abcd",
+                }
+            )
+            json.loads(rendered)
+        except ValueError:
+            raise serializers.ValidationError("Data has incorrect format")
 
         return data
 


### PR DESCRIPTION
Previously, both the provided template _and_ the rendered template had
to be valid JSON in order for validation to pass. This was unnecessarily
restrictive: really, only the rendered template needs to be valid JSON.
It also disallowed using templates such as:

    {
      "labels": {{ alert_payload.labels | tojson }}
    }

even though this would be valid JSON after rendering.

This commit relaxes the validation of custom webhook templates so that
they don't need to be valid JSON, provided that the rendered template
_is_ valid JSON. This is checked using a dummy dictionary of render
params, which use a constant string for the `alert_group_id` field
and a `defaultdict(dict)` for the `alert_payload` field. This should
permit templates like the one above, but still deny templates such as

    {
      "labels": {{ alert_payload.labels }}
    }

which would otherwise fail later if `labels` is not valid JSON.

This should resolve #638.
