### PR TITLE
Add middleware to catch exception for missing integration

### DIFF
--- a/engine/apps/integrations/middlewares.py
+++ b/engine/apps/integrations/middlewares.py
@@ -1,0 +1,14 @@
+import logging
+
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
+from django.utils.deprecation import MiddlewareMixin
+from rest_framework import status
+
+logger = logging.getLogger(__name__)
+
+
+class IntegrationExceptionMiddleware(MiddlewareMixin):
+    def process_exception(self, request, exception):
+        if request.path.startswith("/integrations/v1") and isinstance(exception, PermissionDenied):
+            return HttpResponse(exception, status=status.HTTP_403_FORBIDDEN)

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -244,6 +244,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
     "apps.social_auth.middlewares.SocialAuthAuthCanceledExceptionMiddleware",
+    "apps.integrations.middlewares.IntegrationExceptionMiddleware",
 ]
 
 LOG_REQUEST_ID_HEADER = "HTTP_X_CLOUD_TRACE_CONTEXT"


### PR DESCRIPTION
**What this PR does**:
Add a new middleware to catch PermissionDenied exception coming out of calls to non-existent integrations.
The tracebacks for these are spamming the logs, already have a status=403 in the log so we don't need the traceback here.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated