### PR TITLE
Catch exception for parsing regex during channel filtering

### DIFF
--- a/engine/apps/alerts/models/channel_filter.py
+++ b/engine/apps/alerts/models/channel_filter.py
@@ -120,6 +120,7 @@ class ChannelFilter(OrderedModel):
             return re.search(self.filtering_term, value)
         except re.error:
             logger.error(f"channel_filter={self.id} failed to parse regex={self.filtering_term}")
+            return False
 
     @property
     def slack_channel_id_or_general_log_id(self):

--- a/engine/apps/alerts/models/channel_filter.py
+++ b/engine/apps/alerts/models/channel_filter.py
@@ -116,7 +116,10 @@ class ChannelFilter(OrderedModel):
         return self.is_default or self.check_filter(json.dumps(raw_request_data)) or self.check_filter(str(title))
 
     def check_filter(self, value):
-        return re.search(self.filtering_term, value)
+        try:
+            return re.search(self.filtering_term, value)
+        except re.error:
+            logger.error(f"channel_filter={self.id} failed to parse regex={self.filtering_term}")
 
     @property
     def slack_channel_id_or_general_log_id(self):


### PR DESCRIPTION
**What this PR does**:
If we get a channel filter regex in the database which does not parse treat as no match instead of raising exception which prevents message delivery.

**Which issue(s) this PR fixes**:
https://github.com/grafana/oncall-private/issues/1416

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated