### PR TITLE
Cleanup on deletion/archivation of slack channel

### DIFF
--- a/engine/apps/alerts/models/channel_filter.py
+++ b/engine/apps/alerts/models/channel_filter.py
@@ -159,9 +159,7 @@ class ChannelFilter(OrderedModel):
             "order": self.order,
             "slack_notification_enabled": self.notify_in_slack,
             "telegram_notification_enabled": self.notify_in_telegram,
-            # TODO: use names instead of pks, it's needed to rework messaging backends for that
         }
-        # TODO: use names instead of pks, it's needed to rework messaging backends for that
         if self.slack_channel_id:
             if self.slack_channel_id:
                 SlackChannel = apps.get_model("slack", "SlackChannel")
@@ -169,7 +167,11 @@ class ChannelFilter(OrderedModel):
                 slack_channel = SlackChannel.objects.filter(
                     slack_team_identity=sti, slack_id=self.slack_channel_id
                 ).first()
-                result["slack_channel"] = slack_channel.name
+                if slack_channel is not None:
+                    # Case when slack channel was deleted, but channel filter still has it's id
+                    result["slack_channel"] = slack_channel.name
+        # TODO: use names instead of pks for telegram and other notifications backends.
+        # It's needed to rework messaging backends for that
         if self.telegram_channel:
             result["telegram_channel"] = self.telegram_channel.public_primary_key
         if self.escalation_chain:

--- a/engine/apps/public_api/views/slack_channels.py
+++ b/engine/apps/public_api/views/slack_channels.py
@@ -23,7 +23,8 @@ class SlackChannelView(RateLimitHeadersMixin, mixins.ListModelMixin, GenericView
         channel_name = self.request.query_params.get("channel_name", None)
 
         queryset = SlackChannel.objects.filter(
-            slack_team_identity__organizations=self.request.auth.organization
+            slack_team_identity__organizations=self.request.auth.organization,
+            is_archived=False,
         ).distinct()
 
         if channel_name:

--- a/engine/apps/slack/scenarios/distribute_alerts.py
+++ b/engine/apps/slack/scenarios/distribute_alerts.py
@@ -175,7 +175,6 @@ class AlertShootingStep(scenario_step.ScenarioStep):
     def _send_first_alert(self, alert, channel_id):
         attachments = alert.group.render_slack_attachments()
         blocks = alert.group.render_slack_blocks()
-
         self.publish_slack_messages(
             slack_team_identity=self.slack_team_identity,
             alert_group=alert.group,

--- a/engine/apps/slack/scenarios/slack_channel.py
+++ b/engine/apps/slack/scenarios/slack_channel.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.utils import timezone
 
 from apps.slack.scenarios import scenario_step
+from apps.slack.tasks import clean_slack_channel_leftovers
 
 
 class SlackChannelCreatedOrRenamedEventStep(scenario_step.ScenarioStep):
@@ -53,6 +54,8 @@ class SlackChannelDeletedEventStep(scenario_step.ScenarioStep):
                 slack_id=slack_id,
                 slack_team_identity=slack_team_identity,
             ).delete()
+        # even if channel is deteletd run the task to clean possible leftowers
+        clean_slack_channel_leftovers.apply_async((slack_team_identity.id, slack_id))
 
 
 class SlackChannelArchivedEventStep(scenario_step.ScenarioStep):
@@ -75,6 +78,7 @@ class SlackChannelArchivedEventStep(scenario_step.ScenarioStep):
             slack_id=slack_id,
             slack_team_identity=slack_team_identity,
         ).update(is_archived=True)
+        clean_slack_channel_leftovers.apply_async((slack_team_identity.id, slack_id))
 
 
 class SlackChannelUnArchivedEventStep(scenario_step.ScenarioStep):

--- a/engine/apps/slack/tasks.py
+++ b/engine/apps/slack/tasks.py
@@ -771,3 +771,29 @@ def clean_slack_integration_leftovers(organization_id, *args, **kwargs):
     OnCallSchedule.objects.filter(organization_id=organization_id).update(channel=None)
     logger.info(f"Cleaned OnCallSchedule slack_channel_id for organization {organization_id}")
     logger.info(f"Finish clean slack leftovers for organization {organization_id}")
+
+
+@shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True, max_retries=10)
+def clean_slack_channel_leftovers(slack_team_identity_id, slack_channel_id):
+    """
+    This task removes binding to slack channel after channel arcived or deleted in slack.
+    """
+    SlackTeamIdentity = apps.get_model("slack", "SlackTeamIdentity")
+    ChannelFilter = apps.get_model("alerts", "ChannelFilter")
+
+    try:
+        sti = SlackTeamIdentity.objects.get(id=slack_team_identity_id)
+    except SlackTeamIdentity.DoesNotExist:
+        logger.info(
+            f"Failed to clean_slack_channel_leftovers slack_channel_id={slack_channel_id} slack_team_identity_id={slack_team_identity_id} : Invalid slack_team_identity_id"
+        )
+        return
+
+    for org in sti.organizations.all():
+        if org.general_log_channel_id == slack_channel_id:
+            logger.info(
+                f"Set general_log_channel_id to None for org_id={org.id}  slack_channel_id={slack_channel_id} since slack_channel is arcived or deleted"
+            )
+            org.general_log_channel_id = None
+            org.save(update_fields=["general_log_channel_id"])
+        ChannelFilter.objects.filter(slack_channel_id=slack_channel_id).update(slack_channel_id=None)


### PR DESCRIPTION
**What this PR does**:
It set to None "slack_channel_id" field in ChannelFilters and default channel for organization if corresponding slack channel is deleted or archived.

**Which issue(s) this PR fixes**:
This PR fixes reason of https://github.com/grafana/oncall-private/issues/1461. 
**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated