### PR TITLE
Remove 'emoji' property from Slack markdown blocks in resolution notes

### DIFF
--- a/engine/apps/slack/scenarios/resolution_note.py
+++ b/engine/apps/slack/scenarios/resolution_note.py
@@ -358,7 +358,7 @@ class UpdateResolutionNoteStep(scenario_step.ScenarioStep):
         author_verbal = resolution_note.author_verbal(mention=True)
         resolution_note_text_block = {
             "type": "section",
-            "text": {"type": "mrkdwn", "text": resolution_note.text, "emoji": True},
+            "text": {"type": "mrkdwn", "text": resolution_note.text},
         }
         blocks.append(resolution_note_text_block)
         context_block = {


### PR DESCRIPTION
I'm seeing this error in logs:

> invalid additional property: emoji [json-pointer:/blocks/0/text]

It looks like the 'emoji' argument is not supported when type: mrkdwn. This PR removes that property in the same place that the change to `mrkdwn` was made - see [this PR](https://github.com/grafana/oncall/pull/646).