### PR TITLE
Add rule for jinja2.Template to remind common environment use

### DIFF
--- a/engine/tox.ini
+++ b/engine/tox.ini
@@ -3,6 +3,8 @@ max-line-length = 180
 extend-ignore = F541, E203
 extend-exclude = */migrations/*
 ban-relative-imports = parents
+banned-modules =
+  jinja2.Template = Use apply_jinja_template instead
 
 [pytest]
 # https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings


### PR DESCRIPTION
**What this PR does**:
Add rule to flake8 to remind use of apply_jinja_template instead of importing Template.

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated