### PR TITLE
[RBAC]: Frontend Part I (plugin.json)

### DIFF
--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -197,6 +197,7 @@
           { "action": "grafana-oncall-app.integrations:write" },
           { "action": "grafana-oncall-app.escalation-chains:write" },
           { "action": "grafana-oncall-app.schedules:write" },
+          { "action": "grafana-oncall-app.chatops:update-settings" },
           { "action": "grafana-oncall-app.outgoing-webhooks:write" },
           { "action": "grafana-oncall-app.user-settings:admin" },
           { "action": "grafana-oncall-app.other-settings:write" }
@@ -446,7 +447,8 @@
         "permissions": [
           { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
           { "action": "grafana-oncall-app.chatops:read" },
-          { "action": "grafana-oncall-app.chatops:write" }
+          { "action": "grafana-oncall-app.chatops:write" },
+          { "action": "grafana-oncall-app.chatops:update-settings" }
         ],
         "hidden": false
       },

--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -33,7 +33,7 @@
       "type": "page",
       "name": "Alert Groups",
       "path": "/a/grafana-oncall-app/?page=incidents",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.alert-groups:read",
       "addToNav": true,
       "defaultNav": true
     },
@@ -41,56 +41,56 @@
       "type": "page",
       "name": "Users",
       "path": "/a/grafana-oncall-app/?page=users",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.user-settings:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "Integrations",
       "path": "/a/grafana-oncall-app/?page=integrations",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.integrations:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "Escalation Chains",
       "path": "/a/grafana-oncall-app/?page=escalations",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.escalation-chains:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "Schedules",
       "path": "/a/grafana-oncall-app/?page=schedules",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.schedules:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "ChatOps",
       "path": "/a/grafana-oncall-app/?page=chat-ops",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.chatops:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "Outgoing Webhooks",
       "path": "/a/grafana-oncall-app/?page=outgoing_webhooks",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.outgoing-webhooks:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "Maintenance",
       "path": "/a/grafana-oncall-app/?page=maintenance",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.maintenance:read",
       "addToNav": true
     },
     {
       "type": "page",
       "name": "Settings",
       "path": "/a/grafana-oncall-app/?page=settings",
-      "role": "Viewer",
+      "action": "grafana-oncall-app.other-settings:read",
       "addToNav": true
     }
   ],
@@ -184,6 +184,463 @@
           "content": "{{ .SecureJsonData.onCallApiToken }}"
         }
       ]
+    }
+  ],
+  "roles": [
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:admin-user-settings-admin",
+        "displayName": "",
+        "description": "",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "grafana-oncall-app.integrations:write" },
+          { "action": "grafana-oncall-app.escalation-chains:write" },
+          { "action": "grafana-oncall-app.schedules:write" },
+          { "action": "grafana-oncall-app.outgoing-webhooks:write" },
+          { "action": "grafana-oncall-app.user-settings:admin" },
+          { "action": "grafana-oncall-app.other-settings:write" }
+        ],
+        "hidden": true
+      },
+      "grants": ["Grafana Admin", "Admin"]
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:admin",
+        "displayName": "Admin",
+        "description": "Read/write access to everything in OnCall",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+
+          { "action": "grafana-oncall-app.alert-groups:read" },
+          { "action": "grafana-oncall-app.alert-groups:write" },
+
+          { "action": "grafana-oncall-app.integrations:read" },
+          { "action": "grafana-oncall-app.integrations:test" },
+
+          { "action": "grafana-oncall-app.escalation-chains:read" },
+
+          { "action": "grafana-oncall-app.schedules:read" },
+          { "action": "grafana-oncall-app.schedules:export" },
+
+          { "action": "grafana-oncall-app.chatops:read" },
+          { "action": "grafana-oncall-app.chatops:write" },
+
+          { "action": "grafana-oncall-app.outgoing-webhooks:read" },
+
+          { "action": "grafana-oncall-app.maintenance:read" },
+          { "action": "grafana-oncall-app.maintenance:write" },
+
+          { "action": "grafana-oncall-app.api-keys:read" },
+          { "action": "grafana-oncall-app.api-keys:write" },
+
+          { "action": "grafana-oncall-app.notifications:read" },
+
+          { "action": "grafana-oncall-app.notification-settings:read" },
+          { "action": "grafana-oncall-app.notification-settings:write" },
+
+          { "action": "grafana-oncall-app.user-settings:read" },
+          { "action": "grafana-oncall-app.user-settings:write" },
+
+          { "action": "grafana-oncall-app.other-settings:read" }
+        ],
+        "hidden": false
+      },
+      "grants": ["Grafana Admin", "Admin", "Editor"]
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:reader",
+        "displayName": "Reader",
+        "description": "Read-only access to everything in OnCall",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+
+          { "action": "grafana-oncall-app.alert-groups:read" },
+          { "action": "grafana-oncall-app.integrations:read" },
+          { "action": "grafana-oncall-app.escalation-chains:read" },
+          { "action": "grafana-oncall-app.schedules:read" },
+          { "action": "grafana-oncall-app.chatops:read" },
+          { "action": "grafana-oncall-app.outgoing-webhooks:read" },
+          { "action": "grafana-oncall-app.maintenance:read" },
+          { "action": "grafana-oncall-app.api-keys:read" },
+          { "action": "grafana-oncall-app.notification-settings:read" },
+          { "action": "grafana-oncall-app.user-settings:read" },
+          { "action": "grafana-oncall-app.other-settings:read" }
+        ],
+        "hidden": false
+      },
+      "grants": ["Viewer"]
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:oncaller",
+        "displayName": "OnCaller",
+        "description": "Grants read access to everything in OnCall. In addition, grants edit access to Alert Groups and Schedules",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+
+          { "action": "grafana-oncall-app.alert-groups:read" },
+          { "action": "grafana-oncall-app.alert-groups:write" },
+
+          { "action": "grafana-oncall-app.integrations:read" },
+          { "action": "grafana-oncall-app.escalation-chains:read" },
+
+          { "action": "grafana-oncall-app.schedules:read" },
+          { "action": "grafana-oncall-app.schedules:write" },
+
+          { "action": "grafana-oncall-app.chatops:read" },
+          { "action": "grafana-oncall-app.outgoing-webhooks:read" },
+          { "action": "grafana-oncall-app.maintenance:read" },
+          { "action": "grafana-oncall-app.api-keys:read" },
+          { "action": "grafana-oncall-app.notification-settings:read" },
+          { "action": "grafana-oncall-app.user-settings:read" },
+          { "action": "grafana-oncall-app.other-settings:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:alert-groups-reader",
+        "displayName": "Alert Groups Reader",
+        "description": "Read-only access to OnCall Alert Groups",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.alert-groups:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:alert-groups-editor",
+        "displayName": "Alert Groups Edtiro",
+        "description": "Read/write access to OnCall Alert Groups",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.alert-groups:read" },
+          { "action": "grafana-oncall-app.alert-groups:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:integrations-reader",
+        "displayName": "Integrations Reader",
+        "description": "Read-only access to OnCall Integrations",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.integrations:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:integrations-editor",
+        "displayName": "Integrations Editor",
+        "description": "Read/write access to OnCall Integrations",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.integrations:read" },
+          { "action": "grafana-oncall-app.integrations:write" },
+          { "action": "grafana-oncall-app.integrations:test" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:escalation-chains-reader",
+        "displayName": "Escalation Chains Reader",
+        "description": "Read-only access to OnCall Escalation Chains",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.escalation-chains:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:escalation-chains-editor",
+        "displayName": "Escalation Chains Editor",
+        "description": "Read/write access to OnCall Escalation Chains",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.escalation-chains:read" },
+          { "action": "grafana-oncall-app.escalation-chains:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:schedules-reader",
+        "displayName": "Schedules Reader",
+        "description": "Read-only access to OnCall Schedules",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.schedules:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:schedules-editor",
+        "displayName": "Schedules Editor",
+        "description": "Read/write access to OnCall Schedules",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.schedules:read" },
+          { "action": "grafana-oncall-app.schedules:write" },
+          { "action": "grafana-oncall-app.schedules:export" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:chatops-reader",
+        "displayName": "ChatOps Reader",
+        "description": "Read-only access to OnCall ChatOps",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.chatops:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:chatops-editor",
+        "displayName": "ChatOps Editor",
+        "description": "Read/write access to OnCall ChatOps",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.chatops:read" },
+          { "action": "grafana-oncall-app.chatops:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:outgoing-webhooks-reader",
+        "displayName": "Outgoing Webhooks Reader",
+        "description": "Read-only access to OnCall Outgoing Webhooks",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.outgoing-webhooks:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:outgoing-webhooks-editor",
+        "displayName": "Outgoing Webhooks Editor",
+        "description": "Read/write access to OnCall Outgoing Webhooks",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.outgoing-webhooks:read" },
+          { "action": "grafana-oncall-app.outgoing-webhooks:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:maintenance-reader",
+        "displayName": "Maintenance Reader",
+        "description": "Read-only access to OnCall Maintenance",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.maintenance:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:maintenance-editor",
+        "displayName": "Maintenance Editor",
+        "description": "Read/write access to OnCall Maintenance",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.maintenance:read" },
+          { "action": "grafana-oncall-app.maintenance:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:api-keys-reader",
+        "displayName": "API Keys Reader",
+        "description": "Read-only access to OnCall API Keys",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.api-keys:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:api-keys-editor",
+        "displayName": "API Keys Editor",
+        "description": "Read/write access to OnCall API Keys. Also grants access to be able to consume the API.",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.api-keys:read" },
+          { "action": "grafana-oncall-app.api-keys:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:notification-settings-reader",
+        "displayName": "Notification Settings Reader",
+        "description": "Read-only access to OnCall Notification Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.notification-settings:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:notification-settings-editor",
+        "displayName": "Notification Settings Editor",
+        "description": "Read/write access to OnCall Notification Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.notification-settings:read" },
+          { "action": "grafana-oncall-app.notification-settings:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:user-settings-reader",
+        "displayName": "User Settings Reader",
+        "description": "Read-only access to OnCall User Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.user-settings:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:user-settings-editor",
+        "displayName": "User Settings Editor",
+        "description": "Read/write access to own OnCall User Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.user-settings:read" },
+          { "action": "grafana-oncall-app.user-settings:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:user-settings-admin",
+        "displayName": "User Settings Admin",
+        "description": "Read/write access to your own, plus other's OnCall User Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.user-settings:read" },
+          { "action": "grafana-oncall-app.user-settings:write" },
+          { "action": "grafana-oncall-app.user-settings:admin" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:other-settings-reader",
+        "displayName": "Settings Reader",
+        "description": "Read-only access to OnCall Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.other-settings:read" }
+        ],
+        "hidden": false
+      },
+      "grants": []
+    },
+    {
+      "role": {
+        "name": "plugins.app:grafana-oncall-app:other-settings-editor",
+        "displayName": "Settings Editor",
+        "description": "Read/write access to OnCall Settings",
+        "group": "OnCall",
+        "permissions": [
+          { "action": "plugins.app:access", "scope": "plugins.app:id:grafana-oncall-app" },
+          { "action": "grafana-oncall-app.other-settings:read" },
+          { "action": "grafana-oncall-app.other-settings:write" }
+        ],
+        "hidden": false
+      },
+      "grants": []
     }
   ],
   "dependencies": {


### PR DESCRIPTION
**What this PR does**:
- marks the `dependencies.grafanaDependency` and `dependencies.grafanaVersion` configurations in `plugin.json` to version `x.y.z` (**TODO**  once @gamab deploys his changes to `grafana/grafana`, update this)
- defines 26 new custom roles in `plugin.json` (these are the roles that get shown in the Grafana role component, see screenshot below). The main roles are:
  - `Admin`: read/write access to everything in OnCall
  - `Reader`: read access to everything in OnCall
  - `OnCaller` : read access to everything in OnCall + edit access to Alert Groups and Schedules
  - `<object-type> Editor`: read/write access to everything related to `<object-type>`
  - `<object-type> Reader`: read access for `<object-type>`
  - `User Settings Admin`: read/write access to _all_ user's settings, not just own settings. This is in comparison to `User Settings Editor` which can only read/write own settings
  
<img width="523" alt="Screen Shot 2022-10-11 at 15 39 20" src="https://user-images.githubusercontent.com/9406895/195106725-61a2df14-9b09-4ad7-9d90-b848813002f2.png">

**Which issue(s) this PR fixes**:
`grafana/oncall-private` [#1381](https://github.com/grafana/oncall-private/issues/1381)

**Migration Details**
Basically we won't need to do any migration and users _shouldn't_ notice any functionality differences. This is because of the `grants` section in the `role` objects in `plugin.json`. What this does is essentially "grant" a list of RBAC permissions to the specified "Basic Roles". The basic mapping I have defined is as such:
- Grafana Admin and Admin: can do everything, including updating other user's settings, can receive notifications (`grafana-oncall-app.notifications.read` permission)
- Editor: can read and write everything, except updating other user's settings, can receive notifications (`grafana-oncall-app.notifications.read` permission)
- Viewer: can view everything, and can update own settings

If users actually want to "unlock" more granular OnCall RBAC permissions, they will need to [modify the Basic Roles](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/#basic-roles:~:text=Basic%20role%20modification) to remove the OnCall RBAC permission grants (through the API)

**Checklist**
- [x] Tests updated
- [ ] Documentation added (done in #686)
- [ ] `CHANGELOG.md` updated (done in #686)

RBAC PRs (once approved, all of these PRs will be merged into the `jorlando/rbac` branch and that branch will then be merged to `dev`):
- #635 
- #634 
- #732 
- #687
- #699 
- #686