### PR TITLE
Fix error when generating log line for non-handled messaging backend

### DIFF
--- a/engine/apps/alerts/incident_log_builder/incident_log_builder.py
+++ b/engine/apps/alerts/incident_log_builder/incident_log_builder.py
@@ -596,7 +596,7 @@ class IncidentLogBuilder:
                 except ValueError:
                     pass
                 else:
-                    result += f"send {backend.label.lower()} message to {user_verbal}"
+                    result += f"send {backend.label.lower() if backend else ''} message to {user_verbal}"
         if not result:
             result += f"inviting {user_verbal} but notification channel is unspecified"
         return result


### PR DESCRIPTION
Avoid raising error when generating log line for a backend not explicitly handled, and not a registered messaging backend (eg. mobile).