### PR TITLE
fix(helm): Update the Slack helm values and environment variables

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -33,10 +33,10 @@
   value: {{ .Values.oncall.slack.clientId | default "" | quote }}
 - name: SLACK_CLIENT_OAUTH_SECRET
   value: {{ .Values.oncall.slack.clientSecret | default "" | quote }}
-- name: SLACK_API_TOKEN
-  value: {{ .Values.oncall.slack.apiToken | default "" | quote }}
-- name: SLACK_API_TOKEN_COMMON
-  value: {{ .Values.oncall.slack.apiTokenCommon | default "" | quote }}
+- name: SLACK_SIGNING_SECRET
+  value: {{ .Values.oncall.slack.signingSecret | default "" | quote }}
+- name: SLACK_INSTALL_RETURN_REDIRECT_HOST
+  value: "https://{{ .Values.base_url }}"
 {{- else -}}
 - name: FEATURE_SLACK_INTEGRATION_ENABLED
   value: {{ .Values.oncall.slack.enabled | toString | title | quote }}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -68,13 +68,22 @@ celery:
     #   memory: 128Mi
 
 oncall:
+  # slack configures the Grafana Oncall Slack ChatOps integration.
   slack:
+    # enabled enable the Slack ChatOps integration for the Oncall Engine.
     enabled: false
-    command: ~
+    # command sets the Slack bot slash-command
+    command: oncall
+    # clientId configures the Slack app OAuth2 client ID.
+    # api.slack.com/apps/<yourApp> -> Basic Information -> App Credentials -> Client ID
     clientId: ~
+    # clientSecret configures the Slack app OAuth2 client secret.
+    # api.slack.com/apps/<yourApp> -> Basic Information -> App Credentials -> Client Secret
     clientSecret: ~
-    apiToken: ~
-    apiTokenCommon: ~
+    # signingSecret configures the Slack app signature secret used to sign
+    # requests comming from Slack.
+    # api.slack.com/apps/<yourApp> -> Basic Information -> App Credentials -> Signing Secret
+    signingSecret: ~
   telegram:
     enabled: false
     token: ~


### PR DESCRIPTION
The former helm values apiToken and apiTokenCommon were outdated/unused by the application.

**What this PR does**:
Replaces unused environment variables in the helm release with updated env variables.

**Which issue(s) this PR fixes**:
Slack ChatOps integration for helm.

**Checklist**
- [x]  (N/A) Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated