### PR TITLE
Add placeholder language to  alert behavior doc 

### DIFF
--- a/docs/sources/alert-behavior/_index.md
+++ b/docs/sources/alert-behavior/_index.md
@@ -7,3 +7,14 @@ weight: 900
 ---
 
 # Configure alert behavior for Grafana OnCall
+
+The available alert configurations in Grafana OnCall allow you to define how certain alerts are handled and ensure that alerts are routed, escalated, and grouped to fit your specific alerting needs. Grafana OnCall can receive alerts from any monitoring system that sends alerts via webhook.
+
+
+## About alert behavior 
+
+Once Grafana OnCall receives an alert, the following occurs, based on the alert content:
+
+- Default or customized alert templates are applied to deliver the most useful alert fields with the most valuable information, in a readable format.
+- Alerts are grouped based on your alert grouping configurations, combining similar or related alerts to reduce alert noise.
+- Alerts automatically resolve if an alert from the monitoring system matches the resolve condition for that alert.


### PR DESCRIPTION

**What this PR does**:
Adds temporary language to new top-level Configure alert behavior doc that was added in the docs file restructure. 

The content for this doc is in progress and will replace the basic placeholder language once complete. In the meantime, we don't want this doc to appear empty. 
