### PR TITLE
local dev setup - fixes for some minor issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ DEV_ENV_FILE = $(DEV_ENV_DIR)/.env.dev
 DEV_ENV_EXAMPLE_FILE = $(DEV_ENV_FILE).example
 
 ENGINE_DIR = ./engine
+REQUIREMENTS_TXT = $(ENGINE_DIR)/requirements.txt
+REQUIREMENTS_ENTERPRISE_TXT = $(ENGINE_DIR)/requirements-enterprise.txt
 SQLITE_DB_FILE = $(ENGINE_DIR)/oncall.db
 
 # -n flag only copies DEV_ENV_EXAMPLE_FILE-> DEV_ENV_FILE if it doesn't already exist
@@ -122,7 +124,10 @@ endef
 
 backend-bootstrap:
 	pip install -U pip wheel
-	cd engine && pip install -r requirements.txt
+	pip install -r $(REQUIREMENTS_TXT)
+	@if [ -f $(REQUIREMENTS_ENTERPRISE_TXT) ]; then \
+		pip install -r $(REQUIREMENTS_ENTERPRISE_TXT); \
+	fi
 
 backend-migrate:
 	$(call backend_command,python manage.py migrate)

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,11 @@ else
 endif
 
 define run_engine_docker_command
-    DB=$(DB) BROKER_TYPE=$(BROKER_TYPE) docker-compose -f $(DOCKER_COMPOSE_FILE) run --rm oncall_engine_commands $(1)
+    DB=$(DB) BROKER_TYPE=$(BROKER_TYPE) docker compose -f $(DOCKER_COMPOSE_FILE) run --rm oncall_engine_commands $(1)
 endef
 
 define run_docker_compose_command
-	COMPOSE_PROFILES=$(COMPOSE_PROFILES) DB=$(DB) BROKER_TYPE=$(BROKER_TYPE) docker-compose -f $(DOCKER_COMPOSE_FILE) $(1)
+	COMPOSE_PROFILES=$(COMPOSE_PROFILES) DB=$(DB) BROKER_TYPE=$(BROKER_TYPE) docker compose -f $(DOCKER_COMPOSE_FILE) $(1)
 endef
 
 # touch SQLITE_DB_FILE if it does not exist and DB is eqaul to SQLITE_PROFILE

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,18 @@ else
 	BROKER_TYPE=$(REDIS_PROFILE)
 endif
 
-define run_engine_docker_command
-    DB=$(DB) BROKER_TYPE=$(BROKER_TYPE) docker compose -f $(DOCKER_COMPOSE_FILE) run --rm oncall_engine_commands $(1)
-endef
+# SQLITE_DB_FiLE is set to properly mount the sqlite db file
+DOCKER_COMPOSE_ENV_VARS := COMPOSE_PROFILES=$(COMPOSE_PROFILES) DB=$(DB) BROKER_TYPE=$(BROKER_TYPE)
+ifeq ($(DB),$(SQLITE_PROFILE))
+	DOCKER_COMPOSE_ENV_VARS += SQLITE_DB_FILE=$(SQLITE_DB_FILE)
+endif
 
 define run_docker_compose_command
-	COMPOSE_PROFILES=$(COMPOSE_PROFILES) DB=$(DB) BROKER_TYPE=$(BROKER_TYPE) docker compose -f $(DOCKER_COMPOSE_FILE) $(1)
+	$(DOCKER_COMPOSE_ENV_VARS) docker compose -f $(DOCKER_COMPOSE_FILE) $(1)
+endef
+
+define run_engine_docker_command
+	$(call run_docker_compose_command,run --rm oncall_engine_commands $(1))
 endef
 
 # touch SQLITE_DB_FILE if it does not exist and DB is eqaul to SQLITE_PROFILE

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -235,7 +235,7 @@ services:
   grafana:
     container_name: grafana
     labels: *oncall-labels
-    image: "grafana/grafana:${GRAFANA_VERSION:-main}"
+    image: "grafana/grafana:${GRAFANA_VERSION:-latest}"
     restart: always
     environment:
       GF_SECURITY_ADMIN_USER: oncall

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -12,7 +12,7 @@ x-oncall-volumes: &oncall-volumes
   - ./engine:/etc/app
   # https://stackoverflow.com/a/60456034
   - ${ENTERPRISE_ENGINE:-/dev/null}:/etc/app/extensions/engine_enterprise
-  - ./engine/oncall.db:/var/lib/oncall/oncall.db
+  - ${SQLITE_DB_FILE:-/dev/null}:/var/lib/oncall/oncall.db
 
 x-env-files: &oncall-env-files
   - ./dev/.env.dev

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -1,4 +1,4 @@
-requirements-enterprise.txt
+requirements-enterprise*.txt
 extensions/
 uwsgi-local.ini
 celerybeat-schedule

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -19,7 +19,7 @@ FROM base AS dev
 RUN apk add sqlite mysql-client postgresql-client
 
 FROM dev AS dev-enterprise
-RUN pip install -r requirements-enterprise.txt
+RUN pip install -r requirements-enterprise-docker.txt
 
 FROM base AS prod
 


### PR DESCRIPTION
**What this PR does**:
Addresses some minor issues that @mderynck pointed out when running the project locally w/ the new setup:
- use `docker compose` instead of `docker-compose` in `Makefile` commands (`docker-compose` is the older/deprecated version)
- default to using `latest` tag of `grafana/grafana` image, not `main` (`main` is "bleeding edge", causes certain bugs w/ OnCall atm)
- `make backend-bootstrap` will now install `./engine/requirements-enterprise.txt` (if it exists)
- fix issue when running a non-sqlite db, and the `./engine/oncall.db` file doesn't exist, docker would complain about the sqlite db file volume mount (volume is only mounted when `DB=sqlite`)

**Which issue(s) this PR fixes**:
Some minor local dev issues

**Checklist**
- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)