### PR TITLE
revert object destructuring changes which affect the value of 'this'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,24 @@
 # Change Log
 
+## v1.0.43 (2022-10-26)
+
+- Bug fix for an issue that was affecting phone verification
+
 ## v1.0.43 (2022-10-25)
+
 - Bug fixes
 
 ## v1.0.42 (2022-10-24)
+
 - Fix posting resolution notes to Slack
 
 ## v1.0.41 (2022-10-24)
+
 - Add personal email notifications
 - Bug fixes
 
 ## v1.0.40 (2022-10-05)
+
 - Improved database and celery backends support
 - Added script to import PagerDuty users to Grafana
 - Bug fixes

--- a/grafana-plugin/src/containers/AlertRules/parts/connectors/TelegramConnector.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/connectors/TelegramConnector.tsx
@@ -19,8 +19,10 @@ interface TelegramConnectorProps {
 }
 
 const TelegramConnector = ({ channelFilterId }: TelegramConnectorProps) => {
-  const { alertReceiveChannelStore } = useStore();
-  const channelFilter = alertReceiveChannelStore.channelFilters[channelFilterId];
+  const store = useStore();
+  const { alertReceiveChannelStore } = store;
+
+  const channelFilter = store.alertReceiveChannelStore.channelFilters[channelFilterId];
 
   const handleTelegramChannelChange = useCallback((_value: TelegramChannel['id'], telegramChannel: TelegramChannel) => {
     alertReceiveChannelStore.saveChannelFilter(channelFilterId, { telegram_channel: telegramChannel?.id || null });


### PR DESCRIPTION
**What this PR does**:
Reverts two recent changes made in #678 which destructured `useStore` and implicitly changed how `this` is bound. See [this article](https://suhanwijaya.medium.com/a-method-destructured-from-an-object-loses-its-original-context-21e73cf1451f) for more context on this behavior.

**Which issue(s) this PR fixes**:
Fixes [this](https://github.com/grafana/support-escalations/issues/4364) issue

Loom video which shows phone verification now working:
https://www.loom.com/share/b7267b788c2d4b0f985bf3efe4a9b2ed

**Checklist**
- [ ] Tests updated (**TODO** add some unit tests to these two components to prevent this from happening in the future)
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated