### PR TITLE
Cleanup to reduce Helm chart noise

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -52,9 +52,9 @@ MIRAGE_SECRET_KEY
 {{- end -}}
 
 {{- define "snippet.oncall.slack.env" -}}
-{{- if .Values.oncall.slack.enabled -}}
 - name: FEATURE_SLACK_INTEGRATION_ENABLED
   value: {{ .Values.oncall.slack.enabled | toString | title | quote }}
+{{- if .Values.oncall.slack.enabled }}
 - name: SLACK_SLASH_COMMAND_NAME
   value: "/{{ .Values.oncall.slack.commandName | default "oncall" }}"
 {{- if .Values.oncall.slack.existingSecret }}
@@ -83,18 +83,15 @@ MIRAGE_SECRET_KEY
 {{- end }}
 - name: SLACK_INSTALL_RETURN_REDIRECT_HOST
   value: {{ .Values.oncall.slack.redirectHost | default (printf "https://%s" .Values.base_url) | quote }}
-{{- else -}}
-- name: FEATURE_SLACK_INTEGRATION_ENABLED
-  value: {{ .Values.oncall.slack.enabled | toString | title | quote }}
 {{- end -}}
 {{- end -}}
 
 {{- define "snippet.oncall.telegram.env" -}}
-{{- if .Values.oncall.telegram.enabled -}}
 - name: FEATURE_TELEGRAM_INTEGRATION_ENABLED
   value: {{ .Values.oncall.telegram.enabled | toString | title | quote }}
+{{- if .Values.oncall.telegram.enabled }}
 - name: TELEGRAM_WEBHOOK_HOST
-  value: {{ .Values.oncall.telegram.webhookUrl | default "" | quote }}
+  value: {{ .Values.oncall.telegram.webhookUrl | default (printf "https://%s" .Values.base_url) | quote }}
 {{- if .Values.oncall.telegram.existingSecret }}
 - name: TELEGRAM_TOKEN
   valueFrom:
@@ -105,9 +102,6 @@ MIRAGE_SECRET_KEY
 - name: TELEGRAM_TOKEN
   value: {{ .Values.oncall.telegram.token | default "" | quote }}
 {{- end }}
-{{- else -}}
-- name: FEATURE_TELEGRAM_INTEGRATION_ENABLED
-  value: {{ .Values.oncall.telegram.enabled | toString | title | quote }}
 {{- end -}}
 {{- end -}}
 
@@ -407,7 +401,7 @@ rabbitmq-password
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ template "snippet.redis.password.secret.name" . }}
+      name: {{ include "snippet.redis.password.secret.name" . }}
       key: redis-password
 {{- end }}
 

--- a/helm/oncall/templates/secrets.yaml
+++ b/helm/oncall/templates/secrets.yaml
@@ -9,9 +9,9 @@ type: Opaque
 data:
   {{ template "snippet.oncall.secret.secretKey" . }}: {{ randAlphaNum 40 | b64enc | quote }}
   {{ template "snippet.oncall.secret.mirageSecretKey" . }}: {{ randAlphaNum 40 | b64enc | quote }}
-{{- end }}
 ---
-{{ if and (not .Values.mariadb.enabled) (eq .Values.database.type "mysql") -}}
+{{- end }}
+{{- if and (not .Values.mariadb.enabled) (eq .Values.database.type "mysql") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,9 +19,9 @@ metadata:
 type: Opaque
 data:
   mariadb-root-password: {{ required "externalMysql.password is required if not mariadb.enabled" .Values.externalMysql.password | b64enc | quote }}
-{{- end }}
 ---
-{{ if and (eq .Values.broker.type "rabbitmq") (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingSecret) -}}
+{{- end }}
+{{- if and (eq .Values.broker.type "rabbitmq") (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -29,9 +29,9 @@ metadata:
 type: Opaque
 data:
   rabbitmq-password: {{ required "externalRabbitmq.password is required if not rabbitmq.enabled and not externalRabbitmq.existingSecret" .Values.externalRabbitmq.password | b64enc | quote }}
-{{- end }}
 ---
-{{ if not .Values.redis.enabled -}}
+{{- end }}
+{{- if not .Values.redis.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -39,9 +39,9 @@ metadata:
 type: Opaque
 data:
   redis-password: {{ required "externalRedis.password is required if not redis.enabled" .Values.externalRedis.password | b64enc | quote }}
-{{- end }}
 ---
-{{ if and .Values.oncall.smtp.enabled .Values.oncall.smtp.password -}}
+{{- end }}
+{{- if and .Values.oncall.smtp.enabled .Values.oncall.smtp.password }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -49,9 +49,9 @@ metadata:
 type: Opaque
 data:
   smtp-password: {{ .Values.oncall.smtp.password | b64enc | quote }}
-{{- end }}
 ---
-{{ if and (not .Values.postgresql.enabled) (eq .Values.database.type "postgresql") (not .Values.externalPostgresql.existingSecret) -}}
+{{- end }}
+{{- if and (not .Values.postgresql.enabled) (eq .Values.database.type "postgresql") (not .Values.externalPostgresql.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -59,4 +59,5 @@ metadata:
 type: Opaque
 data:
   postgres-password: {{ required "externalPostgresql.password is required if not postgresql.enabled and not externalPostgresql.existingSecret" .Values.externalPostgresql.password | b64enc | quote }}
+---
 {{- end }}


### PR DESCRIPTION
- Multiple '---' and new lines could be previously produced by secrets.yaml
- Some duplication removed from _env.tpl
- telegram.webhookUrl defaults to base_url

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated