### PR TITLE
specify "prod" as the docker build target for both the drone and GitHub Actions CI pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -104,6 +104,7 @@ steps:
       repo: us.gcr.io/kubernetes-dev/oncall
       dockerfile: engine/Dockerfile
       context: engine/
+      target: prod
       config:
         from_secret: gcr_admin
     depends_on:
@@ -117,6 +118,7 @@ steps:
       repo: grafana/oncall
       dockerfile: engine/Dockerfile
       context: engine/
+      target: prod
       password:
         from_secret: docker_password
       username:
@@ -146,9 +148,9 @@ services:
 trigger:
   event:
     include:
-    - tag
-    - push
-    - pull_request
+      - tag
+      - push
+      - pull_request
   ref:
     include:
       - refs/heads/main
@@ -196,7 +198,7 @@ steps:
       GRAFANA_API_KEY:
         from_secret: gcom_plugin_publisher_api_key
     commands:
-      - "curl -f -s -H \"Authorization: Bearer $${GRAFANA_API_KEY}\" -d \"download[any][url]=https://storage.googleapis.com/grafana-oncall-app/releases/grafana-oncall-app-${DRONE_TAG}.zip\" -d \"download[any][md5]=$$(curl -sL https://storage.googleapis.com/grafana-oncall-app/releases/grafana-oncall-app-${DRONE_TAG}.zip | md5sum | cut -d' ' -f1)\" -d url=https://github.com/grafana/oncall/grafana-plugin https://grafana.com/api/plugins"
+      - 'curl -f -s -H "Authorization: Bearer $${GRAFANA_API_KEY}" -d "download[any][url]=https://storage.googleapis.com/grafana-oncall-app/releases/grafana-oncall-app-${DRONE_TAG}.zip" -d "download[any][md5]=$$(curl -sL https://storage.googleapis.com/grafana-oncall-app/releases/grafana-oncall-app-${DRONE_TAG}.zip | md5sum | cut -d'' '' -f1)" -d url=https://github.com/grafana/oncall/grafana-plugin https://grafana.com/api/plugins'
     depends_on:
       - sign and package plugin
 
@@ -229,6 +231,7 @@ steps:
       repo: grafana/oncall
       tags: ${DRONE_TAG}-amd64-linux
       dockerfile: engine/Dockerfile
+      target: prod
       context: engine/
       password:
         from_secret: docker_password
@@ -266,6 +269,7 @@ steps:
       repo: grafana/oncall
       tags: ${DRONE_TAG}-arm64-linux
       dockerfile: engine/Dockerfile
+      target: prod
       context: engine/
       password:
         from_secret: docker_password
@@ -396,5 +400,3 @@ name: drone_token
 ---
 kind: signature
 hmac: 8a060649c132677ba1b5693b5ac6c846c02f9a5bb645fe990b26a7ea42a0fb66
-
-...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,5 +152,6 @@ jobs:
           context: ./engine
           file: ./engine/Dockerfile
           push: false
+          target: prod
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
**What this PR does**:

Currently the `dev` branch [build is failing](https://drone.grafana.net/grafana/oncall/872), this PR fixes this by being explicit about the image build target (`prod`).

**More info**
For whatever reason, the `plugins/docker` image used in our Drone config builds _all_ build targets in `engine/Dockerfile` (it should skip `dev` and `dev-enterprise`). The failing command being run on drone is:
```shell
/usr/local/bin/docker build --rm=true -f engine/Dockerfile -t 1177e44cc7efb15ad0439915321ed112138f24cb \
  engine/ --pull=true \
  --label org.opencontainers.image.created=2022-11-09T06:23:46Z \
  --label org.opencontainers.image.revision=1177e44cc7efb15ad0439915321ed112138f24cb \
  --label org.opencontainers.image.source=https://github.com/grafana/oncall.git \
  --label org.opencontainers.image.url=https://github.com/grafana/oncall
```

If I run this exact command locally, it skips the `dev` and `dev-enterprise` build stages, as expected, and the image properly builds. On GitHub actions this works properly as well ([this](https://github.com/grafana/oncall/actions/runs/3419803153/jobs/5693782712) is the GitHub Action `docker-build` job for PR #802 which introduced the build stages).

**Which issue(s) this PR fixes**:
Current failing build

**Checklist**
- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)