### PR TITLE
Remove net.core.somaxconn in Helm Chart

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -19,8 +19,6 @@
   value: "admin"
 - name: OSS
   value: "True"
-- name: UWSGI_LISTEN
-  value: "1024"
 - name: BROKER_TYPE
   value: {{ .Values.broker.type | default "rabbitmq" }}
 {{- end -}}


### PR DESCRIPTION
**What this PR does**:

When this PR was accepted https://github.com/grafana/oncall/pull/88/files somebody removed maxconn property for docker-compose https://github.com/grafana/oncall/issues/84#issuecomment-1156672285 but forget about Helm.

**Which issue(s) this PR fixes**:

This issue can be fixed by removing this property.

https://github.com/grafana/oncall/issues/562

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated