### PR TITLE
Enforce until on override shifts

### DIFF
--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -1,5 +1,3 @@
-import datetime
-
 import pytz
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, OuterRef, Subquery
@@ -297,11 +295,7 @@ class ScheduleView(
         users = {u: None for u in schedule.related_users()}
         for e in events:
             user = e["users"][0]["pk"] if e["users"] else None
-            event_end = e["end"]
-            if not isinstance(event_end, datetime.datetime):
-                # all day events end is a date, make it a datetime for comparison
-                event_end = datetime.datetime.combine(event_end, datetime.datetime.min.time(), tzinfo=pytz.UTC)
-            if user is not None and users.get(user) is None and event_end > now:
+            if user is not None and users.get(user) is None and e["end"] > now:
                 users[user] = e
 
         result = {"users": users}

--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -401,7 +401,10 @@ class CustomOnCallShift(models.Model):
         if user:
             event.add("summary", self.get_summary_with_user_for_ical(user))
         event.add("dtstart", self.convert_dt_to_schedule_timezone(start, time_zone))
-        event.add("dtend", self.convert_dt_to_schedule_timezone(start + self.duration, time_zone))
+        dtend = start + self.duration
+        if self.until:
+            dtend = min(dtend, self.until)
+        event.add("dtend", self.convert_dt_to_schedule_timezone(dtend, time_zone))
         event.add("dtstamp", self.rotation_start)
         if custom_rrule:
             event.add("rrule", custom_rrule)

--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -272,11 +272,7 @@ class OnCallSchedule(PolymorphicModel):
             return []
 
         def event_start_cmp_key(e):
-            # all day events: compare using a datetime object at 00:00
-            start = e["start"]
-            if not isinstance(start, datetime.datetime):
-                start = datetime.datetime.combine(start, datetime.datetime.min.time(), tzinfo=pytz.UTC)
-            return start
+            return e["start"]
 
         def event_cmp_key(e):
             """Sorting key criteria for events."""


### PR DESCRIPTION
**What this PR does**:
Enforce `until` value if set for override shifts

**Which issue(s) this PR fixes**:
Related to #532 