### PR TITLE
Helm chart: add smtp settings to helm chart

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -231,6 +231,9 @@
 {{- end }}
 
 {{- define "snippet.oncall.smtp.env" -}}
+{{- if .Values.oncall.smtp.enabled -}}
+- name: FEATURE_EMAIL_INTEGRATION_ENABLED
+  value: {{ .Values.oncall.smtp.enabled | toString | title | quote }}
 - name: EMAIL_HOST
   value: {{ .Values.oncall.smtp.host | quote }}
 - name: EMAIL_PORT
@@ -245,4 +248,10 @@
       key: smtp-password
 - name: EMAIL_USE_TLS
   value: {{ .Values.oncall.smtp.tls | toString | title | quote }}
+- name: DEFAULT_FROM_EMAIL
+  value: {{ .Values.oncall.smtp.fromEmail | quote }}
+{{- else -}}
+- name: FEATURE_EMAIL_INTEGRATION_ENABLED
+  value: {{ .Values.oncall.smtp.enabled | toString | title | quote }}
+{{- end -}}
 {{- end }}

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -241,7 +241,6 @@
 - name: EMAIL_HOST_USER
   value: {{ .Values.oncall.smtp.username | quote }}
 - name: EMAIL_HOST_PASSWORD
-  value: {{ .Values.oncall.smtp.password | quote }}
   valueFrom:
     secretKeyRef:
       name: {{ include "oncall.fullname" . }}-smtp

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -229,3 +229,20 @@
       name: {{ template "snippet.redis.password.secret.name" . }}
       key: redis-password
 {{- end }}
+
+{{- define "snippet.oncall.smtp.env" -}}
+- name: EMAIL_HOST
+  value: {{ .Values.oncall.smtp.host | quote }}
+- name: EMAIL_PORT
+  value: {{ .Values.oncall.smtp.port | default "587" | quote }}
+- name: EMAIL_HOST_USER
+  value: {{ .Values.oncall.smtp.username | quote }}
+- name: EMAIL_HOST_PASSWORD
+  value: {{ .Values.oncall.smtp.password | quote }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "oncall.fullname" . }}-smtp
+      key: smtp-password
+- name: EMAIL_USE_TLS
+  value: {{ .Values.oncall.smtp.tls | toString | title | quote }}
+{{- end }}

--- a/helm/oncall/templates/celery/_deployment.tpl
+++ b/helm/oncall/templates/celery/_deployment.tpl
@@ -41,6 +41,9 @@ spec:
             {{- include "snippet.oncall.env" . | nindent 12 }}
             {{- include "snippet.oncall.slack.env" . | nindent 12 }}
             {{- include "snippet.oncall.telegram.env" . | nindent 12 }}
+            {{- if .Values.oncall.smtp.enabled }}
+            {{- include "snippet.oncall.smtp.env" . | nindent 12 }}
+            {{- end }}
             {{- include "snippet.mysql.env" . | nindent 12 }}
             {{- include "snippet.rabbitmq.env" . | nindent 12 }}
             {{- include "snippet.redis.env" . | nindent 12 }}

--- a/helm/oncall/templates/celery/_deployment.tpl
+++ b/helm/oncall/templates/celery/_deployment.tpl
@@ -41,9 +41,7 @@ spec:
             {{- include "snippet.oncall.env" . | nindent 12 }}
             {{- include "snippet.oncall.slack.env" . | nindent 12 }}
             {{- include "snippet.oncall.telegram.env" . | nindent 12 }}
-            {{- if .Values.oncall.smtp.enabled }}
             {{- include "snippet.oncall.smtp.env" . | nindent 12 }}
-            {{- end }}
             {{- include "snippet.mysql.env" . | nindent 12 }}
             {{- include "snippet.rabbitmq.env" . | nindent 12 }}
             {{- include "snippet.redis.env" . | nindent 12 }}

