### PR TITLE
Send emails from <slug>.grafana.net on cloud

### DIFF
--- a/engine/apps/email/tasks.py
+++ b/engine/apps/email/tasks.py
@@ -76,8 +76,12 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
     subject, html_message = build_subject_and_message(alert_group, emails_left)
 
     message = strip_tags(html_message)
-    email_from = settings.EMAIL_HOST_USER
     recipient_list = [user.email]
+
+    if settings.LICENSE == settings.CLOUD_LICENSE_NAME:
+        email_from = "oncall@{}.grafana.net".format(user.organization.stack_slug)
+    else:
+        email_from = live_settings.EMAIL_HOST_USER
 
     connection = get_connection(
         host=live_settings.EMAIL_HOST,

--- a/engine/apps/email/tests/test_notify_user.py
+++ b/engine/apps/email/tests/test_notify_user.py
@@ -155,3 +155,72 @@ def test_notify_user_no_emails_left(
     log_record = notification_policy.personal_log_records.last()
     assert log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED
     assert log_record.notification_error_code == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_MAIL_LIMIT_EXCEEDED
+
+
+@pytest.mark.django_db
+def test_notify_user_from_email_oss(
+    settings,
+    make_organization,
+    make_user_for_organization,
+    make_token_for_organization,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_alert,
+    make_user_notification_policy,
+):
+    settings.LICENSE = settings.OPEN_SOURCE_LICENSE_NAME
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    settings.EMAIL_HOST = "test"
+    settings.EMAIL_HOST_USER = "test@test.com"
+
+    organization = make_organization(stack_slug="example")
+    user = make_user_for_organization(organization)
+
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    make_alert(alert_group=alert_group, raw_request_data=alert_receive_channel.config.example_payload)
+
+    notification_policy = make_user_notification_policy(
+        user,
+        UserNotificationPolicy.Step.NOTIFY,
+        notify_by=8,
+        important=False,
+    )
+
+    notify_user_async(user.pk, alert_group.pk, notification_policy.pk)
+    assert mail.outbox[0].from_email == "test@test.com"
+
+
+@pytest.mark.django_db
+def test_notify_user_from_email_cloud(
+    settings,
+    make_organization,
+    make_user_for_organization,
+    make_token_for_organization,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_alert,
+    make_user_notification_policy,
+):
+    settings.LICENSE = settings.CLOUD_LICENSE_NAME
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    settings.EMAIL_HOST = "test"
+
+    organization = make_organization(stack_slug="slug")
+    user = make_user_for_organization(organization)
+
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    make_alert(alert_group=alert_group, raw_request_data=alert_receive_channel.config.example_payload)
+
+    notification_policy = make_user_notification_policy(
+        user,
+        UserNotificationPolicy.Step.NOTIFY,
+        notify_by=8,
+        important=False,
+    )
+
+    notify_user_async(user.pk, alert_group.pk, notification_policy.pk)
+    assert mail.outbox[0].from_email == "oncall@slug.grafana.net"


### PR DESCRIPTION
**What this PR does**:

Changes how `from_email` field is set for email notifications on cloud license

**Checklist**
- [x] Tests updated
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)