### PR TITLE
Update pg docker developer compose to setup grafana using pg db

### DIFF
--- a/docker-compose-developer-pg.yml
+++ b/docker-compose-developer-pg.yml
@@ -15,6 +15,11 @@ services:
         limits:
           memory: 500m
           cpus: '0.5'
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis
@@ -42,37 +47,27 @@ services:
       - "15672:15672"
       - "5672:5672"
 
-  mysql-to-create-grafana-db:
-    image: mysql:5.7
-    platform: linux/x86_64
-    command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
-    restart: always
-    ports:
-      - "3306:3306"
-    environment:
-      MYSQL_ROOT_PASSWORD: empty
-      MYSQL_DATABASE: grafana
-    deploy:
-      resources:
-        limits:
-          memory: 500m
-          cpus: '0.5'
-    healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
-      timeout: 20s
-      retries: 10
+  postgres_to_create_grafana_db:
+    image: postgres:14.4
+    command: bash -c "echo \"SELECT 'CREATE DATABASE grafana' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'grafana')\gexec\" | PGPASSWORD=empty psql -h postgres -U postgres"
+    depends_on:
+      postgres:
+        condition: service_healthy
 
   grafana:
     image: "grafana/grafana:main"
     restart: always
     environment:
-      GF_DATABASE_TYPE: mysql
-      GF_DATABASE_HOST: mysql
-      GF_DATABASE_USER: root
+      GF_DATABASE_TYPE: postgres
+      GF_DATABASE_HOST: postgres:5432
+      GF_DATABASE_NAME: grafana
+      GF_DATABASE_USER: postgres
       GF_DATABASE_PASSWORD: empty
-      GF_SECURITY_ADMIN_USER: oncall
-      GF_SECURITY_ADMIN_PASSWORD: oncall
+      GF_DATABASE_SSL_MODE: disable
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
+      GF_INSTALL_PLUGINS: grafana-oncall-app
     deploy:
       resources:
         limits:
@@ -83,5 +78,7 @@ services:
     ports:
       - "3000:3000"
     depends_on:
-      mysql-to-create-grafana-db:
+      postgres_to_create_grafana_db:
+        condition: service_completed_successfully
+      postgres:
         condition: service_healthy

--- a/docker-compose-developer-pg.yml
+++ b/docker-compose-developer-pg.yml
@@ -49,7 +49,7 @@ services:
 
   postgres_to_create_grafana_db:
     image: postgres:14.4
-    command: bash -c "echo \"SELECT 'CREATE DATABASE grafana' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'grafana')\gexec\" | PGPASSWORD=empty psql -h postgres -U postgres"
+    command: bash -c "PGPASSWORD=empty psql -U postgres -h postgres -tc \"SELECT 1 FROM pg_database WHERE datname = 'grafana'\" | grep -q 1 || PGPASSWORD=empty psql -U postgres -h postgres -c \"CREATE DATABASE grafana\""
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
**What this PR does**:
Updates `docker-compose-developer-pg.yml` to use a PostgreSQL db when setting up grafana (ie. no mysql needed)

**Which issue(s) this PR fixes**:
Fixes #745 