### PR TITLE
Add distribute_alert_group task to start escalations for alert groups…

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -12,6 +12,7 @@ from django.db.models.signals import post_save
 from apps.alerts.constants import TASK_DELAY_SECONDS
 from apps.alerts.incident_appearance.templaters import TemplateLoader
 from apps.alerts.tasks import distribute_alert, send_alert_group_signal
+from apps.alerts.tasks.distribute_alert import distribute_alert_group
 from common.jinja_templater import apply_jinja_template
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
@@ -99,6 +100,7 @@ class Alert(models.Model):
         if group_created:
             group.log_records.create(type=AlertGroupLogRecord.TYPE_REGISTERED)
             group.log_records.create(type=AlertGroupLogRecord.TYPE_ROUTE_ASSIGNED)
+            distribute_alert_group.apply_async(group.pk)
 
         mark_as_resolved = (
             enable_autoresolve and group_data.is_resolve_signal and alert_receive_channel.allow_source_based_resolving

--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -100,7 +100,7 @@ class Alert(models.Model):
         if group_created:
             group.log_records.create(type=AlertGroupLogRecord.TYPE_REGISTERED)
             group.log_records.create(type=AlertGroupLogRecord.TYPE_ROUTE_ASSIGNED)
-            distribute_alert_group.apply_async(group.pk)
+            distribute_alert_group.apply_async((group.pk,))
 
         mark_as_resolved = (
             enable_autoresolve and group_data.is_resolve_signal and alert_receive_channel.allow_source_based_resolving

--- a/engine/settings/prod_without_db.py
+++ b/engine/settings/prod_without_db.py
@@ -80,6 +80,7 @@ CELERY_TASK_ROUTES = {
     "apps.alerts.tasks.acknowledge_reminder.acknowledge_reminder_task": {"queue": "critical"},
     "apps.alerts.tasks.acknowledge_reminder.unacknowledge_timeout_task": {"queue": "critical"},
     "apps.alerts.tasks.distribute_alert.distribute_alert": {"queue": "critical"},
+    "apps.alerts.tasks.distribute_alert.distribute_alert_group": {"queue": "critical"},
     "apps.alerts.tasks.distribute_alert.send_alert_create_signal": {"queue": "critical"},
     "apps.alerts.tasks.escalate_alert_group.escalate_alert_group": {"queue": "critical"},
     "apps.alerts.tasks.invite_user_to_join_incident.invite_user_to_join_incident": {"queue": "critical"},


### PR DESCRIPTION
… instead of disctribute_alert

**What this PR does**:

**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated