### PR TITLE
Use markdown formatting for web based resolution notes

### DIFF
--- a/engine/apps/slack/scenarios/resolution_note.py
+++ b/engine/apps/slack/scenarios/resolution_note.py
@@ -358,7 +358,7 @@ class UpdateResolutionNoteStep(scenario_step.ScenarioStep):
         author_verbal = resolution_note.author_verbal(mention=True)
         resolution_note_text_block = {
             "type": "section",
-            "text": {"type": "plain_text", "text": resolution_note.text, "emoji": True},
+            "text": {"type": "mrkdwn", "text": resolution_note.text, "emoji": True},
         }
         blocks.append(resolution_note_text_block)
         context_block = {


### PR DESCRIPTION
We would like to include some more sophisticated content in our
resolution notes (specifically URLs), so need the resolution notes to be
rendered as Markdown for this.

This PR changes _all_ resolution note text blocks to be markdown, but
perhaps it would be better to allow the caller to specify that they
would prefer markdown to plain text (this would also allow backwards
compatibility). Let me know if you'd prefer that and I can try and
figure it out!
