### PR TITLE
[RBAC]: Backend changes - tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,12 @@ jobs:
           docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
 
   unit-test-backend-mysql-rabbitmq:
+    name: "Backend Tests: MySQL + RabbitMQ (RBAC enabled: ${{ matrix.rbac_enabled }})"
     runs-on: ubuntu-latest
     container: python:3.9
+    strategy:
+      matrix:
+        rbac_enabled: ["True", "False"]
     env:
       DJANGO_SETTINGS_MODULE: settings.ci-test
       SLACK_CLIENT_OAUTH_ID: 1
@@ -72,7 +76,6 @@ jobs:
         env:
           MYSQL_DATABASE: oncall_local_dev
           MYSQL_ROOT_PASSWORD: local_dev_pwd
-
     steps:
       - uses: actions/checkout@v2
       - name: Unit Test Backend
@@ -80,11 +83,15 @@ jobs:
           apt-get update && apt-get install -y netcat
           cd engine/
           pip install -r requirements.txt
-          ./wait_for_test_mysql_start.sh && pytest --ds=settings.ci-test -x
+          ./wait_for_test_mysql_start.sh && ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest --ds=settings.ci-test -x
 
   unit-test-backend-postgresql-rabbitmq:
+    name: "Backend Tests: PostgreSQL + RabbitMQ (RBAC enabled: ${{ matrix.rbac_enabled }})"
     runs-on: ubuntu-latest
     container: python:3.9
+    strategy:
+      matrix:
+        rbac_enabled: ["True", "False"]
     env:
       DATABASE_TYPE: postgresql
       DJANGO_SETTINGS_MODULE: settings.ci-test
@@ -112,11 +119,15 @@ jobs:
         run: |
           cd engine/
           pip install -r requirements.txt
-          pytest --ds=settings.ci-test -x
+          ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest --ds=settings.ci-test -x
 
   unit-test-backend-sqlite-redis:
+    name: "Backend Tests: SQLite + Redis (RBAC enabled: ${{ matrix.rbac_enabled }})"
     runs-on: ubuntu-latest
     container: python:3.9
+    strategy:
+      matrix:
+        rbac_enabled: ["True", "False"]
     env:
       DATABASE_TYPE: sqlite3
       BROKER_TYPE: redis
@@ -131,7 +142,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     steps:
       - uses: actions/checkout@v2
       - name: Unit Test Backend
@@ -139,7 +149,7 @@ jobs:
           apt-get update && apt-get install -y netcat
           cd engine/
           pip install -r requirements.txt
-          pytest --ds=settings.ci-test -x
+          ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest --ds=settings.ci-test -x
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           apt-get update && apt-get install -y netcat
           cd engine/
           pip install -r requirements.txt
-          ./wait_for_test_mysql_start.sh && ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest --ds=settings.ci-test -x
+          ./wait_for_test_mysql_start.sh && ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest -x
 
   unit-test-backend-postgresql-rabbitmq:
     name: "Backend Tests: PostgreSQL + RabbitMQ (RBAC enabled: ${{ matrix.rbac_enabled }})"
@@ -119,7 +119,7 @@ jobs:
         run: |
           cd engine/
           pip install -r requirements.txt
-          ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest --ds=settings.ci-test -x
+          ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest -x
 
   unit-test-backend-sqlite-redis:
     name: "Backend Tests: SQLite + Redis (RBAC enabled: ${{ matrix.rbac_enabled }})"
@@ -149,7 +149,7 @@ jobs:
           apt-get update && apt-get install -y netcat
           cd engine/
           pip install -r requirements.txt
-          ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest --ds=settings.ci-test -x
+          ONCALL_TESTING_RBAC_ENABLED=${{ matrix.rbac_enabled }} pytest -x
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           pre-commit run --all-files
 
-  test:
+  test-frontend:
     runs-on: ubuntu-latest
     container: python:3.9
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Backend
 */db.sqlite3
-engine/oncall_dev.db
 *.pyc
 venv
 .python-version
@@ -10,7 +9,7 @@ venv
 .vscode
 dump.rdb
 .idea
