### PR TITLE
Helm: allow for using existing secret for RabbitMQ

### DIFF
--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.7
+version: 1.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -224,6 +224,11 @@ externalRabbitmq:
   port:
   user:
   password:
+  protocol:
+  vhost:
+  existingSecret: ""
+  passwordKey: password
+  usernameKey: username
 ```
 
 ### Connect external Redis

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -237,13 +237,21 @@
 
 {{- define "snippet.rabbitmq.env" -}}
 {{- if eq .Values.broker.type "rabbitmq" -}}
+{{- if and (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingSecret) (not .Values.externalRabbitmq.usernameKey) .Values.externalRabbitmq.user }}
 - name: RABBITMQ_USERNAME
   value: {{ include "snippet.rabbitmq.user" . }}
+{{- else if and (not .Values.rabbitmq.enabled) .Values.externalRabbitmq.existingSecret .Values.externalRabbitmq.usernameKey (not .Values.externalRabbitmq.user) }}
+- name: RABBITMQ_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "snippet.rabbitmq.password.secret.name" . }}
+      key: {{ .Values.externalRabbitmq.usernameKey }}
+{{- end }}
 - name: RABBITMQ_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ include "snippet.rabbitmq.password.secret.name" . }}
-      key: rabbitmq-password
+      key: {{ include "snippet.rabbitmq.password.secret.key" . }}
 - name: RABBITMQ_HOST
   value: {{ include "snippet.rabbitmq.host" . }}
 - name: RABBITMQ_PORT
@@ -298,8 +306,18 @@
 {{- define "snippet.rabbitmq.password.secret.name" -}}
 {{- if and (not .Values.rabbitmq.enabled) .Values.externalRabbitmq.password -}}
 {{ include "oncall.fullname" . }}-rabbitmq-external
+{{- else if and (not .Values.rabbitmq.enabled) .Values.externalRabbitmq.existingSecret -}}
+{{ .Values.externalRabbitmq.existingSecret }}
 {{- else -}}
 {{ include "oncall.rabbitmq.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "snippet.rabbitmq.password.secret.key" -}}
+{{- if and (not .Values.rabbitmq.enabled) .Values.externalRabbitmq.passwordKey -}}
+{{ .Values.externalRabbitmq.passwordKey }}
+{{- else -}}
+rabbitmq-password
 {{- end -}}
 {{- end -}}
 

--- a/helm/oncall/templates/secrets.yaml
+++ b/helm/oncall/templates/secrets.yaml
@@ -21,14 +21,14 @@ data:
   mariadb-root-password: {{ required "externalMysql.password is required if not mariadb.enabled" .Values.externalMysql.password | b64enc | quote }}
 {{- end }}
 ---
-{{ if and (eq .Values.broker.type "rabbitmq") (not .Values.rabbitmq.enabled) -}}
+{{ if and (eq .Values.broker.type "rabbitmq") (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "oncall.fullname" . }}-rabbitmq-external
 type: Opaque
 data:
-  rabbitmq-password: {{ required "externalRabbitmq.password is required if not rabbitmq.enabled" .Values.externalRabbitmq.password | b64enc | quote }}
+  rabbitmq-password: {{ required "externalRabbitmq.password is required if not rabbitmq.enabled and not externalRabbitmq.existingSecret" .Values.externalRabbitmq.password | b64enc | quote }}
 {{- end }}
 ---
 {{ if not .Values.redis.enabled -}}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -239,6 +239,12 @@ externalRabbitmq:
   password:
   protocol:
   vhost:
+  # use an existing secret for the rabbitmq password
+  existingSecret: ""
+  # the key in the secret containing the rabbitmq password
+  passwordKey: password
+  # the key in the secret containing the rabbitmq username
+  usernameKey: username
 
 # Redis is included into this release for the convenience.
 # It is recommended to host it separately from this release


### PR DESCRIPTION
**What this PR does**:
This PR adds the ability to use an existing secret for external RabbitMQ. It a key in the existing secret can be specified for both the password and the username. The ability to specify the username key is required when an operator is used to create RabbitMQ credentials. We are using the [RabbitMQ Messaging Topology Kubernetes Operator](https://github.com/rabbitmq/messaging-topology-operator) to create the vhost, user and permissions for OnCall, where both the username and password are auto-generated and placed into a secret.

**Checklist**
- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated