### PR TITLE
PagerDuty migrator minor improvements

### DIFF
--- a/tools/pagerduty-migrator/migrator/config.py
+++ b/tools/pagerduty-migrator/migrator/config.py
@@ -8,7 +8,10 @@ assert MODE in (MODE_PLAN, MODE_MIGRATE)
 
 PAGERDUTY_API_TOKEN = os.environ["PAGERDUTY_API_TOKEN"]
 ONCALL_API_TOKEN = os.environ["ONCALL_API_TOKEN"]
-ONCALL_API_URL = urljoin(os.environ["ONCALL_API_URL"], "api/v1/")
+ONCALL_API_URL = urljoin(
+    os.environ["ONCALL_API_URL"].removesuffix("/") + "/"
+    "api/v1/"
+)
 
 ONCALL_DELAY_OPTIONS = [1, 5, 15, 30, 60]
 ONCALL_DEFAULT_CONTACT_METHOD = "notify_by_" + os.getenv(

--- a/tools/pagerduty-migrator/migrator/config.py
+++ b/tools/pagerduty-migrator/migrator/config.py
@@ -10,7 +10,7 @@ PAGERDUTY_API_TOKEN = os.environ["PAGERDUTY_API_TOKEN"]
 ONCALL_API_TOKEN = os.environ["ONCALL_API_TOKEN"]
 ONCALL_API_URL = urljoin(
     os.environ["ONCALL_API_URL"].removesuffix("/") + "/",
-    "api/v1/"
+    "api/v1/",
 )
 
 ONCALL_DELAY_OPTIONS = [1, 5, 15, 30, 60]

--- a/tools/pagerduty-migrator/migrator/config.py
+++ b/tools/pagerduty-migrator/migrator/config.py
@@ -9,7 +9,7 @@ assert MODE in (MODE_PLAN, MODE_MIGRATE)
 PAGERDUTY_API_TOKEN = os.environ["PAGERDUTY_API_TOKEN"]
 ONCALL_API_TOKEN = os.environ["ONCALL_API_TOKEN"]
 ONCALL_API_URL = urljoin(
-    os.environ["ONCALL_API_URL"].removesuffix("/") + "/"
+    os.environ["ONCALL_API_URL"].removesuffix("/") + "/",
     "api/v1/"
 )
 

--- a/tools/pagerduty-migrator/migrator/report.py
+++ b/tools/pagerduty-migrator/migrator/report.py
@@ -52,8 +52,7 @@ def format_integration(integration: dict) -> str:
     if not integration["oncall_type"]:
         result = (
             "{} {} — cannot find appropriate Grafana OnCall integration type".format(
-                ERROR_SIGN,
-                result,
+                ERROR_SIGN, result
             )
         )
 

--- a/tools/pagerduty-migrator/migrator/report.py
+++ b/tools/pagerduty-migrator/migrator/report.py
@@ -52,9 +52,14 @@ def format_integration(integration: dict) -> str:
     if not integration["oncall_type"]:
         result = (
             "{} {} — cannot find appropriate Grafana OnCall integration type".format(
-                ERROR_SIGN, result
+                ERROR_SIGN,
+                result,
             )
         )
+
+        if integration["vendor_name"]:
+            result += ": '{}'".format(integration["vendor_name"])
+
     elif integration["is_escalation_policy_flawed"]:
         policy_name = integration["service"]["escalation_policy"]["summary"]
         result = "{} {} — escalation policy '{}' references unmatched users or schedules with unmatched users".format(

--- a/tools/pagerduty-migrator/migrator/resources/integrations.py
+++ b/tools/pagerduty-migrator/migrator/resources/integrations.py
@@ -17,20 +17,15 @@ def match_integration(integration: dict, oncall_integrations: list[dict]) -> Non
 def match_integration_type(integration: dict, vendors: list[dict]) -> None:
     vendors_map = {vendor["id"]: vendor for vendor in vendors}
 
-    if (
-        integration["type"]
-        not in [
-            "generic_events_api_inbound_integration",
-            "events_api_v2_inbound_integration",
-        ]
-        or integration["vendor"] is None
-    ):
+    if integration["vendor"] is None:
+        integration["vendor_name"] = None
         integration["oncall_type"] = None
         return
 
     vendor_id = integration["vendor"]["id"]
     vendor_name = vendors_map[vendor_id]["name"]
 
+    integration["vendor_name"] = vendor_name
     integration["oncall_type"] = PAGERDUTY_TO_ONCALL_VENDOR_MAP.get(vendor_name)
 
 

--- a/tools/pagerduty-migrator/scripts/add_users_pagerduty_to_grafana.py
+++ b/tools/pagerduty-migrator/scripts/add_users_pagerduty_to_grafana.py
@@ -8,11 +8,12 @@ from pdpyras import APISession
 
 PAGERDUTY_API_TOKEN = os.environ["PAGERDUTY_API_TOKEN"]
 PATH_USERS_GRAFANA = "/api/admin/users"
-GRAFANA_URL = os.environ["GRAFANA_URL"] # Example: http://localhost:3000
+GRAFANA_URL = os.environ["GRAFANA_URL"]  # Example: http://localhost:3000
 GRAFANA_USERNAME = os.environ["GRAFANA_USERNAME"]
 GRAFANA_PASSWORD = os.environ["GRAFANA_PASSWORD"]
 SUCCESS_SIGN = "✅"
 ERROR_SIGN = "❌"
+
 
 def list_pagerduty_users():
     session = APISession(PAGERDUTY_API_TOKEN)
@@ -22,21 +23,30 @@ def list_pagerduty_users():
     for user in users:
         password = secrets.token_urlsafe(15)
         username = user["email"].split("@")[0]
-        json = {"name": user["name"], "email": user["email"], "login": username, "password": password}
+        json = {
+            "name": user["name"],
+            "email": user["email"],
+            "login": username,
+            "password": password,
+        }
         create_grafana_user(json)
+
 
 def create_grafana_user(data):
     url = urljoin(GRAFANA_URL, PATH_USERS_GRAFANA)
-    response = requests.request("POST", url, auth=(GRAFANA_USERNAME, GRAFANA_PASSWORD), json=data)
+    response = requests.request(
+        "POST", url, auth=(GRAFANA_USERNAME, GRAFANA_PASSWORD), json=data
+    )
 
     if response.status_code == 200:
         print(SUCCESS_SIGN + " User created: " + data["login"])
     elif response.status_code == 401:
         sys.exit(ERROR_SIGN + " Invalid username or password.")
     elif response.status_code == 412:
-        print(ERROR_SIGN + " User " + data["login"] + " already exists." )
-    else: 
+        print(ERROR_SIGN + " User " + data["login"] + " already exists.")
+    else:
         print("{} {}".format(ERROR_SIGN, response.text))
+
 
 if __name__ == "__main__":
     list_pagerduty_users()

--- a/tools/pagerduty-migrator/scripts/add_users_pagerduty_to_grafana.py
+++ b/tools/pagerduty-migrator/scripts/add_users_pagerduty_to_grafana.py
@@ -1,9 +1,9 @@
 import os
 import secrets
 import sys
-import requests
-
 from urllib.parse import urljoin
+
+import requests
 from pdpyras import APISession
 
 PAGERDUTY_API_TOKEN = os.environ["PAGERDUTY_API_TOKEN"]


### PR DESCRIPTION
1. Allow `ONCALL_API_URL` without trailing slash
2. Show vendor name for unsupported integrations
3. run isort and black in `scripts` folder