-engine/celerybeat-schedule.db
+engine/*.db
 engine/sqlite_data
 jupiter_playbooks/*
 engine/reports/*.csv

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -15,9 +15,9 @@ services:
       resources:
         limits:
           memory: 500m
-          cpus: '0.5'
+          cpus: "0.5"
     healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 20s
       retries: 10
 
@@ -30,7 +30,7 @@ services:
       resources:
         limits:
           memory: 100m
-          cpus: '0.1'
+          cpus: "0.1"
 
   rabbit:
     image: "rabbitmq:3.7.15-management"
@@ -42,7 +42,7 @@ services:
       resources:
         limits:
           memory: 1000m
-          cpus: '0.5'
+          cpus: "0.5"
     ports:
       - "15672:15672"
       - "5672:5672"
@@ -70,7 +70,7 @@ services:
       resources:
         limits:
           memory: 500m
-          cpus: '0.5'
+          cpus: "0.5"
     volumes:
       - ./grafana-plugin:/var/lib/grafana/plugins/grafana-plugin
     ports:

--- a/engine/apps/alerts/tests/test_alert_group.py
+++ b/engine/apps/alerts/tests/test_alert_group.py
@@ -4,7 +4,6 @@ from apps.alerts.incident_appearance.renderers.phone_call_renderer import AlertG
 from apps.alerts.models import AlertGroup
 from apps.alerts.tasks.delete_alert_group import delete_alert_group
 from apps.slack.models import SlackMessage
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
@@ -14,7 +13,7 @@ def test_render_for_phone_call(
     make_alert_group,
     make_alert,
 ):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    organization, _ = make_organization_with_slack_team_identity()
     alert_receive_channel = make_alert_receive_channel(organization, integration_slack_channel_id="CWER1ASD")
 
     alert_group = make_alert_group(alert_receive_channel)
@@ -59,7 +58,7 @@ def test_delete(
 
     organization, slack_team_identity = make_organization_with_slack_team_identity()
     slack_channel = make_slack_channel(slack_team_identity, name="general", slack_id="CWER1ASD")
-    user = make_user(organization=organization, role=Role.ADMIN)
+    user = make_user(organization=organization)
 
     alert_receive_channel = make_alert_receive_channel(organization, integration_slack_channel_id="CWER1ASD")
 

--- a/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
+++ b/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
@@ -10,7 +10,6 @@ from apps.alerts.escalation_snapshot.utils import eta_for_escalation_step_notify
 from apps.alerts.models import AlertGroupLogRecord, EscalationPolicy
 from apps.schedules.ical_utils import list_users_to_notify_from_ical
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleCalendar
-from common.constants.role import Role
 
 
 def get_escalation_policy_snapshot_from_model(escalation_policy):
@@ -213,8 +212,8 @@ def test_escalation_step_notify_on_call_schedule_viewer_user(
     make_schedule,
     make_on_call_shift,
 ):
-    organization, user, _, channel_filter, alert_group, reason = escalation_step_test_setup
-    viewer = make_user_for_organization(organization=organization, role=Role.VIEWER)
+    organization, _, _, channel_filter, alert_group, reason = escalation_step_test_setup
+    viewer = make_user_for_organization(organization=organization)
 
     schedule = make_schedule(organization, schedule_class=OnCallScheduleCalendar)
     # create on_call_shift with user to notify

--- a/engine/apps/alerts/tests/test_notify_user.py
+++ b/engine/apps/alerts/tests/test_notify_user.py
@@ -3,9 +3,11 @@ from unittest.mock import patch
 import pytest
 
 from apps.alerts.tasks.notify_user import notify_user_task, perform_notification
+from apps.api.permissions import LegacyAccessControlRole
 from apps.base.models.user_notification_policy import UserNotificationPolicy
 from apps.base.models.user_notification_policy_log_record import UserNotificationPolicyLogRecord
-from common.constants.role import Role
+
+NOTIFICATION_UNAUTHORIZED_MSG = "notification is not allowed for user"
 
 
 @pytest.mark.django_db
@@ -131,7 +133,9 @@ def test_notify_user_perform_notification_error_if_viewer(
     make_user_notification_policy_log_record,
 ):
     organization = make_organization()
-    user_1 = make_user(organization=organization, role=Role.VIEWER, _verified_phone_number="1234567890")
+    user_1 = make_user(
+        organization=organization, role=LegacyAccessControlRole.VIEWER, _verified_phone_number="1234567890"
+    )
     user_notification_policy = make_user_notification_policy(
         user=user_1,
         step=UserNotificationPolicy.Step.NOTIFY,
@@ -150,11 +154,8 @@ def test_notify_user_perform_notification_error_if_viewer(
 
     error_log_record = UserNotificationPolicyLogRecord.objects.last()
     assert error_log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED
-    assert error_log_record.reason == f"notification is not allowed for user with role {user_1.role}"
-    assert (
-        error_log_record.notification_error_code
-        == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_NOT_ALLOWED_USER_ROLE
-    )
+    assert error_log_record.reason == NOTIFICATION_UNAUTHORIZED_MSG
+    assert error_log_record.notification_error_code == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_UNAUTHORIZED
 
 
 @pytest.mark.django_db
@@ -165,7 +166,9 @@ def test_notify_user_error_if_viewer(
     make_alert_group,
 ):
     organization = make_organization()
-    user_1 = make_user(organization=organization, role=Role.VIEWER, _verified_phone_number="1234567890")
+    user_1 = make_user(
+        organization=organization, role=LegacyAccessControlRole.VIEWER, _verified_phone_number="1234567890"
+    )
     alert_receive_channel = make_alert_receive_channel(organization=organization)
     alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
 
@@ -173,8 +176,5 @@ def test_notify_user_error_if_viewer(
 
     error_log_record = UserNotificationPolicyLogRecord.objects.last()
     assert error_log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED
-    assert error_log_record.reason == f"notification is not allowed for user with role {user_1.role}"
-    assert (
-        error_log_record.notification_error_code
-        == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_NOT_ALLOWED_USER_ROLE
-    )
+    assert error_log_record.reason == NOTIFICATION_UNAUTHORIZED_MSG
+    assert error_log_record.notification_error_code == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_UNAUTHORIZED

--- a/engine/apps/api/permissions/__init__.py
+++ b/engine/apps/api/permissions/__init__.py
@@ -254,6 +254,52 @@ class IsStaff(permissions.BasePermission):
 RBACPermissionsAttribute = typing.Dict[str, typing.List[LegacyAccessControlCompatiblePermission]]
 RBACObjectPermissionsAttribute = typing.Dict[permissions.BasePermission, typing.List[str]]
 
-ALL_PERMISSIONS = [
-    getattr(RBACPermission.Permissions, attr) for attr in dir(RBACPermission.Permissions) if not attr.startswith("_")
+# The below stuff is mostly for testing purposes
+# ROLE_PERMISSION_MAPPING essentially represents the basic legacy role -> RBAC permission mapping
+# that is defined in plugin.json on the frontend
+
+
+def _get_list_of_perms_for_role(
+    role: LegacyAccessControlCompatiblePermission,
+) -> typing.List[LegacyAccessControlCompatiblePermission]:
+    return [
+        getattr(RBACPermission.Permissions, attr)
+        for attr in dir(RBACPermission.Permissions)
+        if not attr.startswith("_") and getattr(RBACPermission.Permissions, attr).fallback_role == role
+    ]
+
+
+_VIEWER_PERMISSIONS = _get_list_of_perms_for_role(LegacyAccessControlRole.VIEWER)
+_EDITOR_PERMISSIONS = _VIEWER_PERMISSIONS + _get_list_of_perms_for_role(LegacyAccessControlRole.EDITOR)
+_ADMIN_PERMISSIONS = _EDITOR_PERMISSIONS + _get_list_of_perms_for_role(LegacyAccessControlRole.ADMIN)
+ROLE_PERMISSION_MAPPING: typing.Dict[LegacyAccessControlRole, typing.List[LegacyAccessControlCompatiblePermission]] = {
+    LegacyAccessControlRole.VIEWER: _VIEWER_PERMISSIONS,
+    LegacyAccessControlRole.EDITOR: _EDITOR_PERMISSIONS,
+    LegacyAccessControlRole.ADMIN: _ADMIN_PERMISSIONS,
+}
+
+# The below is legacy, it is only needed currently for backward compatibility w/ users running
+# older "pinned" version of Grafana in Grafana Cloud
+_DONT_USE_LEGACY_VIEWER_PERMISSIONS = []
+_DONT_USE_LEGACY_EDITOR_PERMISSIONS = ["update_incidents", "update_own_settings", "view_other_users"]
+_DONT_USE_LEGACY_ADMIN_PERMISSIONS = _DONT_USE_LEGACY_EDITOR_PERMISSIONS + [
+    "update_alert_receive_channels",
+    "update_escalation_policies",
+    "update_notification_policies",
+    "update_general_log_channel_id",
+    "update_other_users_settings",
+    "update_integrations",
+    "update_schedules",
+    "update_custom_actions",
+    "update_api_tokens",
+    "update_teams",
+    "update_maintenances",
+    "update_global_settings",
+    "send_demo_alert",
 ]
+
+DONT_USE_LEGACY_PERMISSION_MAPPING: typing.Dict[LegacyAccessControlRole, typing.List[str]] = {
+    LegacyAccessControlRole.VIEWER: _DONT_USE_LEGACY_VIEWER_PERMISSIONS,
+    LegacyAccessControlRole.EDITOR: _DONT_USE_LEGACY_EDITOR_PERMISSIONS,
+    LegacyAccessControlRole.ADMIN: _DONT_USE_LEGACY_ADMIN_PERMISSIONS,
+}

--- a/engine/apps/api/permissions/test_permissions.py
+++ b/engine/apps/api/permissions/test_permissions.py
@@ -1,0 +1,428 @@
+import typing
+
+import pytest
+from rest_framework.views import APIView
+from rest_framework.viewsets import ViewSetMixin
+
+from . import (
+    RBAC_PERMISSIONS_ATTR,
+    GrafanaAPIPermission,
+    HasRBACPermissions,
+    IsOwner,
+    IsOwnerOrHasRBACPermissions,
+    LegacyAccessControlCompatiblePermission,
+    RBACObjectPermissionsAttribute,
+    RBACPermission,
+    RBACPermissionsAttribute,
+    get_most_authorized_role,
+    user_is_authorized,
+)
+
+
+class MockedOrg:
+    def __init__(self, org_has_rbac_enabled: bool) -> None:
+        self.is_rbac_permissions_enabled = org_has_rbac_enabled
+
+
+class MockedUser:
+    def __init__(
+        self, permissions: typing.List[LegacyAccessControlCompatiblePermission], org_has_rbac_enabled=True
+    ) -> None:
+        self.permissions = [GrafanaAPIPermission(action=perm.value) for perm in permissions]
+        self.role = get_most_authorized_role(permissions)
+        self.organization = MockedOrg(org_has_rbac_enabled)
+
+
+class MockedSchedule:
+    def __init__(self, user: MockedUser) -> None:
+        self.user = user
+
+
+class MockedRequest:
+    def __init__(self, user: typing.Optional[MockedUser] = None, method: typing.Optional[str] = None) -> None:
+        if user:
+            self.user = user
+        if method:
+            self.method = method
+
+
+class MockedViewSet(ViewSetMixin):
+    def __init__(
+        self,
+        action: str,
+        rbac_permissions: typing.Optional[RBACPermissionsAttribute] = None,
+        rbac_object_permissions: typing.Optional[RBACObjectPermissionsAttribute] = None,
+    ) -> None:
+        super().__init__()
+        self.action = action
+
+        if rbac_permissions:
+            self.rbac_permissions = rbac_permissions
+        if rbac_object_permissions:
+            self.rbac_object_permissions = rbac_object_permissions
+
+
+class MockedAPIView(APIView):
+    def __init__(
+        self,
+        rbac_permissions: typing.Optional[RBACPermissionsAttribute] = None,
+        rbac_object_permissions: typing.Optional[RBACObjectPermissionsAttribute] = None,
+    ) -> None:
+        super().__init__()
+
+        if rbac_permissions:
+            self.rbac_permissions = rbac_permissions
+        if rbac_object_permissions:
+            self.rbac_object_permissions = rbac_object_permissions
+
+
+@pytest.mark.parametrize(
+    "user_permissions,required_permissions,org_has_rbac_enabled,expected_result",
+    [
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            True,
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            False,
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            True,
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            False,
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            True,
+            False,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            False,
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            False,
+            False,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            True,
+            False,
+        ),
+    ],
+)
+def test_user_is_authorized(user_permissions, required_permissions, org_has_rbac_enabled, expected_result) -> None:
+    user = MockedUser(user_permissions, org_has_rbac_enabled=org_has_rbac_enabled)
+    assert user_is_authorized(user, required_permissions) == expected_result
+
+
+@pytest.mark.parametrize(
+    "permissions,expected_role",
+    [
+        ([RBACPermission.Permissions.ALERT_GROUPS_READ], RBACPermission.Permissions.ALERT_GROUPS_READ.fallback_role),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            RBACPermission.Permissions.ALERT_GROUPS_WRITE.fallback_role,
+        ),
+        (
+            [
+                RBACPermission.Permissions.USER_SETTINGS_READ,
+                RBACPermission.Permissions.USER_SETTINGS_WRITE,
+                RBACPermission.Permissions.USER_SETTINGS_ADMIN,
+            ],
+            RBACPermission.Permissions.USER_SETTINGS_ADMIN.fallback_role,
+        ),
+    ],
+)
+def test_get_most_authorized_role(permissions, expected_role) -> None:
+    assert get_most_authorized_role(permissions) == expected_role
+
+
+class TestRBACPermission:
+    def test_get_view_action(self) -> None:
+        viewset_action = "viewset_action"
+        viewset = MockedViewSet(viewset_action)
+
+        apiview = MockedAPIView()
+
+        method = "APIVIEW_ACTION"
+        request = MockedRequest(method=method)
+
+        assert RBACPermission._get_view_action(request, viewset) == viewset_action, "it works with a ViewSet"
+        assert RBACPermission._get_view_action(request, apiview) == method.lower(), "it works with an APIView"
+
+    def test_has_permission_works_on_a_viewset_view(self) -> None:
+        required_permission = RBACPermission.Permissions.ALERT_GROUPS_READ
+
+        action = "hello"
+        viewset = MockedViewSet(
+            action=action,
+            rbac_permissions={
+                action: [required_permission],
+            },
+        )
+
+        viewset_with_no_required_permissions = MockedViewSet(
+            action=action,
+            rbac_permissions={
+                action: [],
+            },
+        )
+
+        user_with_permission = MockedUser([required_permission])
+        user_without_permission = MockedUser([RBACPermission.Permissions.ALERT_GROUPS_WRITE])
+
+        assert (
+            RBACPermission().has_permission(MockedRequest(user_with_permission), viewset) is True
+        ), "it works on a viewset when the user does have permission"
+
+        assert (
+            RBACPermission().has_permission(MockedRequest(user_without_permission), viewset) is False
+        ), "it works on a viewset when the user does have permission"
+
+        assert (
+            RBACPermission().has_permission(
+                MockedRequest(user_without_permission), viewset_with_no_required_permissions
+            )
+            is True
+        ), "it works on a viewset when the viewset action does not require permissions"
+
+    def test_has_permission_works_on_an_apiview_view(self) -> None:
+        required_permission = RBACPermission.Permissions.ALERT_GROUPS_READ
+
+        method = "hello"
+        apiview = MockedAPIView(
+            rbac_permissions={
+                method: [required_permission],
+            }
+        )
+        apiview_with_no_permissions = MockedAPIView(
+            rbac_permissions={
+                method: [],
+            }
+        )
+
+        user1 = MockedUser([required_permission])
+        user2 = MockedUser([RBACPermission.Permissions.ALERT_GROUPS_WRITE])
+
+        class Request(MockedRequest):
+            def __init__(self, user: typing.Optional[MockedUser] = None) -> None:
+                super().__init__(user, method)
+
+        assert (
+            RBACPermission().has_permission(Request(user1), apiview) is True
+        ), "it works on an APIView when the user has permission"
+
+        assert (
+            RBACPermission().has_permission(Request(user2), apiview) is False
+        ), "it works on an APIView when the user does not have permission"
+
+        assert (
+            RBACPermission().has_permission(Request(user2), apiview_with_no_permissions) is True
+        ), "it works on a viewset when the viewset action does not require permissions"
+
+    def test_has_permission_throws_assertion_error_if_developer_forgets_to_specify_rbac_permissions(self) -> None:
+        action_slash_method = "hello"
+        error_msg = (
+            f"Must define a {RBAC_PERMISSIONS_ATTR} dict on the ViewSet that is consuming the RBACPermission class"
+        )
+
+        viewset = MockedViewSet(action_slash_method)
+        apiview = MockedAPIView()
+
+        with pytest.raises(AssertionError, match=error_msg):
+            RBACPermission().has_permission(MockedRequest(), viewset)
+
+        with pytest.raises(AssertionError, match=error_msg):
+            RBACPermission().has_permission(MockedRequest(method=action_slash_method), apiview)
+
+    def test_has_permission_throws_assertion_error_if_developer_forgets_to_specify_an_action_in_rbac_permissions(
+        self,
+    ) -> None:
+        action_slash_method = "hello"
+        other_action_rbac_permissions = {"bonjour": []}
+        error_msg = f"""Each action must be defined within the {RBAC_PERMISSIONS_ATTR} dict on the ViewSet.
+\nIf an action requires no permissions, its value should explicitly be set to an empty list"""
+
+        viewset = MockedViewSet(action_slash_method, other_action_rbac_permissions)
+        apiview = MockedAPIView(rbac_permissions=other_action_rbac_permissions)
+
+        with pytest.raises(AssertionError, match=error_msg):
+            RBACPermission().has_permission(MockedRequest(), viewset)
+
+        with pytest.raises(AssertionError, match=error_msg):
+            RBACPermission().has_permission(MockedRequest(method=action_slash_method), apiview)
+
+    def test_has_object_permission_returns_true_if_rbac_object_permissions_not_specified(self) -> None:
+        request = MockedRequest()
+        assert RBACPermission().has_object_permission(request, MockedAPIView(), None) is True
+        assert RBACPermission().has_object_permission(request, MockedViewSet("potato"), None) is True
+
+    def test_has_object_permission_works_if_no_permission_class_specified_for_action(self) -> None:
+        action = "hello"
+
+        request = MockedRequest(None, action)
+        apiview = MockedAPIView(rbac_object_permissions={})
+        viewset = MockedViewSet(action, rbac_object_permissions={})
+
+        assert RBACPermission().has_object_permission(request, apiview, None) is True
+        assert RBACPermission().has_object_permission(request, viewset, None) is True
+
+    def test_has_object_permission_works_when_permission_class_specified_for_action(self) -> None:
+        action = "hello"
+        mocked_permission_class_response = "asdfasdfasdf"
+
+        class MockedPermissionClass:
+            def has_object_permission(self, _req, _view, _obj) -> None:
+                return mocked_permission_class_response
+
+        rbac_object_permissions = {MockedPermissionClass(): (action,)}
+        request = MockedRequest(None, action)
+        apiview = MockedAPIView(rbac_object_permissions=rbac_object_permissions)
+        viewset = MockedViewSet(action, rbac_object_permissions=rbac_object_permissions)
+
+        assert RBACPermission().has_object_permission(request, apiview, None) == mocked_permission_class_response
+        assert RBACPermission().has_object_permission(request, viewset, None) == mocked_permission_class_response
+
+
+class TestIsOwner:
+    def test_it_works_when_comparing_user_to_object(self) -> None:
+        user1 = MockedUser([])
+        user2 = MockedUser([])
+        request = MockedRequest(user1)
+        IsUser = IsOwner()
+
+        assert IsUser.has_object_permission(request, None, user1) is True
+        assert IsUser.has_object_permission(request, None, user2) is False
+
+    def test_it_works_when_comparing_user_to_ownership_field_object(self) -> None:
+        user1 = MockedUser([])
+        user2 = MockedUser([])
+        schedule = MockedSchedule(user1)
+        IsScheduleOwner = IsOwner("user")
+
+        assert IsScheduleOwner.has_object_permission(MockedRequest(user1), None, schedule) is True
+        assert IsScheduleOwner.has_object_permission(MockedRequest(user2), None, schedule) is False
+
+    def test_it_works_when_comparing_user_to_nested_ownership_field_object(self) -> None:
+        class Thingy:
+            def __init__(self, schedule: MockedSchedule) -> None:
+                self.schedule = schedule
+
+        user1 = MockedUser([])
+        user2 = MockedUser([])
+        schedule = MockedSchedule(user1)
+        thingy = Thingy(schedule)
+        IsScheduleOwner = IsOwner("schedule.user")
+
+        assert IsScheduleOwner.has_object_permission(MockedRequest(user1), None, thingy) is True
+        assert IsScheduleOwner.has_object_permission(MockedRequest(user2), None, thingy) is False
+
+
+@pytest.mark.parametrize(
+    "user_permissions,required_permissions,expected_result",
+    [
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            True,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            False,
+        ),
+        (
+            [RBACPermission.Permissions.ALERT_GROUPS_READ],
+            [RBACPermission.Permissions.ALERT_GROUPS_READ, RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+            False,
+        ),
+    ],
+)
+def test_HasRBACPermission(user_permissions, required_permissions, expected_result) -> None:
+    request = MockedRequest(MockedUser(user_permissions))
+    assert HasRBACPermissions(required_permissions).has_object_permission(request, None, None) == expected_result
+
+
+class TestIsOwnerOrHasRBACPermissions:
+    required_permission = RBACPermission.Permissions.SCHEDULES_READ
+    required_permissions = [required_permission]
+
+    def test_it_works_when_user_is_owner_and_does_not_have_permissions(self) -> None:
+        user1 = MockedUser([])
+        schedule = MockedSchedule(user1)
+        request = MockedRequest(user1)
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions)
+        assert PermClass.has_object_permission(request, None, user1) is True
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions, "user")
+        assert PermClass.has_object_permission(request, None, schedule) is True
+
+    def test_it_works_when_user_is_owner_and_has_permissions(self) -> None:
+        user1 = MockedUser(self.required_permissions)
+        schedule = MockedSchedule(user1)
+        request = MockedRequest(user1)
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions)
+        assert PermClass.has_object_permission(request, None, user1) is True
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions, "user")
+        assert PermClass.has_object_permission(request, None, schedule) is True
+
+    def test_it_works_when_user_is_not_owner_and_does_not_have_permissions(self) -> None:
+        user1 = MockedUser([])
+        user2 = MockedUser([])
+        schedule = MockedSchedule(user1)
+        request = MockedRequest(user2)
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions)
+        assert PermClass.has_object_permission(request, None, user1) is False
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions, "user")
+        assert PermClass.has_object_permission(request, None, schedule) is False
+
+    def test_it_works_when_user_is_not_owner_and_has_permissions(self) -> None:
+        user1 = MockedUser([])
+        user2 = MockedUser(self.required_permissions)
+        schedule = MockedSchedule(user1)
+        request = MockedRequest(user2)
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions)
+        assert PermClass.has_object_permission(request, None, user1) is True
+
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions, "user")
+        assert PermClass.has_object_permission(request, None, schedule) is True
+
+        class Thingy:
+            def __init__(self, schedule: MockedSchedule) -> None:
+                self.schedule = schedule
+
+        thingy = Thingy(schedule)
+        PermClass = IsOwnerOrHasRBACPermissions(self.required_permissions, "schedule.user")
+
+        assert PermClass.has_object_permission(request, None, thingy) is True
+        assert PermClass.has_object_permission(MockedRequest(MockedUser([])), None, thingy) is False

--- a/engine/apps/api/serializers/user.py
+++ b/engine/apps/api/serializers/user.py
@@ -6,7 +6,7 @@ import pytz
 from django.conf import settings
 from rest_framework import serializers
 
-from apps.api.permissions import LegacyAccessControlRole
+from apps.api.permissions import DONT_USE_LEGACY_PERMISSION_MAPPING
 from apps.api.serializers.telegram import TelegramToUserConnectorSerializer
 from apps.base.messaging import get_messaging_backends
 from apps.base.models import UserNotificationPolicy
@@ -137,32 +137,7 @@ class UserSerializer(DynamicFieldsModelSerializer, EagerLoadingMixin):
         return serialized_data
 
     def get_permissions(self, obj) -> typing.List[str]:
-        """
-        NOTE: this is legacy. This is only here to support older "pinned" versions of Grafana Cloud
-        that are communicating with this version, or later, of OnCall backend
-        """
-        editor_permissions = ["update_incidents", "update_own_settings", "view_other_users"]
-
-        if obj.role == LegacyAccessControlRole.ADMIN:
-            return editor_permissions + [
-                "update_alert_receive_channels",
-                "update_escalation_policies",
-                "update_notification_policies",
-                "update_general_log_channel_id",
-                "update_other_users_settings",
-                "update_integrations",
-                "update_schedules",
-                "update_custom_actions",
-                "update_api_tokens",
-                "update_teams",
-                "update_maintenances",
-                "update_global_settings",
-                "send_demo_alert",
-            ]
-        elif obj.role == LegacyAccessControlRole.EDITOR:
-            return editor_permissions
-        else:
-            return []
+        return DONT_USE_LEGACY_PERMISSION_MAPPING[obj.role]
 
     def get_notification_chain_verbal(self, obj):
         default, important = UserNotificationPolicy.get_short_verbals_for_user(user=obj)

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.alerts.models import AlertReceiveChannel, EscalationPolicy
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.fixture()
@@ -205,9 +205,9 @@ def test_integration_search(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_create_permissions(
@@ -235,9 +235,9 @@ def test_alert_receive_channel_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_update_permissions(
@@ -272,9 +272,9 @@ def test_alert_receive_channel_update_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_delete_permissions(
@@ -303,7 +303,11 @@ def test_alert_receive_channel_delete_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_alert_receive_channel_list_permissions(
     make_organization_and_user_with_plugin_token,
@@ -311,7 +315,7 @@ def test_alert_receive_channel_list_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:alert_receive_channel-list")
@@ -330,7 +334,11 @@ def test_alert_receive_channel_list_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_alert_receive_channel_detail_permissions(
     make_organization_and_user_with_plugin_token,
@@ -360,9 +368,9 @@ def test_alert_receive_channel_detail_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_send_demo_alert_permissions(
@@ -395,9 +403,9 @@ def test_alert_receive_channel_send_demo_alert_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_alert_receive_channel_integration_options_permissions(
@@ -426,9 +434,9 @@ def test_alert_receive_channel_integration_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_preview_template_permissions(
@@ -501,9 +509,9 @@ def test_alert_receive_channel_preview_template_require_notification_channel(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_change_team_permissions(
@@ -597,9 +605,9 @@ def test_alert_receive_channel_change_team(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_alert_receive_channel_counters_permissions(
@@ -608,7 +616,7 @@ def test_alert_receive_channel_counters_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse(
@@ -630,9 +638,9 @@ def test_alert_receive_channel_counters_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_alert_receive_channel_counters_per_integration_permissions(

--- a/engine/apps/api/tests/test_alert_receive_channel_template.py
+++ b/engine/apps/api/tests/test_alert_receive_channel_template.py
@@ -6,17 +6,17 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.base.messaging import BaseMessagingBackend
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_template_update_permissions(
@@ -26,7 +26,7 @@ def test_alert_receive_channel_template_update_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     alert_receive_channel = make_alert_receive_channel(organization)
     client = APIClient()
 
@@ -48,9 +48,9 @@ def test_alert_receive_channel_template_update_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_alert_receive_channel_template_detail_permissions(
@@ -60,7 +60,7 @@ def test_alert_receive_channel_template_detail_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     alert_receive_channel = make_alert_receive_channel(organization)
     client = APIClient()
 
@@ -83,7 +83,7 @@ def test_alert_receive_channel_template_include_additional_backend_templates(
     make_user_auth_headers,
     make_alert_receive_channel,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(
         organization,
         messaging_backends_templates={"TESTONLY": {"title": "the-title", "message": "the-message", "image_url": "url"}},
@@ -109,7 +109,7 @@ def test_alert_receive_channel_template_include_additional_backend_templates_usi
     make_user_auth_headers,
     make_alert_receive_channel,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization, messaging_backends_templates=None)
     client = APIClient()
 
@@ -138,7 +138,7 @@ def test_update_alert_receive_channel_backend_template_invalid_template(
     make_user_auth_headers,
     make_alert_receive_channel,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization, messaging_backends_templates=None)
     client = APIClient()
 
@@ -160,7 +160,7 @@ def test_update_alert_receive_channel_backend_template_invalid_url(
     make_user_auth_headers,
     make_alert_receive_channel,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization, messaging_backends_templates=None)
     client = APIClient()
 
@@ -182,7 +182,7 @@ def test_update_alert_receive_channel_backend_template_empty_values_allowed(
     make_user_auth_headers,
     make_alert_receive_channel,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization, messaging_backends_templates=None)
     client = APIClient()
 
@@ -208,7 +208,7 @@ def test_update_alert_receive_channel_backend_template_update_values(
     make_user_auth_headers,
     make_alert_receive_channel,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(
         organization,
         messaging_backends_templates={
@@ -249,7 +249,7 @@ def test_preview_alert_receive_channel_backend_templater(
     make_alert_group,
     make_alert,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=Role.ADMIN)
+    organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization)
     default_channel_filter = make_channel_filter(alert_receive_channel, is_default=True)
     alert_group = make_alert_group(alert_receive_channel, channel_filter=default_channel_filter)

--- a/engine/apps/api/tests/test_channel_filter.py
+++ b/engine/apps/api/tests/test_channel_filter.py
@@ -6,21 +6,20 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_channel_filter_create_permissions(
     make_organization_and_user_with_plugin_token,
-    make_alert_receive_channel,
     make_user_auth_headers,
     role,
     expected_status,
@@ -45,9 +44,9 @@ def test_channel_filter_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_channel_filter_update_permissions(
@@ -83,7 +82,11 @@ def test_channel_filter_update_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_channel_filter_list_permissions(
     make_organization_and_user_with_plugin_token,
@@ -114,7 +117,11 @@ def test_channel_filter_list_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_channel_filter_retrieve_permissions(
     make_organization_and_user_with_plugin_token,
@@ -146,9 +153,9 @@ def test_channel_filter_retrieve_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_channel_filter_delete_permissions(
@@ -181,9 +188,9 @@ def test_channel_filter_delete_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_channel_filter_move_to_position_permissions(
@@ -216,9 +223,9 @@ def test_channel_filter_move_to_position_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_alert_receive_channel_send_demo_alert_permissions(

--- a/engine/apps/api/tests/test_custom_button.py
+++ b/engine/apps/api/tests/test_custom_button.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.alerts.models import CustomButton
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 TEST_URL = "https://amixr.io"
 
@@ -291,14 +291,13 @@ def test_delete_custom_button(custom_button_internal_api_setup, make_user_auth_h
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_custom_button_create_permissions(
     make_organization_and_user_with_plugin_token,
-    make_custom_action,
     make_user_auth_headers,
     role,
     expected_status,
@@ -323,9 +322,9 @@ def test_custom_button_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_custom_button_update_permissions(
@@ -359,7 +358,11 @@ def test_custom_button_update_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_custom_button_list_permissions(
     make_organization_and_user_with_plugin_token,
@@ -388,7 +391,11 @@ def test_custom_button_list_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_custom_button_retrieve_permissions(
     make_organization_and_user_with_plugin_token,
@@ -418,9 +425,9 @@ def test_custom_button_retrieve_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_custom_button_delete_permissions(
@@ -451,9 +458,9 @@ def test_custom_button_delete_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_custom_button_action_permissions(

--- a/engine/apps/api/tests/test_escalation_chain.py
+++ b/engine/apps/api/tests/test_escalation_chain.py
@@ -24,7 +24,7 @@ def test_delete_escalation_chain(escalation_chain_internal_api_setup, make_user_
 
 
 @pytest.mark.django_db
-def test_update_escalation_chain(escalation_chain_internal_api_setup, make_user_auth_headers, make_organization):
+def test_update_escalation_chain(escalation_chain_internal_api_setup, make_user_auth_headers):
     user, token, escalation_chain = escalation_chain_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:escalation_chain-detail", kwargs={"pk": escalation_chain.public_primary_key})

--- a/engine/apps/api/tests/test_escalation_policy.py
+++ b/engine/apps/api/tests/test_escalation_policy.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.alerts.models import EscalationPolicy
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.fixture()
@@ -93,9 +93,9 @@ def test_move_to_position(escalation_policy_internal_api_setup, make_user_auth_h
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_escalation_policy_create_permissions(
@@ -130,9 +130,9 @@ def test_escalation_policy_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_escalation_policy_update_permissions(
@@ -171,9 +171,9 @@ def test_escalation_policy_update_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_escalation_policy_list_permissions(
@@ -208,9 +208,9 @@ def test_escalation_policy_list_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_escalation_policy_retrieve_permissions(
@@ -245,9 +245,9 @@ def test_escalation_policy_retrieve_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_escalation_policy_delete_permissions(
@@ -282,9 +282,9 @@ def test_escalation_policy_delete_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_escalation_policy_escalation_options_permissions(
@@ -319,9 +319,9 @@ def test_escalation_policy_escalation_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_escalation_policy_delay_options_permissions(
@@ -357,9 +357,9 @@ def test_escalation_policy_delay_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_escalation_policy_move_to_position_permissions(

--- a/engine/apps/api/tests/test_gitops.py
+++ b/engine/apps/api/tests/test_gitops.py
@@ -3,16 +3,16 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_terraform_gitops_permissions(
@@ -22,7 +22,7 @@ def test_terraform_gitops_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
     make_escalation_chain(organization)
 
     client = APIClient()
@@ -38,15 +38,15 @@ def test_terraform_gitops_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_terraform_state_permissions(
     make_organization_and_user_with_plugin_token, make_user_auth_headers, role, expected_status
 ):
-    _, user, token = make_organization_and_user_with_plugin_token(role)
+    _, user, token = make_organization_and_user_with_plugin_token(role=role)
     client = APIClient()
 
     url = reverse("api-internal:terraform_imports")

--- a/engine/apps/api/tests/test_integration_heartbeat.py
+++ b/engine/apps/api/tests/test_integration_heartbeat.py
@@ -8,8 +8,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.heartbeat.models import IntegrationHeartBeat
-from common.constants.role import Role
 
 MOCK_LAST_HEARTBEAT_TIME_VERBAL = "a moment"
 
@@ -151,7 +151,7 @@ def test_create_empty_alert_receive_channel_integration_heartbeat(
     integration_heartbeat_internal_api_setup,
     make_user_auth_headers,
 ):
-    user, token, alert_receive_channel, integration_heartbeat = integration_heartbeat_internal_api_setup
+    user, token, _, _ = integration_heartbeat_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:integration_heartbeat-list")
 
@@ -185,9 +185,39 @@ def test_update_integration_heartbeat(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
+    ],
+)
+def test_integration_heartbeat_create_permissions(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    role,
+    expected_status,
+):
+    _, user, token = make_organization_and_user_with_plugin_token(role)
+    client = APIClient()
+
+    url = reverse("api-internal:integration_heartbeat-list")
+
+    with patch(
+        "apps.api.views.integration_heartbeat.IntegrationHeartBeatView.create",
+        return_value=Response(
+            status=status.HTTP_200_OK,
+        ),
+    ):
+        response = client.post(url, format="json", **make_user_auth_headers(user, token))
+        assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected_status",
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_integration_heartbeat_update_permissions(
@@ -223,7 +253,11 @@ def test_integration_heartbeat_update_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_integration_heartbeat_list_permissions(
     make_organization_and_user_with_plugin_token,
@@ -255,9 +289,40 @@ def test_integration_heartbeat_list_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
+)
+def test_integration_heartbeat_timeout_options_permissions(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    role,
+    expected_status,
+):
+    _, user, token = make_organization_and_user_with_plugin_token(role)
+    client = APIClient()
+
+    url = reverse("api-internal:integration_heartbeat-timeout-options")
+
+    with patch(
+        "apps.api.views.integration_heartbeat.IntegrationHeartBeatView.timeout_options",
+        return_value=Response(
+            status=status.HTTP_200_OK,
+        ),
+    ):
+        response = client.get(url, format="json", **make_user_auth_headers(user, token))
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected_status",
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_integration_heartbeat_retrieve_permissions(

--- a/engine/apps/api/tests/test_maintenance.py
+++ b/engine/apps/api/tests/test_maintenance.py
@@ -6,6 +6,8 @@ from rest_framework.test import APIClient
 from apps.alerts.models import AlertReceiveChannel
 from apps.user_management.models import Organization
 
+# TODO: should probably modify these tests to take into account new rbac permissions
+
 
 @pytest.fixture()
 def maintenance_internal_api_setup(
@@ -23,7 +25,7 @@ def maintenance_internal_api_setup(
 def test_start_maintenance_integration(
     maintenance_internal_api_setup, mock_start_disable_maintenance_task, make_user_auth_headers
 ):
-    token, organization, user, alert_receive_channel = maintenance_internal_api_setup
+    token, _, user, alert_receive_channel = maintenance_internal_api_setup
     client = APIClient()
 
     url = reverse("api-internal:start_maintenance")
@@ -50,7 +52,7 @@ def test_stop_maintenance_integration(
     mock_start_disable_maintenance_task,
     make_user_auth_headers,
 ):
-    token, organization, user, alert_receive_channel = maintenance_internal_api_setup
+    token, _, user, alert_receive_channel = maintenance_internal_api_setup
     client = APIClient()
     mode = AlertReceiveChannel.MAINTENANCE
     duration = AlertReceiveChannel.DURATION_ONE_HOUR.seconds
@@ -161,7 +163,7 @@ def test_maintenances_list(
 def test_empty_maintenances_list(
     maintenance_internal_api_setup, mock_start_disable_maintenance_task, make_user_auth_headers
 ):
-    token, organization, user, alert_receive_channel = maintenance_internal_api_setup
+    token, _, user, alert_receive_channel = maintenance_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:maintenance")
     response = client.get(url, format="json", **make_user_auth_headers(user, token))

--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -7,8 +7,8 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.schedules.models import CustomOnCallShift, OnCallSchedule, OnCallScheduleWeb
-from common.constants.role import Role
 
 
 @pytest.fixture()
@@ -26,7 +26,7 @@ def on_call_shift_internal_api_setup(
 
 @pytest.mark.django_db
 def test_create_on_call_shift_rotation(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -58,7 +58,7 @@ def test_create_on_call_shift_rotation(on_call_shift_internal_api_setup, make_us
 
 @pytest.mark.django_db
 def test_create_on_call_shift_override(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -98,7 +98,7 @@ def test_get_on_call_shift(
     make_on_call_shift,
     make_user_auth_headers,
 ):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = timezone.now().replace(microsecond=0)
@@ -144,7 +144,7 @@ def test_list_on_call_shift(
     make_on_call_shift,
     make_user_auth_headers,
 ):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = timezone.now().replace(microsecond=0)
@@ -270,7 +270,7 @@ def test_update_future_on_call_shift(
     make_user_auth_headers,
 ):
     """Test updating the shift that has not started (rotation_start > now)"""
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = (timezone.now() + timezone.timedelta(days=1)).replace(microsecond=0)
@@ -337,7 +337,7 @@ def test_update_started_on_call_shift(
 ):
     """Test updating the shift that has started (rotation_start < now)"""
 
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = (timezone.now() - timezone.timedelta(hours=1)).replace(microsecond=0)
@@ -409,7 +409,7 @@ def test_update_old_on_call_shift_with_future_version(
     make_user_auth_headers,
 ):
     """Test updating the shift that has the newer version (updated_shift is not None)"""
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     now = timezone.now().replace(microsecond=0)
@@ -498,7 +498,7 @@ def test_update_started_on_call_shift_title(
 ):
     """Test updating the title for the shift that has started (rotation_start < now)"""
 
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = (timezone.now() - timezone.timedelta(hours=1)).replace(microsecond=0)
@@ -560,7 +560,7 @@ def test_delete_started_on_call_shift(
 ):
     """Test deleting the shift that has started (rotation_start < now)"""
 
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = (timezone.now() - timezone.timedelta(hours=1)).replace(microsecond=0)
@@ -598,7 +598,7 @@ def test_delete_future_on_call_shift(
 ):
     """Test deleting the shift that has not started (rotation_start > now)"""
 
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
 
     client = APIClient()
     start_date = (timezone.now() + timezone.timedelta(days=1)).replace(microsecond=0)
@@ -631,7 +631,7 @@ def test_create_on_call_shift_invalid_data_rotation_start(
     on_call_shift_internal_api_setup,
     make_user_auth_headers,
 ):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -660,7 +660,7 @@ def test_create_on_call_shift_invalid_data_rotation_start(
 
 @pytest.mark.django_db
 def test_create_on_call_shift_invalid_data_until(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -713,7 +713,7 @@ def test_create_on_call_shift_invalid_data_until(on_call_shift_internal_api_setu
 
 @pytest.mark.django_db
 def test_create_on_call_shift_invalid_data_by_day(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -763,7 +763,7 @@ def test_create_on_call_shift_invalid_data_by_day(on_call_shift_internal_api_set
 
 @pytest.mark.django_db
 def test_create_on_call_shift_invalid_data_interval(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -792,7 +792,7 @@ def test_create_on_call_shift_invalid_data_interval(on_call_shift_internal_api_s
 
 @pytest.mark.django_db
 def test_create_on_call_shift_invalid_data_shift_end(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -845,7 +845,7 @@ def test_create_on_call_shift_invalid_data_rolling_users(
     on_call_shift_internal_api_setup,
     make_user_auth_headers,
 ):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -873,7 +873,7 @@ def test_create_on_call_shift_invalid_data_rolling_users(
 
 @pytest.mark.django_db
 def test_create_on_call_shift_override_invalid_data(on_call_shift_internal_api_setup, make_user_auth_headers):
-    token, user1, user2, organization, schedule = on_call_shift_internal_api_setup
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
     client = APIClient()
     url = reverse("api-internal:oncall_shifts-list")
     start_date = timezone.now().replace(microsecond=0, tzinfo=None)
@@ -904,9 +904,9 @@ def test_create_on_call_shift_override_invalid_data(on_call_shift_internal_api_s
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_201_CREATED),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_on_call_shift_create_permissions(
@@ -915,7 +915,7 @@ def test_on_call_shift_create_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
 
     client = APIClient()
 
@@ -936,9 +936,9 @@ def test_on_call_shift_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_on_call_shift_update_permissions(
@@ -984,9 +984,9 @@ def test_on_call_shift_update_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_on_call_shift_list_permissions(
@@ -995,7 +995,7 @@ def test_on_call_shift_list_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:oncall_shifts-list")
@@ -1015,9 +1015,9 @@ def test_on_call_shift_list_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_on_call_shift_retrieve_permissions(
@@ -1058,9 +1058,9 @@ def test_on_call_shift_retrieve_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_on_call_shift_delete_permissions(
@@ -1101,9 +1101,9 @@ def test_on_call_shift_delete_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_on_call_shift_frequency_options_permissions(
@@ -1132,9 +1132,9 @@ def test_on_call_shift_frequency_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_on_call_shift_days_options_permissions(
@@ -1163,9 +1163,9 @@ def test_on_call_shift_days_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_on_call_shift_preview_permissions(

--- a/engine/apps/api/tests/test_organization.py
+++ b/engine/apps/api/tests/test_organization.py
@@ -6,30 +6,28 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
+
+# TODO: should maybe add rbac permissions tests for
+# SetGeneralChannel.post
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_current_team_retrieve_permissions(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    org = make_organization()
-    tester = make_user_for_organization(org, role=role)
-    _, token = make_token_for_organization(org)
-
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:api-current-team")
@@ -48,23 +46,18 @@ def test_current_team_retrieve_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_current_team_update_permissions(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    org = make_organization()
-    tester = make_user_for_organization(org, role=role)
-    _, token = make_token_for_organization(org)
-
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:api-current-team")
@@ -84,9 +77,9 @@ def test_current_team_update_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_current_team_get_telegram_verification_code_permissions(
@@ -95,8 +88,7 @@ def test_current_team_get_telegram_verification_code_permissions(
     role,
     expected_status,
 ):
-    organization, tester, token = make_organization_and_user_with_plugin_token(role)
-
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:api-get-telegram-verification-code")
@@ -109,9 +101,9 @@ def test_current_team_get_telegram_verification_code_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_current_team_get_channel_verification_code_permissions(
@@ -120,8 +112,7 @@ def test_current_team_get_channel_verification_code_permissions(
     role,
     expected_status,
 ):
-    organization, tester, token = make_organization_and_user_with_plugin_token(role)
-
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:api-get-channel-verification-code") + "?backend=TESTONLY"
@@ -135,8 +126,7 @@ def test_current_team_get_channel_verification_code_ok(
     make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
 ):
-    organization, tester, token = make_organization_and_user_with_plugin_token(Role.ADMIN)
-
+    organization, tester, token = make_organization_and_user_with_plugin_token()
     client = APIClient()
 
     url = reverse("api-internal:api-get-channel-verification-code") + "?backend=TESTONLY"
@@ -156,8 +146,7 @@ def test_current_team_get_channel_verification_code_invalid(
     make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
 ):
-    organization, tester, token = make_organization_and_user_with_plugin_token(Role.ADMIN)
-
+    _, tester, token = make_organization_and_user_with_plugin_token()
     client = APIClient()
 
     url = reverse("api-internal:api-get-channel-verification-code") + "?backend=INVALID"

--- a/engine/apps/api/tests/test_postmortem_messages.py
+++ b/engine/apps/api/tests/test_postmortem_messages.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.alerts.models import ResolutionNote
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
@@ -212,9 +212,9 @@ def test_delete_resolution_note(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_resolution_note_create_permissions(
@@ -224,7 +224,7 @@ def test_resolution_note_create_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:resolution_note-list")
@@ -245,9 +245,9 @@ def test_resolution_note_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_resolution_note_update_permissions(
@@ -260,7 +260,7 @@ def test_resolution_note_update_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     resolution_note = make_resolution_note(
@@ -289,9 +289,9 @@ def test_resolution_note_update_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_204_NO_CONTENT),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_resolution_note_delete_permissions(
@@ -304,7 +304,7 @@ def test_resolution_note_delete_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     resolution_note = make_resolution_note(
@@ -331,9 +331,9 @@ def test_resolution_note_delete_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_resolution_note_list_permissions(
@@ -343,7 +343,7 @@ def test_resolution_note_list_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:resolution_note-list")
@@ -363,9 +363,9 @@ def test_resolution_note_list_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_resolution_note_detail_permissions(
@@ -378,7 +378,7 @@ def test_resolution_note_detail_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     resolution_note = make_resolution_note(

--- a/engine/apps/api/tests/test_public_api_tokens.py
+++ b/engine/apps/api/tests/test_public_api_tokens.py
@@ -1,0 +1,115 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.api.permissions import LegacyAccessControlRole
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected_status",
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
+)
+def test_public_api_tokens_retrieve_permissions(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    make_public_api_token,
+    role,
+    expected_status,
+):
+    organization, user, plugin_token = make_organization_and_user_with_plugin_token(role)
+    api_token, _ = make_public_api_token(user, organization)
+    client = APIClient()
+
+    url = reverse("api-internal:api_token-detail", kwargs={"pk": api_token.id})
+    response = client.get(url, format="json", **make_user_auth_headers(user, plugin_token))
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected_status",
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
+)
+def test_public_api_tokens_list_permissions(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    make_public_api_token,
+    role,
+    expected_status,
+):
+    organization, user, plugin_token = make_organization_and_user_with_plugin_token(role)
+    make_public_api_token(user, organization)
+    client = APIClient()
+
+    url = reverse("api-internal:api_token-list")
+    response = client.get(url, format="json", **make_user_auth_headers(user, plugin_token))
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected_status",
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
+    ],
+)
+def test_public_api_tokens_create_permissions(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    role,
+    expected_status,
+):
+    _, user, plugin_token = make_organization_and_user_with_plugin_token(role)
+    client = APIClient()
+
+    url = reverse("api-internal:api_token-list")
+    response = client.post(
+        url,
+        data={
+            "name": "helloooo",
+        },
+        format="json",
+        **make_user_auth_headers(user, plugin_token),
+    )
+
+    assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "role,expected_status",
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
+    ],
+)
+def test_public_api_tokens_delete_permissions(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    make_public_api_token,
+    role,
+    expected_status,
+):
+    organization, user, plugin_token = make_organization_and_user_with_plugin_token(role)
+    api_token, _ = make_public_api_token(user, organization)
+    client = APIClient()
+
+    url = reverse("api-internal:api_token-detail", kwargs={"pk": api_token.id})
+    response = client.delete(url, format="json", **make_user_auth_headers(user, plugin_token))
+
+    assert response.status_code == expected_status

--- a/engine/apps/api/tests/test_schedule_export.py
+++ b/engine/apps/api/tests/test_schedule_export.py
@@ -3,9 +3,9 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.auth_token.models import ScheduleExportAuthToken
 from apps.schedules.models import OnCallScheduleICal
-from common.constants.role import Role
 
 ICAL_URL = "https://calendar.google.com/calendar/ical/amixr.io_37gttuakhrtr75ano72p69rt78%40group.calendar.google.com/private-1d00a680ba5be7426c3eb3ef1616e26d/basic.ics"  # noqa
 
@@ -14,9 +14,9 @@ ICAL_URL = "https://calendar.google.com/calendar/ical/amixr.io_37gttuakhrtr75ano
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_get_schedule_export_token(
@@ -26,8 +26,7 @@ def test_get_schedule_export_token(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -50,9 +49,9 @@ def test_get_schedule_export_token(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_404_NOT_FOUND),
-        (Role.EDITOR, status.HTTP_404_NOT_FOUND),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_schedule_export_token_not_found(
@@ -62,8 +61,7 @@ def test_schedule_export_token_not_found(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -84,9 +82,9 @@ def test_schedule_export_token_not_found(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_201_CREATED),
-        (Role.EDITOR, status.HTTP_201_CREATED),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_schedule_create_export_token(
@@ -96,8 +94,7 @@ def test_schedule_create_export_token(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -118,9 +115,9 @@ def test_schedule_create_export_token(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_204_NO_CONTENT),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_schedule_delete_export_token(
@@ -130,8 +127,7 @@ def test_schedule_delete_export_token(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -10,6 +10,7 @@ from rest_framework.serializers import ValidationError
 from rest_framework.test import APIClient
 
 from apps.alerts.models import EscalationPolicy
+from apps.api.permissions import LegacyAccessControlRole
 from apps.schedules.ical_utils import memoized_users_in_ical
 from apps.schedules.models import (
     CustomOnCallShift,
@@ -18,7 +19,6 @@ from apps.schedules.models import (
     OnCallScheduleICal,
     OnCallScheduleWeb,
 )
-from common.constants.role import Role
 
 ICAL_URL = "https://calendar.google.com/calendar/ical/amixr.io_37gttuakhrtr75ano72p69rt78%40group.calendar.google.com/private-1d00a680ba5be7426c3eb3ef1616e26d/basic.ics"
 
@@ -1062,7 +1062,7 @@ def test_merging_same_shift_events(
 
     user_a = make_user_for_organization(organization)
     user_b = make_user_for_organization(organization)
-    user_c = make_user_for_organization(organization, role=Role.VIEWER)
+    user_c = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
     # clear users pks <-> organization cache (persisting between tests)
     memoized_users_in_ical.cache_clear()
 
@@ -1158,9 +1158,9 @@ def test_filter_events_invalid_type(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_schedule_create_permissions(
@@ -1170,7 +1170,7 @@ def test_schedule_create_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1196,9 +1196,9 @@ def test_schedule_create_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_schedule_update_permissions(
@@ -1208,7 +1208,7 @@ def test_schedule_update_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1237,7 +1237,11 @@ def test_schedule_update_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_schedule_list_permissions(
     make_organization_and_user_with_plugin_token,
@@ -1246,7 +1250,7 @@ def test_schedule_list_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1271,7 +1275,11 @@ def test_schedule_list_permissions(
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
-    [(Role.ADMIN, status.HTTP_200_OK), (Role.EDITOR, status.HTTP_200_OK), (Role.VIEWER, status.HTTP_200_OK)],
+    [
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+    ],
 )
 def test_schedule_retrieve_permissions(
     make_organization_and_user_with_plugin_token,
@@ -1280,7 +1288,7 @@ def test_schedule_retrieve_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1306,9 +1314,9 @@ def test_schedule_retrieve_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_schedule_delete_permissions(
@@ -1318,7 +1326,7 @@ def test_schedule_delete_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1344,9 +1352,9 @@ def test_schedule_delete_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_events_permissions(
@@ -1356,7 +1364,7 @@ def test_events_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1382,9 +1390,9 @@ def test_events_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_reload_ical_permissions(
@@ -1394,7 +1402,7 @@ def test_reload_ical_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     schedule = make_schedule(
         organization,
         schedule_class=OnCallScheduleICal,
@@ -1420,9 +1428,9 @@ def test_reload_ical_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_schedule_notify_oncall_shift_freq_options_permissions(
@@ -1432,7 +1440,7 @@ def test_schedule_notify_oncall_shift_freq_options_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     url = reverse("api-internal:schedule-notify-oncall-shift-freq-options")
     client = APIClient()
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
@@ -1444,9 +1452,9 @@ def test_schedule_notify_oncall_shift_freq_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_schedule_notify_empty_oncall_options_permissions(
@@ -1456,7 +1464,7 @@ def test_schedule_notify_empty_oncall_options_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     url = reverse("api-internal:schedule-notify-empty-oncall-options")
     client = APIClient()
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
@@ -1468,9 +1476,9 @@ def test_schedule_notify_empty_oncall_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_schedule_mention_options_permissions(
@@ -1480,7 +1488,7 @@ def test_schedule_mention_options_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     url = reverse("api-internal:schedule-mention-options")
     client = APIClient()
     response = client.get(url, format="json", **make_user_auth_headers(user, token))

--- a/engine/apps/api/tests/test_set_general_log_channel.py
+++ b/engine/apps/api/tests/test_set_general_log_channel.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 # Testing permissions, not view itself. So mock is ok here
@@ -14,13 +14,16 @@ from common.constants.role import Role
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_set_general_log_channel_permissions(
-    make_organization_and_user_with_plugin_token, make_user_auth_headers, role, expected_status
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    role,
+    expected_status,
 ):
     _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()

--- a/engine/apps/api/tests/test_slack_channels.py
+++ b/engine/apps/api/tests/test_slack_channels.py
@@ -6,20 +6,23 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_slack_channels_list_permissions(
-    make_organization_and_user_with_plugin_token, make_user_auth_headers, role, expected_status
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    role,
+    expected_status,
 ):
     _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
@@ -40,13 +43,17 @@ def test_slack_channels_list_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_slack_channels_detail_permissions(
-    make_organization_and_user_with_plugin_token, make_user_auth_headers, role, make_slack_channel, expected_status
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    make_slack_channel,
+    role,
+    expected_status,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token(role)
     slack_channel = make_slack_channel(organization.slack_team_identity)

--- a/engine/apps/api/tests/test_slack_team_settings.py
+++ b/engine/apps/api/tests/test_slack_team_settings.py
@@ -6,16 +6,16 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_get_slack_settings_permissions(
@@ -24,7 +24,7 @@ def test_get_slack_settings_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:slack-settings")
@@ -43,9 +43,9 @@ def test_get_slack_settings_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_update_slack_settings_permissions(
@@ -54,7 +54,7 @@ def test_update_slack_settings_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:slack-settings")
@@ -73,9 +73,9 @@ def test_update_slack_settings_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_get_acknowledge_remind_options_permissions(
@@ -84,7 +84,7 @@ def test_get_acknowledge_remind_options_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:acknowledge-reminder-options")
@@ -103,9 +103,9 @@ def test_get_acknowledge_remind_options_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_get_unacknowledge_timeout_options_permissions(
@@ -114,7 +114,7 @@ def test_get_unacknowledge_timeout_options_permissions(
     role,
     expected_status,
 ):
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
 
     url = reverse("api-internal:unacknowledge-timeout-options")

--- a/engine/apps/api/tests/test_subscription.py
+++ b/engine/apps/api/tests/test_subscription.py
@@ -6,16 +6,16 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_subscription_retrieve_permissions(

--- a/engine/apps/api/tests/test_telegram_channel.py
+++ b/engine/apps/api/tests/test_telegram_channel.py
@@ -3,14 +3,14 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 def test_not_authorized(make_organization_and_user_with_plugin_token, make_telegram_channel):
     client = APIClient()
 
-    organization, user, _ = make_organization_and_user_with_plugin_token()
+    organization, _, _ = make_organization_and_user_with_plugin_token()
     telegram_channel = make_telegram_channel(organization=organization)
 
     url = reverse("api-internal:telegram_channel-list")
@@ -34,9 +34,9 @@ def test_not_authorized(make_organization_and_user_with_plugin_token, make_teleg
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_list_telegram_channels_permissions(
@@ -46,8 +46,7 @@ def test_list_telegram_channels_permissions(
     expected_status,
 ):
     client = APIClient()
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
 
     url = reverse("api-internal:telegram_channel-list")
     response = client.get(url, **make_user_auth_headers(user, token))
@@ -59,9 +58,9 @@ def test_list_telegram_channels_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_get_telegram_channels_permissions(
@@ -72,8 +71,7 @@ def test_get_telegram_channels_permissions(
     expected_status,
 ):
     client = APIClient()
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     telegram_channel = make_telegram_channel(organization=organization)
 
     url = reverse("api-internal:telegram_channel-detail", kwargs={"pk": telegram_channel.public_primary_key})
@@ -86,9 +84,9 @@ def test_get_telegram_channels_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_delete_telegram_channels_permissions(
@@ -100,7 +98,7 @@ def test_delete_telegram_channels_permissions(
 ):
     client = APIClient()
 
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     telegram_channel = make_telegram_channel(organization=organization)
 
     url = reverse("api-internal:telegram_channel-detail", kwargs={"pk": telegram_channel.public_primary_key})
@@ -113,9 +111,9 @@ def test_delete_telegram_channels_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_set_default_telegram_channels_permissions(
@@ -127,8 +125,7 @@ def test_set_default_telegram_channels_permissions(
 ):
     client = APIClient()
 
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
-
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
     telegram_channel = make_telegram_channel(organization=organization)
 
     url = reverse("api-internal:telegram_channel-set-default", kwargs={"pk": telegram_channel.public_primary_key})

--- a/engine/apps/api/tests/test_terraform_renderer.py
+++ b/engine/apps/api/tests/test_terraform_renderer.py
@@ -18,7 +18,7 @@ def test_get_terraform_file(
 
 @pytest.mark.django_db
 def test_get_terraform_imports(make_organization_and_user_with_plugin_token, make_user_auth_headers):
-    organization, user, token = make_organization_and_user_with_plugin_token()
+    _, user, token = make_organization_and_user_with_plugin_token()
     client = APIClient()
     url = reverse("api-internal:terraform_imports")
     response = client.get(url, format="text/plain", **make_user_auth_headers(user, token))

--- a/engine/apps/api/tests/test_user.py
+++ b/engine/apps/api/tests/test_user.py
@@ -8,10 +8,9 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from apps.base.constants import ADMIN_PERMISSIONS, EDITOR_PERMISSIONS
+from apps.api.permissions import DONT_USE_LEGACY_PERMISSION_MAPPING, LegacyAccessControlRole
 from apps.base.models import UserNotificationPolicy
 from apps.user_management.models.user import default_working_hours
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
@@ -80,7 +79,7 @@ def test_update_user_cant_change_email_and_username(
             }
         },
         "cloud_connection_status": 0,
-        "permissions": ADMIN_PERMISSIONS,
+        "permissions": DONT_USE_LEGACY_PERMISSION_MAPPING[admin.role],
         "notification_chain_verbal": {"default": "", "important": ""},
         "slack_user_identity": None,
         "avatar": admin.avatar_url,
@@ -99,7 +98,7 @@ def test_list_users(
 ):
     organization = make_organization()
     admin = make_user_for_organization(organization)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
+    editor = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
     _, token = make_token_for_organization(organization)
 
     client = APIClient()
@@ -128,7 +127,7 @@ def test_list_users(
                         "user": admin.username,
                     }
                 },
-                "permissions": ADMIN_PERMISSIONS,
+                "permissions": DONT_USE_LEGACY_PERMISSION_MAPPING[admin.role],
                 "notification_chain_verbal": {"default": "", "important": ""},
                 "slack_user_identity": None,
                 "avatar": admin.avatar_url,
@@ -152,7 +151,7 @@ def test_list_users(
                         "user": editor.username,
                     }
                 },
-                "permissions": EDITOR_PERMISSIONS,
+                "permissions": DONT_USE_LEGACY_PERMISSION_MAPPING[editor.role],
                 "notification_chain_verbal": {"default": "", "important": ""},
                 "slack_user_identity": None,
                 "avatar": editor.avatar_url,
@@ -229,22 +228,18 @@ def test_notification_chain_verbal(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_update_self_permissions(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": tester.public_primary_key})
     with patch(
@@ -262,23 +257,20 @@ def test_user_update_self_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_update_other_permissions(
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
+    organization, tester, token = make_organization_and_user_with_plugin_token(role)
     admin = make_user_for_organization(organization)
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": admin.public_primary_key})
@@ -293,22 +285,18 @@ def test_user_update_other_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_list_permissions(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
 
     client = APIClient()
     url = reverse("api-internal:user-list")
@@ -327,22 +315,18 @@ def test_user_list_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_user_detail_self_permissions(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": tester.public_primary_key})
@@ -361,23 +345,20 @@ def test_user_detail_self_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_detail_other_permissions(
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
+    organization, tester, token = make_organization_and_user_with_plugin_token(role)
     admin = make_user_for_organization(organization)
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": admin.public_primary_key})
@@ -390,22 +371,18 @@ def test_user_detail_other_permissions(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_get_own_verification_code(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
 
     client = APIClient()
     url = reverse("api-internal:user-get-verification-code", kwargs={"pk": tester.public_primary_key})
@@ -424,23 +401,20 @@ def test_user_get_own_verification_code(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_get_other_verification_code(
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
+    organization, tester, token = make_organization_and_user_with_plugin_token(role)
     admin = make_user_for_organization(organization)
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
 
     client = APIClient()
     url = reverse("api-internal:user-get-verification-code", kwargs={"pk": admin.public_primary_key})
@@ -454,22 +428,18 @@ def test_user_get_other_verification_code(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_verify_own_phone(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
 
     client = APIClient()
     url = reverse("api-internal:user-verify-number", kwargs={"pk": tester.public_primary_key})
@@ -493,23 +463,20 @@ Tests below are outdated
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_verify_another_phone(
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    other_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, tester, token = make_organization_and_user_with_plugin_token(role)
+    other_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-verify-number", kwargs={"pk": other_user.public_primary_key})
@@ -524,22 +491,18 @@ def test_user_verify_another_phone(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_get_own_telegram_verification_code(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    _, token = make_token_for_organization(organization)
+    _, tester, token = make_organization_and_user_with_plugin_token(role)
 
     client = APIClient()
     url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": tester.public_primary_key})
@@ -552,23 +515,20 @@ def test_user_get_own_telegram_verification_code(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_get_another_telegram_verification_code(
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
     role,
     expected_status,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=role)
-    other_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, tester, token = make_organization_and_user_with_plugin_token(role)
+    other_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": other_user.public_primary_key})
@@ -579,270 +539,16 @@ def test_user_get_another_telegram_verification_code(
 
 @pytest.mark.django_db
 def test_admin_can_update_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
 ):
-    organization = make_organization()
-    tester = make_user_for_organization(organization, role=Role.ADMIN)
-    other_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
 
     client = APIClient()
     data = {
         "email": "test@amixr.io",
-        "role": Role.ADMIN,
-        "username": "updated_test_username",
-        "unverified_phone_number": "+1234567890",
-        "slack_login": "",
-    }
-    url = reverse("api-internal:user-detail", kwargs={"pk": other_user.public_primary_key})
-    response = client.put(url, format="json", data=data, **make_user_auth_headers(tester, token))
-
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_update_himself(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    data = {
-        "email": "test@amixr.io",
-        "role": Role.ADMIN,
-        "username": "updated_test_username",
-        "unverified_phone_number": "+1234567890",
-        "slack_login": "",
-    }
-
-    url = reverse("api-internal:user-detail", kwargs={"pk": admin.public_primary_key})
-    response = client.put(url, format="json", data=data, **make_user_auth_headers(admin, token))
-
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_list_users(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-
-    url = reverse("api-internal:user-list")
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_detail_users(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-
-    url = reverse("api-internal:user-detail", kwargs={"pk": editor.public_primary_key})
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-
-    assert response.status_code == status.HTTP_200_OK
-
-
-@patch("apps.twilioapp.phone_manager.PhoneManager.send_verification_code", return_value=Mock())
-@pytest.mark.django_db
-def test_admin_can_get_own_verification_code(
-    mock_verification_start,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-get-verification-code", kwargs={"pk": admin.public_primary_key})
-
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@patch("apps.twilioapp.phone_manager.PhoneManager.send_verification_code", return_value=Mock())
-@pytest.mark.django_db
-def test_admin_can_get_another_user_verification_code(
-    mock_verification_start,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-get-verification-code", kwargs={"pk": editor.public_primary_key})
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@patch("apps.twilioapp.phone_manager.PhoneManager.verify_phone_number", return_value=(True, None))
-@pytest.mark.django_db
-def test_admin_can_verify_own_phone(
-    mocked_verification_check,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-verify-number", kwargs={"pk": admin.public_primary_key})
-
-    response = client.put(f"{url}?token=12345", format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@patch("apps.twilioapp.phone_manager.PhoneManager.verify_phone_number", return_value=(True, None))
-@pytest.mark.django_db
-def test_admin_can_verify_another_user_phone(
-    mocked_verification_check,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-verify-number", kwargs={"pk": editor.public_primary_key})
-
-    response = client.put(f"{url}?token=12345", format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_get_own_telegram_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": admin.public_primary_key})
-
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_get_another_user_telegram_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": editor.public_primary_key})
-
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_get_another_user_backend_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = (
-        reverse("api-internal:user-get-backend-verification-code", kwargs={"pk": editor.public_primary_key})
-        + "?backend=TESTONLY"
-    )
-
-    response = client.get(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_unlink_another_user_backend_account(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-unlink-backend", kwargs={"pk": editor.public_primary_key}) + "?backend=TESTONLY"
-
-    response = client.post(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_admin_can_unlink_another_user_slack_account(
-    make_organization_with_slack_team_identity,
-    make_user_for_organization,
-    make_user_with_slack_user_identity,
-    make_token_for_organization,
-    make_user_auth_headers,
-):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor, slack_user_identity_1 = make_user_with_slack_user_identity(
-        slack_team_identity, organization, slack_id="user_1", role=Role.EDITOR
-    )
-
-    _, token = make_token_for_organization(organization)
-    client = APIClient()
-    url = reverse("api-internal:user-unlink-slack", kwargs={"pk": editor.public_primary_key})
-
-    response = client.post(url, format="json", **make_user_auth_headers(admin, token))
-    assert response.status_code == status.HTTP_200_OK
-    editor.refresh_from_db()
-    assert editor.slack_user_identity is None
-
-
-"""Test user permissions"""
-
-
-@pytest.mark.django_db
-def test_user_cant_update_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    data = {
-        "email": "test@amixr.io",
-        "role": Role.ADMIN,
         "username": "updated_test_username",
         "unverified_phone_number": "+1234567890",
         "slack_login": "",
@@ -850,21 +556,16 @@ def test_user_cant_update_user(
     url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
     response = client.put(url, format="json", data=data, **make_user_auth_headers(second_user, token))
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db
-def test_user_can_update_themself(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_admin_can_update_himself(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.ADMIN)
 
     client = APIClient()
     data = {
         "email": "test@amixr.io",
-        "role": Role.EDITOR,
         "username": "updated_test_username",
         "unverified_phone_number": "+1234567890",
         "slack_login": "",
@@ -877,49 +578,267 @@ def test_user_can_update_themself(
 
 
 @pytest.mark.django_db
-def test_user_can_list_users(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_admin_can_list_users(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.ADMIN)
 
     client = APIClient()
 
     url = reverse("api-internal:user-list")
-    response = client.get(url, format="json", **make_user_auth_headers(editor, token))
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_admin_can_detail_users(
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+
+    url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
+    response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+@patch("apps.twilioapp.phone_manager.PhoneManager.send_verification_code", return_value=Mock())
+@pytest.mark.django_db
+def test_admin_can_get_own_verification_code(
+    mock_verification_start,
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = reverse("api-internal:user-get-verification-code", kwargs={"pk": user.public_primary_key})
+
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@patch("apps.twilioapp.phone_manager.PhoneManager.send_verification_code", return_value=Mock())
+@pytest.mark.django_db
+def test_admin_can_get_another_user_verification_code(
+    mock_verification_start,
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = reverse("api-internal:user-get-verification-code", kwargs={"pk": first_user.public_primary_key})
+    response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@patch("apps.twilioapp.phone_manager.PhoneManager.verify_phone_number", return_value=(True, None))
+@pytest.mark.django_db
+def test_admin_can_verify_own_phone(
+    mocked_verification_check,
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = reverse("api-internal:user-verify-number", kwargs={"pk": user.public_primary_key})
+
+    response = client.put(f"{url}?token=12345", format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@patch("apps.twilioapp.phone_manager.PhoneManager.verify_phone_number", return_value=(True, None))
+@pytest.mark.django_db
+def test_admin_can_verify_another_user_phone(
+    mocked_verification_check,
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = reverse("api-internal:user-verify-number", kwargs={"pk": first_user.public_primary_key})
+
+    response = client.put(f"{url}?token=12345", format="json", **make_user_auth_headers(second_user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_admin_can_get_own_telegram_verification_code(
+    make_organization_and_user_with_plugin_token, make_user_auth_headers
+):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": user.public_primary_key})
+
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_admin_can_get_another_user_telegram_verification_code(
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": first_user.public_primary_key})
+
+    response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_admin_can_get_another_user_backend_verification_code(
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = (
+        reverse("api-internal:user-get-backend-verification-code", kwargs={"pk": first_user.public_primary_key})
+        + "?backend=TESTONLY"
+    )
+
+    response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_admin_can_unlink_another_user_backend_account(
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token()
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.ADMIN)
+
+    client = APIClient()
+    url = (
+        reverse("api-internal:user-unlink-backend", kwargs={"pk": first_user.public_primary_key}) + "?backend=TESTONLY"
+    )
+
+    response = client.post(url, format="json", **make_user_auth_headers(second_user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_admin_can_unlink_another_user_slack_account(
+    make_organization_with_slack_team_identity,
+    make_user_for_organization,
+    make_user_with_slack_user_identity,
+    make_token_for_organization,
+    make_user_auth_headers,
+):
+    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, token = make_token_for_organization(organization)
+
+    user, _ = make_user_with_slack_user_identity(
+        slack_team_identity, organization, slack_id="user_2", role=LegacyAccessControlRole.ADMIN
+    )
+    other_user = make_user_for_organization(organization)
+
+    client = APIClient()
+    url = reverse("api-internal:user-unlink-slack", kwargs={"pk": other_user.public_primary_key})
+
+    response = client.post(url, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+    other_user.refresh_from_db()
+    assert other_user.slack_user_identity is None
+
+
+"""Test user permissions"""
+
+
+@pytest.mark.django_db
+def test_user_cant_update_user(
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
+):
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
+
+    client = APIClient()
+    data = {
+        "email": "test@amixr.io",
+        "username": "updated_test_username",
+        "unverified_phone_number": "+1234567890",
+        "slack_login": "",
+    }
+    url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
+    response = client.put(url, format="json", data=data, **make_user_auth_headers(second_user, token))
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_user_can_update_themself(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+
+    client = APIClient()
+    data = {
+        "email": "test@amixr.io",
+        "username": "updated_test_username",
+        "unverified_phone_number": "+1234567890",
+        "slack_login": "",
+    }
+
+    url = reverse("api-internal:user-detail", kwargs={"pk": user.public_primary_key})
+    response = client.put(url, format="json", data=data, **make_user_auth_headers(user, token))
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_user_can_list_users(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+
+    client = APIClient()
+
+    url = reverse("api-internal:user-list")
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
 
     assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db
 def test_user_can_detail_users(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
-    url = reverse("api-internal:user-detail", kwargs={"pk": admin.public_primary_key})
+    url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
 
-    response = client.get(url, format="json", **make_user_auth_headers(editor, token))
+    response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @patch("apps.twilioapp.phone_manager.PhoneManager.send_verification_code", return_value=Mock())
 @pytest.mark.django_db
 def test_user_can_get_own_verification_code(
-    mock_verification_start,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
+    mock_verification_start, make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-get-verification-code", kwargs={"pk": user.public_primary_key})
@@ -932,15 +851,12 @@ def test_user_can_get_own_verification_code(
 @pytest.mark.django_db
 def test_user_cant_get_another_user_verification_code(
     mock_verification_start,
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-get-verification-code", kwargs={"pk": first_user.public_primary_key})
@@ -952,15 +868,9 @@ def test_user_cant_get_another_user_verification_code(
 @patch("apps.twilioapp.phone_manager.PhoneManager.verify_phone_number", return_value=(True, None))
 @pytest.mark.django_db
 def test_user_can_verify_own_phone(
-    mocked_verification_check,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
+    mocked_verification_check, make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-verify-number", kwargs={"pk": user.public_primary_key})
@@ -973,15 +883,12 @@ def test_user_can_verify_own_phone(
 @pytest.mark.django_db
 def test_user_cant_verify_another_user_phone(
     mocked_verification_check,
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-verify-number", kwargs={"pk": first_user.public_primary_key})
@@ -992,11 +899,9 @@ def test_user_cant_verify_another_user_phone(
 
 @pytest.mark.django_db
 def test_user_can_get_own_telegram_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": user.public_primary_key})
@@ -1007,12 +912,12 @@ def test_user_can_get_own_telegram_verification_code(
 
 @pytest.mark.django_db
 def test_user_cant_get_another_user_telegram_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": first_user.public_primary_key})
@@ -1023,11 +928,9 @@ def test_user_cant_get_another_user_telegram_verification_code(
 
 @pytest.mark.django_db
 def test_user_can_get_own_backend_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = (
@@ -1048,12 +951,12 @@ def test_user_can_get_own_backend_verification_code(
 
 @pytest.mark.django_db
 def test_user_cant_get_another_user_backend_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token,
+    make_user_for_organization,
+    make_user_auth_headers,
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = (
@@ -1073,8 +976,8 @@ def test_user_can_unlink_own_slack_account(
     make_user_auth_headers,
 ):
     organization, slack_team_identity = make_organization_with_slack_team_identity()
-    user, slack_user_identity_1 = make_user_with_slack_user_identity(
-        slack_team_identity, organization, slack_id="user_1", role=Role.EDITOR
+    user, _ = make_user_with_slack_user_identity(
+        slack_team_identity, organization, slack_id="user_2", role=LegacyAccessControlRole.EDITOR
     )
 
     _, token = make_token_for_organization(organization)
@@ -1088,12 +991,8 @@ def test_user_can_unlink_own_slack_account(
 
 
 @pytest.mark.django_db
-def test_user_can_unlink_backend_own_account(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_user_can_unlink_backend_own_account(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-unlink-backend", kwargs={"pk": user.public_primary_key}) + "?backend=TESTONLY"
@@ -1104,12 +1003,8 @@ def test_user_can_unlink_backend_own_account(
 
 
 @pytest.mark.django_db
-def test_user_unlink_backend_invalid_backend_id(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_user_unlink_backend_invalid_backend_id(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-unlink-backend", kwargs={"pk": user.public_primary_key}) + "?backend=INVALID"
@@ -1121,11 +1016,9 @@ def test_user_unlink_backend_invalid_backend_id(
 
 @pytest.mark.django_db
 def test_user_unlink_backend_backend_account_not_found(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-unlink-backend", kwargs={"pk": user.public_primary_key}) + "?backend=TESTONLY"
@@ -1143,11 +1036,12 @@ def test_user_cant_unlink_slack_another_user(
     make_user_auth_headers,
 ):
     organization, slack_team_identity = make_organization_with_slack_team_identity()
-    first_user, slack_user_identity_1 = make_user_with_slack_user_identity(
-        slack_team_identity, organization, slack_id="user_1", role=Role.EDITOR
+
+    first_user, _ = make_user_with_slack_user_identity(
+        slack_team_identity, organization, slack_id="user_1", role=LegacyAccessControlRole.EDITOR
     )
-    second_user, slack_user_identity_2 = make_user_with_slack_user_identity(
-        slack_team_identity, organization, slack_id="user_2", role=Role.EDITOR
+    second_user, _ = make_user_with_slack_user_identity(
+        slack_team_identity, organization, slack_id="user_2", role=LegacyAccessControlRole.EDITOR
     )
 
     _, token = make_token_for_organization(organization)
@@ -1162,12 +1056,10 @@ def test_user_cant_unlink_slack_another_user(
 
 @pytest.mark.django_db
 def test_user_cant_unlink_backend__another_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = (
@@ -1182,39 +1074,14 @@ def test_user_cant_unlink_backend__another_user(
 
 
 @pytest.mark.django_db
-def test_viewer_cant_create_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
-
-    client = APIClient()
-    url = reverse("api-internal:user-list")
-    data = {
-        "email": "test@amixr.io",
-        "role": Role.ADMIN,
-        "username": "test_username",
-        "unverified_phone_number": None,
-        "slack_login": "",
-    }
-    response = client.post(url, format="json", data=data, **make_user_auth_headers(user, token))
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-
-
-@pytest.mark.django_db
 def test_viewer_cant_update_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     data = {
         "email": "test@amixr.io",
-        "role": Role.EDITOR,
         "username": "updated_test_username",
         "unverified_phone_number": "+1234567890",
         "slack_login": "",
@@ -1228,16 +1095,11 @@ def test_viewer_cant_update_user(
 
 
 @pytest.mark.django_db
-def test_viewer_cant_update_himself(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+def test_viewer_cant_update_himself(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     data = {
         "email": "test@amixr.io",
-        "role": Role.VIEWER,
         "username": "updated_test_username",
         "unverified_phone_number": "+1234567890",
         "slack_login": "",
@@ -1251,12 +1113,8 @@ def test_viewer_cant_update_himself(
 
 
 @pytest.mark.django_db
-def test_viewer_cant_list_users(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+def test_viewer_cant_list_users(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-list")
@@ -1267,12 +1125,10 @@ def test_viewer_cant_list_users(
 
 @pytest.mark.django_db
 def test_viewer_cant_detail_users(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
@@ -1284,15 +1140,9 @@ def test_viewer_cant_detail_users(
 @patch("apps.twilioapp.phone_manager.PhoneManager.send_verification_code", return_value=Mock())
 @pytest.mark.django_db
 def test_viewer_cant_get_own_verification_code(
-    mock_verification_start,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
+    mock_verification_start, make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-get-verification-code", kwargs={"pk": user.public_primary_key})
@@ -1305,15 +1155,12 @@ def test_viewer_cant_get_own_verification_code(
 @pytest.mark.django_db
 def test_viewer_cant_get_another_user_verification_code(
     mock_verification_start,
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-get-verification-code", kwargs={"pk": first_user.public_primary_key})
@@ -1325,15 +1172,9 @@ def test_viewer_cant_get_another_user_verification_code(
 @patch("apps.twilioapp.phone_manager.PhoneManager.verify_phone_number", return_value=(True, None))
 @pytest.mark.django_db
 def test_viewer_cant_verify_own_phone(
-    mocked_verification_check,
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
+    mocked_verification_check, make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-verify-number", kwargs={"pk": user.public_primary_key})
@@ -1346,15 +1187,12 @@ def test_viewer_cant_verify_own_phone(
 @pytest.mark.django_db
 def test_viewer_cant_verify_another_user_phone(
     mocked_verification_check,
-    make_organization,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-verify-number", kwargs={"pk": first_user.public_primary_key})
@@ -1365,11 +1203,9 @@ def test_viewer_cant_verify_another_user_phone(
 
 @pytest.mark.django_db
 def test_viewer_cant_get_own_telegram_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": user.public_primary_key})
@@ -1380,12 +1216,10 @@ def test_viewer_cant_get_own_telegram_verification_code(
 
 @pytest.mark.django_db
 def test_viewer_cant_get_another_user_telegram_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-get-telegram-verification-code", kwargs={"pk": first_user.public_primary_key})
@@ -1398,34 +1232,30 @@ def test_viewer_cant_get_another_user_telegram_verification_code(
 @pytest.mark.parametrize(
     "role,expected_status,initial_unverified_number,initial_verified_number",
     [
-        (Role.ADMIN, status.HTTP_200_OK, "+1234567890", None),
-        (Role.EDITOR, status.HTTP_200_OK, "+1234567890", None),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN, "+1234567890", None),
-        (Role.ADMIN, status.HTTP_200_OK, None, "+1234567890"),
-        (Role.EDITOR, status.HTTP_200_OK, None, "+1234567890"),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN, None, "+1234567890"),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK, "+1234567890", None),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK, "+1234567890", None),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN, "+1234567890", None),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK, None, "+1234567890"),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK, None, "+1234567890"),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN, None, "+1234567890"),
     ],
 )
 def test_forget_own_number(
-    make_organization,
-    make_team,
+    make_organization_and_user_with_plugin_token,
     make_user_for_organization,
-    make_token_for_organization,
     make_user_auth_headers,
     role,
     expected_status,
     initial_unverified_number,
     initial_verified_number,
 ):
-    organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
+    organization, admin, token = make_organization_and_user_with_plugin_token()
     user = make_user_for_organization(
         organization,
         role=role,
         unverified_phone_number=initial_unverified_number,
         _verified_phone_number=initial_verified_number,
     )
-    _, token = make_token_for_organization(organization)
 
     client = APIClient()
     url = reverse("api-internal:user-forget-number", kwargs={"pk": user.public_primary_key})
@@ -1450,17 +1280,16 @@ def test_forget_own_number(
 @pytest.mark.parametrize(
     "role,expected_status,initial_unverified_number,initial_verified_number",
     [
-        (Role.ADMIN, status.HTTP_200_OK, "+1234567890", None),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN, "+1234567890", None),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN, "+1234567890", None),
-        (Role.ADMIN, status.HTTP_200_OK, None, "+1234567890"),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN, None, "+1234567890"),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN, None, "+1234567890"),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK, "+1234567890", None),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN, "+1234567890", None),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN, "+1234567890", None),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK, None, "+1234567890"),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN, None, "+1234567890"),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN, None, "+1234567890"),
     ],
 )
 def test_forget_other_number(
     make_organization,
-    make_team,
     make_user_for_organization,
     make_token_for_organization,
     make_user_auth_headers,
@@ -1470,26 +1299,26 @@ def test_forget_other_number(
     initial_verified_number,
 ):
     organization = make_organization()
-    user = make_user_for_organization(
-        organization,
-        role=Role.ADMIN,
-        unverified_phone_number=initial_unverified_number,
-        _verified_phone_number=initial_verified_number,
-    )
-    other_user = make_user_for_organization(organization, role=role)
     _, token = make_token_for_organization(organization)
 
+    admin = make_user_for_organization(
+        organization, unverified_phone_number=initial_unverified_number, _verified_phone_number=initial_verified_number
+    )
+    other_user = make_user_for_organization(organization, role=role)
+    admin_primary_key = admin.public_primary_key
+
     client = APIClient()
-    url = reverse("api-internal:user-forget-number", kwargs={"pk": user.public_primary_key})
+    url = reverse("api-internal:user-forget-number", kwargs={"pk": admin_primary_key})
     with patch(
         "apps.twilioapp.phone_manager.PhoneManager.notify_about_changed_verified_phone_number", return_value=None
     ):
         response = client.put(url, None, format="json", **make_user_auth_headers(other_user, token))
         assert response.status_code == expected_status
 
-    user_detail_url = reverse("api-internal:user-detail", kwargs={"pk": user.public_primary_key})
-    response = client.get(user_detail_url, None, format="json", **make_user_auth_headers(user, token))
+    user_detail_url = reverse("api-internal:user-detail", kwargs={"pk": admin_primary_key})
+    response = client.get(user_detail_url, None, format="json", **make_user_auth_headers(admin, token))
     assert response.status_code == status.HTTP_200_OK
+
     if expected_status == status.HTTP_200_OK:
         assert not response.json()["unverified_phone_number"]
         assert not response.json()["verified_phone_number"]
@@ -1500,11 +1329,9 @@ def test_forget_other_number(
 
 @pytest.mark.django_db
 def test_viewer_cant_get_own_backend_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_auth_headers
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = (
@@ -1518,12 +1345,10 @@ def test_viewer_cant_get_own_backend_verification_code(
 
 @pytest.mark.django_db
 def test_viewer_cant_get_another_user_backend_verification_code(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = (
@@ -1536,13 +1361,8 @@ def test_viewer_cant_get_another_user_backend_verification_code(
 
 
 @pytest.mark.django_db
-def test_viewer_cant_unlink_backend_own_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
-
+def test_viewer_cant_unlink_backend_own_user(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
     client = APIClient()
     url = reverse("api-internal:user-unlink-backend", kwargs={"pk": user.public_primary_key}) + "?backend=TESTONLY"
 
@@ -1552,12 +1372,10 @@ def test_viewer_cant_unlink_backend_own_user(
 
 @pytest.mark.django_db
 def test_viewer_cant_unlink_backend_another_user(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
 ):
-    organization = make_organization()
-    first_user = make_user_for_organization(organization, role=Role.EDITOR)
-    second_user = make_user_for_organization(organization, role=Role.VIEWER)
-    _, token = make_token_for_organization(organization)
+    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = (
@@ -1569,12 +1387,8 @@ def test_viewer_cant_unlink_backend_another_user(
 
 
 @pytest.mark.django_db
-def test_change_timezone(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_change_timezone(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": user.public_primary_key})
@@ -1589,12 +1403,8 @@ def test_change_timezone(
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("timezone", ["", 1, "NotATimezone"])
-def test_invalid_timezone(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers, timezone
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_invalid_timezone(make_organization_and_user_with_plugin_token, make_user_auth_headers, timezone):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": user.public_primary_key})
@@ -1606,12 +1416,8 @@ def test_invalid_timezone(
 
 
 @pytest.mark.django_db
-def test_change_working_hours(
-    make_organization, make_user_for_organization, make_token_for_organization, make_user_auth_headers
-):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+def test_change_working_hours(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": user.public_primary_key})
@@ -1645,15 +1451,9 @@ def test_change_working_hours(
     ],
 )
 def test_invalid_working_hours(
-    make_organization,
-    make_user_for_organization,
-    make_token_for_organization,
-    make_user_auth_headers,
-    working_hours_extra,
+    make_organization_and_user_with_plugin_token, make_user_auth_headers, working_hours_extra
 ):
-    organization = make_organization()
-    user = make_user_for_organization(organization, role=Role.EDITOR)
-    _, token = make_token_for_organization(organization)
+    _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
 
     client = APIClient()
     url = reverse("api-internal:user-detail", kwargs={"pk": user.public_primary_key})

--- a/engine/apps/api/tests/test_user_groups.py
+++ b/engine/apps/api/tests/test_user_groups.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
@@ -52,13 +52,16 @@ def test_usergroup_list_without_slack_installed(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
     ],
 )
 def test_usergroup_permissions(
-    make_organization_and_user_with_plugin_token, make_user_auth_headers, role, expected_status
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    role,
+    expected_status,
 ):
     _, user, token = make_organization_and_user_with_plugin_token(role)
     client = APIClient()

--- a/engine/apps/api/tests/test_user_notification_policy.py
+++ b/engine/apps/api/tests/test_user_notification_policy.py
@@ -6,8 +6,8 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.base.models import UserNotificationPolicy
-from common.constants.role import Role
 
 DEFAULT_NOTIFICATION_CHANNEL = UserNotificationPolicy.NotificationChannel.SLACK
 
@@ -17,7 +17,7 @@ def user_notification_policy_internal_api_setup(
     make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_notification_policy
 ):
     organization, admin, token = make_organization_and_user_with_plugin_token()
-    user = make_user_for_organization(organization, Role.EDITOR)
+    user = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     wait_notification_step = make_user_notification_policy(
         admin, UserNotificationPolicy.Step.WAIT, wait_delay=timezone.timedelta(minutes=15), important=False
@@ -49,7 +49,7 @@ def user_notification_policy_internal_api_setup(
 
 @pytest.mark.django_db
 def test_create_notification_policy(user_notification_policy_internal_api_setup, make_user_auth_headers):
-    token, steps, users = user_notification_policy_internal_api_setup
+    token, _, users = user_notification_policy_internal_api_setup
     admin, _ = users
     client = APIClient()
     url = reverse("api-internal:notification_policy-list")
@@ -69,7 +69,7 @@ def test_create_notification_policy(user_notification_policy_internal_api_setup,
 def test_admin_can_create_notification_policy_for_user(
     user_notification_policy_internal_api_setup, make_user_auth_headers
 ):
-    token, steps, users = user_notification_policy_internal_api_setup
+    token, _, users = user_notification_policy_internal_api_setup
     admin, user = users
     client = APIClient()
     url = reverse("api-internal:notification_policy-list")

--- a/engine/apps/api/tests/test_user_schedule_export.py
+++ b/engine/apps/api/tests/test_user_schedule_export.py
@@ -3,8 +3,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.auth_token.models import UserScheduleExportAuthToken
-from common.constants.role import Role
 
 ICAL_URL = "https://calendar.google.com/calendar/ical/amixr.io_37gttuakhrtr75ano72p69rt78%40group.calendar.google.com/private-1d00a680ba5be7426c3eb3ef1616e26d/basic.ics"  # noqa
 
@@ -13,9 +13,9 @@ ICAL_URL = "https://calendar.google.com/calendar/ical/amixr.io_37gttuakhrtr75ano
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_get_user_schedule_export_token(
@@ -24,8 +24,7 @@ def test_get_user_schedule_export_token(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
 
     UserScheduleExportAuthToken.create_auth_token(
         user=user,
@@ -45,9 +44,9 @@ def test_get_user_schedule_export_token(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_404_NOT_FOUND),
-        (Role.EDITOR, status.HTTP_404_NOT_FOUND),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_schedule_export_token_not_found(
@@ -56,8 +55,7 @@ def test_user_schedule_export_token_not_found(
     role,
     expected_status,
 ):
-
-    _, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
 
     url = reverse("api-internal:user-export-token", kwargs={"pk": user.public_primary_key})
 
@@ -72,9 +70,9 @@ def test_user_schedule_export_token_not_found(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_201_CREATED),
-        (Role.EDITOR, status.HTTP_201_CREATED),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_schedule_create_export_token(
@@ -83,8 +81,7 @@ def test_user_schedule_create_export_token(
     role,
     expected_status,
 ):
-
-    _, user, token = make_organization_and_user_with_plugin_token(role=role)
+    _, user, token = make_organization_and_user_with_plugin_token(role)
 
     url = reverse("api-internal:user-export-token", kwargs={"pk": user.public_primary_key})
 
@@ -99,9 +96,9 @@ def test_user_schedule_create_export_token(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_409_CONFLICT),
-        (Role.EDITOR, status.HTTP_409_CONFLICT),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_409_CONFLICT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_409_CONFLICT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_schedule_create_multiple_export_tokens_fails(
@@ -110,8 +107,7 @@ def test_user_schedule_create_multiple_export_tokens_fails(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
 
     UserScheduleExportAuthToken.create_auth_token(
         user=user,
@@ -131,9 +127,9 @@ def test_user_schedule_create_multiple_export_tokens_fails(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_204_NO_CONTENT),
-        (Role.EDITOR, status.HTTP_204_NO_CONTENT),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_schedule_delete_export_token(
@@ -142,8 +138,7 @@ def test_user_schedule_delete_export_token(
     role,
     expected_status,
 ):
-
-    organization, user, token = make_organization_and_user_with_plugin_token(role=role)
+    organization, user, token = make_organization_and_user_with_plugin_token(role)
 
     instance, _ = UserScheduleExportAuthToken.create_auth_token(
         user=user,
@@ -168,9 +163,9 @@ def test_user_schedule_delete_export_token(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_404_NOT_FOUND),
-        (Role.EDITOR, status.HTTP_404_NOT_FOUND),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_cannot_get_another_users_schedule_token(
@@ -179,9 +174,8 @@ def test_user_cannot_get_another_users_schedule_token(
     role,
     expected_status,
 ):
-
-    organization1, user1, _ = make_organization_and_user_with_plugin_token(role=role)
-    _, user2, token2 = make_organization_and_user_with_plugin_token(role=role)
+    organization1, user1, _ = make_organization_and_user_with_plugin_token(role)
+    _, user2, token2 = make_organization_and_user_with_plugin_token(role)
 
     UserScheduleExportAuthToken.create_auth_token(
         user=user1,
@@ -201,9 +195,9 @@ def test_user_cannot_get_another_users_schedule_token(
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_404_NOT_FOUND),
-        (Role.EDITOR, status.HTTP_404_NOT_FOUND),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_404_NOT_FOUND),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_user_cannot_delete_another_users_schedule_token(
@@ -212,9 +206,8 @@ def test_user_cannot_delete_another_users_schedule_token(
     role,
     expected_status,
 ):
-
-    organization1, user1, _ = make_organization_and_user_with_plugin_token(role=role)
-    _, user2, token2 = make_organization_and_user_with_plugin_token(role=role)
+    organization1, user1, _ = make_organization_and_user_with_plugin_token(role)
+    _, user2, token2 = make_organization_and_user_with_plugin_token(role)
 
     UserScheduleExportAuthToken.create_auth_token(
         user=user1,

--- a/engine/apps/grafana_plugin/tests/test_sync.py
+++ b/engine/apps/grafana_plugin/tests/test_sync.py
@@ -26,6 +26,8 @@ class TestGcomAPIClient:
     info = None
     status = None
 
+    STACK_STATUS_ACTIVE = "active"
+
     def reset(self):
         self.called = False
         self.info = None
@@ -39,7 +41,7 @@ class TestGcomAPIClient:
 
     def get_instance_info(self, stack_id: str):
         self.called = True
-        return self.info, self.status
+        return self.info
 
 
 @pytest.mark.django_db

--- a/engine/apps/public_api/tests/test_users.py
+++ b/engine/apps/public_api/tests/test_users.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.fixture()
@@ -20,7 +20,7 @@ def user_public_api_setup(
 def test_get_user(
     user_public_api_setup,
 ):
-    organization, user, token, slack_team_identity, slack_user_identity = user_public_api_setup
+    _, user, token, slack_team_identity, slack_user_identity = user_public_api_setup
 
     client = APIClient()
 
@@ -93,7 +93,7 @@ def test_get_users_list_short(
     user_public_api_setup,
     make_user_for_organization,
 ):
-    organization, user_1, token, slack_team_identity, slack_user_identity = user_public_api_setup
+    organization, user_1, token, _, _ = user_public_api_setup
     user_2 = make_user_for_organization(organization)
 
     client = APIClient()
@@ -145,13 +145,10 @@ def test_forbidden_access(
 
 
 @pytest.mark.django_db
-def test_get_users_list_all_role_users(
-    user_public_api_setup,
-    make_user_for_organization,
-):
+def test_get_users_list_all_role_users(user_public_api_setup, make_user_for_organization):
     organization, admin, token, _, _ = user_public_api_setup
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
-    viewer = make_user_for_organization(organization, role=Role.VIEWER)
+    editor = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
+    viewer = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
 

--- a/engine/apps/schedules/tests/test_ical_utils.py
+++ b/engine/apps/schedules/tests/test_ical_utils.py
@@ -5,6 +5,7 @@ import pytest
 import pytz
 from django.utils import timezone
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.schedules.ical_utils import (
     list_of_oncall_shifts_from_ical,
     list_users_to_notify_from_ical,
@@ -12,7 +13,6 @@ from apps.schedules.ical_utils import (
     users_in_ical,
 )
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleCalendar
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
@@ -26,13 +26,10 @@ def test_users_in_ical_email_case_insensitive(make_organization_and_user, make_u
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "include_viewers",
-    [True, False],
-)
+@pytest.mark.parametrize("include_viewers", [True, False])
 def test_users_in_ical_viewers_inclusion(make_organization_and_user, make_user_for_organization, include_viewers):
     organization, user = make_organization_and_user()
-    viewer = make_user_for_organization(organization, Role.VIEWER)
+    viewer = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     usernames = [user.username, viewer.username]
     result = users_in_ical(usernames, organization, include_viewers=include_viewers)
@@ -43,15 +40,12 @@ def test_users_in_ical_viewers_inclusion(make_organization_and_user, make_user_f
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "include_viewers",
-    [True, False],
-)
+@pytest.mark.parametrize("include_viewers", [True, False])
 def test_list_users_to_notify_from_ical_viewers_inclusion(
     make_organization_and_user, make_user_for_organization, make_schedule, make_on_call_shift, include_viewers
 ):
     organization, user = make_organization_and_user()
-    viewer = make_user_for_organization(organization, Role.VIEWER)
+    viewer = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     schedule = make_schedule(organization, schedule_class=OnCallScheduleCalendar)
     date = timezone.now().replace(tzinfo=None, microsecond=0)

--- a/engine/apps/schedules/tests/test_on_call_schedule.py
+++ b/engine/apps/schedules/tests/test_on_call_schedule.py
@@ -4,9 +4,9 @@ import pytest
 import pytz
 from django.utils import timezone
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.schedules.ical_utils import memoized_users_in_ical
 from apps.schedules.models import CustomOnCallShift, OnCallSchedule, OnCallScheduleCalendar, OnCallScheduleWeb
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
@@ -18,7 +18,7 @@ def test_filter_events(make_organization, make_user_for_organization, make_sched
         name="test_web_schedule",
     )
     user = make_user_for_organization(organization)
-    viewer = make_user_for_organization(organization, role=Role.VIEWER)
+    viewer = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
     now = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
     start_date = now - timezone.timedelta(days=7)
 
@@ -190,7 +190,7 @@ def test_filter_events_include_empty(make_organization, make_user_for_organizati
         schedule_class=OnCallScheduleWeb,
         name="test_web_schedule",
     )
-    user = make_user_for_organization(organization, role=Role.VIEWER)
+    user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
     now = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
     start_date = now - timezone.timedelta(days=7)
 

--- a/engine/apps/slack/tests/test_reset_slack.py
+++ b/engine/apps/slack/tests/test_reset_slack.py
@@ -7,24 +7,24 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from common.constants.role import Role
+from apps.api.permissions import LegacyAccessControlRole
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_403_FORBIDDEN),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_reset_slack_integration_permissions(
-    make_organization_and_user_with_plugin_token, role, expected_status, load_slack_urls, make_user_auth_headers
+    make_organization_and_user_with_plugin_token, load_slack_urls, make_user_auth_headers, role, expected_status
 ):
     settings.FEATURE_SLACK_INTEGRATION_ENABLED = True
 
-    _, user, token = make_organization_and_user_with_plugin_token(role)
+    _, user, token = make_organization_and_user_with_plugin_token(role=role)
     client = APIClient()
 
     url = reverse("reset-slack")

--- a/engine/apps/user_management/tests/test_free_public_beta_subcription_strategy.py
+++ b/engine/apps/user_management/tests/test_free_public_beta_subcription_strategy.py
@@ -1,7 +1,6 @@
 import pytest
 
 from apps.twilioapp.constants import TwilioCallStatuses, TwilioMessageStatuses
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
@@ -13,8 +12,8 @@ def test_phone_calls_left(
     make_alert_group,
 ):
     organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    user = make_user_for_organization(organization, role=Role.EDITOR)
+    admin = make_user_for_organization(organization)
+    user = make_user_for_organization(organization)
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     make_phone_call(receiver=admin, status=TwilioCallStatuses.COMPLETED, represents_alert_group=alert_group)
@@ -28,8 +27,8 @@ def test_sms_left(
     make_organization, make_user_for_organization, make_sms, make_alert_receive_channel, make_alert_group
 ):
     organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    user = make_user_for_organization(organization, role=Role.EDITOR)
+    admin = make_user_for_organization(organization)
+    user = make_user_for_organization(organization)
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     make_sms(receiver=admin, status=TwilioMessageStatuses.SENT, represents_alert_group=alert_group)
@@ -48,8 +47,8 @@ def test_phone_calls_and_sms_counts_together(
     make_alert_group,
 ):
     organization = make_organization()
-    admin = make_user_for_organization(organization, role=Role.ADMIN)
-    user = make_user_for_organization(organization, role=Role.EDITOR)
+    admin = make_user_for_organization(organization)
+    user = make_user_for_organization(organization)
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     make_phone_call(receiver=admin, status=TwilioCallStatuses.COMPLETED, represents_alert_group=alert_group)

--- a/engine/apps/user_management/tests/test_user.py
+++ b/engine/apps/user_management/tests/test_user.py
@@ -1,20 +1,15 @@
-# from unittest.mock import Mock, patch
-
 import pytest
 
+from apps.api.permissions import LegacyAccessControlRole
 from apps.user_management.models import User
-from common.constants.role import Role
 
 
 @pytest.mark.django_db
-def test_self_or_admin(
-    make_organization,
-    make_user_for_organization,
-):
+def test_self_or_admin(make_organization, make_user_for_organization):
     organization = make_organization()
     admin = make_user_for_organization(organization)
     second_admin = make_user_for_organization(organization)
-    editor = make_user_for_organization(organization, role=Role.EDITOR)
+    editor = make_user_for_organization(organization, role=LegacyAccessControlRole.EDITOR)
 
     another_organization = make_organization()
     admin_from_another_organization = make_user_for_organization(another_organization)
@@ -26,10 +21,7 @@ def test_self_or_admin(
 
 
 @pytest.mark.django_db
-def test_lower_email_filter(
-    make_organization,
-    make_user_for_organization,
-):
+def test_lower_email_filter(make_organization, make_user_for_organization):
     organization = make_organization()
     user = make_user_for_organization(organization, email="TestingUser@test.com")
     make_user_for_organization(organization, email="testing_user@test.com")

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -40,4 +40,3 @@ PyMySQL==1.0.2
 psycopg2-binary==2.9.3
 emoji==1.7.0
 apns2==0.7.2
-

--- a/engine/tox.ini
+++ b/engine/tox.ini
@@ -7,6 +7,6 @@ ban-relative-imports = parents
 [pytest]
 # https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings
 # https://pytest-django.readthedocs.io/en/latest/database.html
-addopts = --reuse-db --nomigrations --color=yes --showlocals
+addopts = --color=yes --showlocals
 # https://pytest-django.readthedocs.io/en/latest/faq.html#my-tests-are-not-being-found-why
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
**What this PR does**:
This is a follow up to #634. It adds the necessary tests and makes a few other minor changes:
- run backend tests as matrix where RBAC is enabled/disabled
- remove `--reuse-db` and `--nomigrations` flags from `engine/tox.ini`
- minor autoformatting changes to `docker-compose-developer.yml`
- adds permission tests for `api/views/public_api_tokens.py` (we previously didn't have any and I was modifying the authorization here)