--- a/helm/oncall/templates/engine/deployment.yaml
+++ b/helm/oncall/templates/engine/deployment.yaml
@@ -47,9 +47,7 @@ spec:
             {{- include "snippet.oncall.env" . | nindent 12 }}
             {{- include "snippet.oncall.slack.env" . | nindent 12 }}
             {{- include "snippet.oncall.telegram.env" . | nindent 12 }}
-            {{- if .Values.oncall.smtp.enabled }}
             {{- include "snippet.oncall.smtp.env" . | nindent 12 }}
-            {{- end }}
             {{- include "snippet.mysql.env" . | nindent 12 }}
             {{- include "snippet.rabbitmq.env" . | nindent 12 }}
             {{- include "snippet.redis.env" . | nindent 12 }}

--- a/helm/oncall/templates/engine/deployment.yaml
+++ b/helm/oncall/templates/engine/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             {{- include "snippet.oncall.env" . | nindent 12 }}
             {{- include "snippet.oncall.slack.env" . | nindent 12 }}
             {{- include "snippet.oncall.telegram.env" . | nindent 12 }}
+            {{- if .Values.oncall.smtp.enabled }}
+            {{- include "snippet.oncall.smtp.env" . | nindent 12 }}
+            {{- end }}
             {{- include "snippet.mysql.env" . | nindent 12 }}
             {{- include "snippet.rabbitmq.env" . | nindent 12 }}
             {{- include "snippet.redis.env" . | nindent 12 }}

--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -43,6 +43,9 @@ spec:
             python manage.py migrate
         env:
           {{- include "snippet.oncall.env" . | nindent 12 }}
+          {{- if .Values.oncall.smtp.enabled }}
+          {{- include "snippet.oncall.smtp.env" . | nindent 12 }}
+          {{- end }}
           {{- include "snippet.mysql.env" . | nindent 12 }}
           {{- include "snippet.rabbitmq.env" . | nindent 12 }}
           {{- include "snippet.redis.env" . | nindent 12 }}

--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -43,9 +43,7 @@ spec:
             python manage.py migrate
         env:
           {{- include "snippet.oncall.env" . | nindent 12 }}
-          {{- if .Values.oncall.smtp.enabled }}
           {{- include "snippet.oncall.smtp.env" . | nindent 12 }}
-          {{- end }}
           {{- include "snippet.mysql.env" . | nindent 12 }}
           {{- include "snippet.rabbitmq.env" . | nindent 12 }}
           {{- include "snippet.redis.env" . | nindent 12 }}

--- a/helm/oncall/templates/secrets.yaml
+++ b/helm/oncall/templates/secrets.yaml
@@ -40,4 +40,13 @@ type: Opaque
 data:
   redis-password: {{ required "externalRedis.password is required if not redis.enabled" .Values.externalRedis.password | b64enc | quote }}
 {{- end }}
-
+---
+{{ if .Values.oncall.smtp.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "oncall.fullname" . }}-smtp
+type: Opaque
+data:
+  smtp-password: {{ required "oncall.smtp.password is required if oncall.smtp.enabled" .Values.oncall.smtp.password | b64enc | quote }}
+{{- end }}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -79,6 +79,13 @@ oncall:
     enabled: false
     token: ~
     webhookUrl: ~
+  smtp:
+    enabled: false
+    host: ~
+    port: ~
+    username: ~
+    password: ~
+    tls: ~
 
 # Whether to run django database migrations automatically
 migrate:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -86,6 +86,7 @@ oncall:
     username: ~
     password: ~
     tls: ~
+    fromEmail: ~
 
 # Whether to run django database migrations automatically
 migrate:


### PR DESCRIPTION
**What this PR does**:
This PR adds the new SMTP settings from https://github.com/grafana/oncall/pull/621 to the Helm chart.

/cc @vadimkerr since this is related to your PR that was just merged.

**Which issue(s) this PR fixes**:

**Checklist**
- [x] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated