### PR TITLE
remove POST /api/internal/v1/custom_buttons/{id}/action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Change Log
 
-
-## v1.0.46 (2022-10-27)
+## v1.0.46 (2022-10-28)
 
 - Bug fixes
+- remove `POST /api/internal/v1/custom_buttons/{id}/action` endpoint
 
 ## v1.0.45 (2022-10-27)
 

--- a/engine/apps/api/tests/test_custom_button.py
+++ b/engine/apps/api/tests/test_custom_button.py
@@ -448,39 +448,6 @@ def test_custom_button_delete_permissions(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "role,expected_status",
-    [
-        (Role.ADMIN, status.HTTP_200_OK),
-        (Role.EDITOR, status.HTTP_200_OK),
-        (Role.VIEWER, status.HTTP_403_FORBIDDEN),
-    ],
-)
-def test_custom_button_action_permissions(
-    make_organization_and_user_with_plugin_token,
-    make_custom_action,
-    make_user_auth_headers,
-    role,
-    expected_status,
-):
-    organization, user, token = make_organization_and_user_with_plugin_token(role)
-    custom_button = make_custom_action(organization=organization)
-    client = APIClient()
-
-    url = reverse("api-internal:custom_button-action", kwargs={"pk": custom_button.public_primary_key})
-
-    with patch(
-        "apps.api.views.custom_button.CustomButtonView.action",
-        return_value=Response(
-            status=status.HTTP_200_OK,
-        ),
-    ):
-        response = client.post(url, format="json", **make_user_auth_headers(user, token))
-
-    assert response.status_code == expected_status
-
-
-@pytest.mark.django_db
 def test_get_custom_button_from_other_team_with_flag(
     make_organization_and_user_with_plugin_token,
     make_team,

--- a/grafana-plugin/src/models/alert_receive_channel/alert_receive_channel.ts
+++ b/grafana-plugin/src/models/alert_receive_channel/alert_receive_channel.ts
@@ -314,13 +314,6 @@ export class AlertReceiveChannelStore extends BaseStore {
     });
   }
 
-  async doCustomButtonAction(actionId: ActionDTO['id'], alertId: Alert['pk']) {
-    return await makeRequest(`/custom_buttons/${actionId}/action/`, {
-      method: 'POST',
-      params: { alert_group: alertId },
-    });
-  }
-
   async getAccessLogs(alertReceiveChannelId: AlertReceiveChannel['id']) {
     const { integration_log } = await makeRequest(`/alert_receive_channel_access_log/${alertReceiveChannelId}/`, {});
 


### PR DESCRIPTION
**What this PR does**:
It removes the `POST /api/internal/v1/custom_buttons/{id}/action endpoint` and the only reference to it in the frontend.

I am running across this endpoint in my work on RBAC. Either I would need to create a separate permission to accommodate this endpoint's current authorization setup, or I remove it since it is not used.


AFAICT it is only referenced in one method in the frontend [here](https://github.com/grafana/oncall/blob/6e5cb4e8a7577f6318ea937491e2b796ba2a419e/grafana-plugin/src/models/alert_receive_channel/alert_receive_channel.ts#L317-L322), and that method isn't actually called anywhere. I did a quick [loki query](https://ops.grafana.net/explore?orgId=1&left=%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22,%22expr%22:%22%7Bnamespace%3D%5C%22amixr-prod%5C%22,%20container%3D%5C%22amixr-engine%5C%22%7D%7C~%5C%22%2Fcustom_buttons%2F.%2A%2Faction%5C%22%22,%22queryType%22:%22range%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D) and there's no traffic to that endpoint over the last week as well.

**Which issue(s) this PR fixes**:
N/A

**Checklist**
- [x] Tests updated
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated