### PR TITLE
added Redis variables to be configured in helm chart

### DIFF
--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -140,11 +140,11 @@ if DATABASE_TYPE == DatabaseTypes.MYSQL:
     pymysql.install_as_MySQLdb()
 
 # Redis
+REDIS_PROTOCOL = os.getenv("REDIS_PROTOCOL", "redis")
 REDIS_USERNAME = os.getenv("REDIS_USERNAME", "")
 REDIS_PASSWORD = os.getenv("REDIS_PASSWORD")
 REDIS_HOST = os.getenv("REDIS_HOST")
 REDIS_PORT = os.getenv("REDIS_PORT", 6379)
-REDIS_PROTOCOL = os.getenv("REDIS_PROTOCOL", "redis")
 
 REDIS_URI = os.getenv("REDIS_URI")
 if not REDIS_URI:

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -202,11 +202,35 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "snippet.redis.protocol" -}}
+{{- if and (not .Values.redis.enabled) .Values.externalRedis.protocol -}}
+{{ .Values.externalRedis.protocol | quote }}
+{{- else -}}
+"redis"
+{{- end -}}
+{{- end -}}
+
+{{- define "snippet.redis.username" -}}
+{{- if and (not .Values.redis.enabled) .Values.externalRedis.username -}}
+{{ .Values.externalRedis.username | quote }}
+{{- else -}}
+""
+{{- end -}}
+{{- end -}}
+
 {{- define "snippet.redis.host" -}}
 {{- if and (not .Values.redis.enabled) .Values.externalRedis.host -}}
 {{- required "externalRedis.host is required if not redis.enabled" .Values.externalRedis.host | quote }}
 {{- else -}}
 {{ include "oncall.redis.fullname" . }}-master
+{{- end -}}
+{{- end -}}
+
+{{- define "snippet.redis.port" -}}
+{{- if and (not .Values.redis.enabled) .Values.externalRedis.port -}}
+{{ .Values.externalRedis.port | quote }}
+{{- else -}}
+"6379"
 {{- end -}}
 {{- end -}}
 
@@ -219,15 +243,20 @@
 {{- end -}}
 
 {{- define "snippet.redis.env" -}}
-- name: REDIS_HOST
-  value: {{ include "snippet.redis.host" . }}
-- name: REDIS_PORT
-  value: "6379"
+- name: REDIS_PROTOCOL
+  value: {{ include "snippet.redis.protocol . }}
+- name: REDIS_USERNAME
+  value: {{ include "snippet.redis.username" . }}
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ template "snippet.redis.password.secret.name" . }}
       key: redis-password
+- name: REDIS_HOST
+  value: {{ include "snippet.redis.host" . }}
+- name: REDIS_PORT
+  value: {{ include "snippet.redis.port" . }}
+
 {{- end }}
 
 {{- define "snippet.oncall.smtp.env" -}}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -202,8 +202,12 @@ redis:
   enabled: true
 
 externalRedis:
-  host:
+  protocol:
+  username:
   password:
+  host:
+  port:
+
 
 # Grafana is included into this release for the convenience.
 # It is recommended to host it separately from this release


### PR DESCRIPTION
**What this PR does**:
Added the redis connection properties, defined in base.py,  to be configureable in the helm chart.
**Which issue(s) this PR fixes**:
No issue directly, but its a fix for something that is clearly missing. also closes a request at #538

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated