### PR TITLE
Remove references to Alert.migrator_lock attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v1.0.46 (2022-10-27)
+
+- Bug fixes
+
 ## v1.0.44 (2022-10-26)
 
 - Bug fix for an issue that was affecting phone verification

--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -232,21 +232,13 @@ class Alert(models.Model):
 
         return distinction
 
-    @property
-    def skip_signal(self):
-        try:
-            _ = self.migrator_lock
-            return True
-        except Alert.migrator_lock.RelatedObjectDoesNotExist:
-            return False
-
 
 def listen_for_alert_model_save(sender, instance, created, *args, **kwargs):
     AlertGroup = apps.get_model("alerts", "AlertGroup")
     """
     Here we invoke AlertShootingStep by model saving action.
     """
-    if created and instance.group.maintenance_uuid is None and not instance.skip_signal:
+    if created and instance.group.maintenance_uuid is None:
         # RFCT - why additinal save ?
         instance.save()
 


### PR DESCRIPTION
**What this PR does**:
This PR patches issue related to #708.

#708 forgot to remove attributes on models outside of the `migration_tool` django app that were referencing model attributes from `migration_tool`.

The only attribute that referenced a field in migration_tool was `migrator_lock` on the `Alert` model. This PR removes any references to that attribute.

https://www.loom.com/share/c7824ee21b8745e0a06249d9e3e7e65a

**Checklist**
- [ ] Tests updated (N/A as we did not previously have tests that tested the celery tasks responsible for sending Alerts; this would be a nice improvement to add in a future PR)
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated