### PR TITLE
Catch TemplateRuntimeError when applying jinja template

### DIFF
--- a/engine/apps/api/tests/test_alert_group.py
+++ b/engine/apps/api/tests/test_alert_group.py
@@ -1468,4 +1468,5 @@ def test_alert_group_preview_body_invalid_template_syntax(
     data = {"template_name": "testonly_title_template", "template_body": "{{'' if foo is None else foo}}"}
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
 
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["preview"] is None

--- a/engine/common/jinja_templater/apply_jinja_template.py
+++ b/engine/common/jinja_templater/apply_jinja_template.py
@@ -1,4 +1,4 @@
-from jinja2 import TemplateSyntaxError, UndefinedError
+from jinja2 import TemplateSyntaxError, UndefinedError, TemplateRuntimeError
 
 from .jinja_template_env import jinja_template_env
 
@@ -8,5 +8,5 @@ def apply_jinja_template(template, payload=None, **kwargs):
         template = jinja_template_env.from_string(template)
         result = template.render(payload=payload, **kwargs)
         return result, True
-    except (UndefinedError, TypeError, ValueError, KeyError, TemplateSyntaxError):
+    except (UndefinedError, TypeError, ValueError, KeyError, TemplateSyntaxError, TemplateRuntimeError):
         return None, False


### PR DESCRIPTION
**What this PR does**:
Catch TemplateRuntimeError when applying jinja template to alert for rendering.

**Which issue(s) this PR fixes**:
Partially fixes https://github.com/grafana/oncall-private/issues/1431

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated