### PR TITLE
[helm] change telegram webhook host

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -47,7 +47,7 @@
 {{- if .Values.oncall.telegram.enabled -}}
 - name: FEATURE_TELEGRAM_INTEGRATION_ENABLED
   value: {{ .Values.oncall.telegram.enabled | toString | title | quote }}
-- name: TELEGRAM_WEBHOOK_URL
+- name: TELEGRAM_WEBHOOK_HOST
   value: {{ .Values.oncall.telegram.webhookUrl | default "" | quote }}
 - name: TELEGRAM_TOKEN
   value: {{ .Values.oncall.telegram.token | default "" | quote }}


### PR DESCRIPTION
**What this PR does**:

Rename webhook env from `TELEGRAM_WEBHOOK_URL` to `TELEGRAM_WEBHOOK_HOST` as per documentation https://grafana.com/docs/oncall/latest/open-source/#telegram-setup

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated