### PR TITLE
remove manual CTAs and add section shortcode to alert-behavior

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -29,6 +29,4 @@ Grafana OnCall is an open source incident response management tool built to help
 - **Massive scalability:** Grafana OnCall is equipped with a full API and Terraform capabilities. Ready for GitOps and large organization configuration. 
 
 
-> **Note:** You can use [Grafana Cloud](https://grafana.com/products/cloud/?plcmt=nav-products-cta1&cta=cloud) to avoid installing, maintaining, and scaling your own instance of Grafana OnCall. The free forever plan includes 30 Grafana OnCall notification. [Create an account to get started](https://grafana.com/auth/sign-up/create-user?pg=oncall&plcmt=hero-btn-1).
-
 {{< section >}}

--- a/docs/sources/alert-behavior/_index.md
+++ b/docs/sources/alert-behavior/_index.md
@@ -18,3 +18,6 @@ Once Grafana OnCall receives an alert, the following occurs, based on the alert 
 - Default or customized alert templates are applied to deliver the most useful alert fields with the most valuable information, in a readable format.
 - Alerts are grouped based on your alert grouping configurations, combining similar or related alerts to reduce alert noise.
 - Alerts automatically resolve if an alert from the monitoring system matches the resolve condition for that alert.
+
+
+{{< section >}}

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -26,10 +26,7 @@ These procedures introduce you to initial Grafana OnCall configuration steps, in
 
 ## Before you begin
 
-Grafana OnCall is available for Grafana Cloud as well as Grafana open source users. You must have a Grafana Cloud account or [Open Source Grafana OnCall]({{< relref "../open-source" >}})
-
-For more information, see [Grafana Pricing](https://grafana.com/pricing/) for details.
-
+Grafana OnCall is available for Grafana Cloud as well as Grafana open source users. You must have a Grafana Cloud account or use [Open Source Grafana OnCall]({{< relref "../open-source" >}})
 
 ## Install Open Source Grafana OnCall
 


### PR DESCRIPTION
**What this PR does**:
Removes manual Grafana Cloud CTAs (calls to action) from OnCall docs. 
