### PR TITLE
Introduce `copy-invite-token` make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ define run_engine_docker_command
 	$(call run_docker_compose_command,run --rm oncall_engine_commands $(1))
 endef
 
-# touch SQLITE_DB_FILE if it does not exist and DB is eqaul to SQLITE_PROFILE
+# touch SQLITE_DB_FILE if it does not exist and DB is equal to SQLITE_PROFILE
 start:
 ifeq ($(DB),$(SQLITE_PROFILE))
 	@if [ ! -f $(SQLITE_DB_FILE) ]; then \
@@ -107,6 +107,11 @@ install-precommit-hook: install-pre-commit
 
 get-invite-token:
 	$(call run_engine_docker_command,python manage.py issue_invite_for_the_frontend --override)
+
+copy-invite-token:
+	$(call run_engine_docker_command,python manage.py issue_invite_for_the_frontend --no-color --override) |\
+	grep 'Your invite token' | perl -pe 's/Your invite token: ([0-9a-f]*?)[^0-9a-f].*/$$1/' | pbcopy
+
 
 test:
 	$(call run_engine_docker_command,pytest)

--- a/engine/engine/management/commands/issue_invite_for_the_frontend.py
+++ b/engine/engine/management/commands/issue_invite_for_the_frontend.py
@@ -42,4 +42,4 @@ class Command(BaseCommand):
         self_hosted_settings.json_value["keys"].append(invite_token)
         self_hosted_settings.save(update_fields=["json_value"])
 
-        self.stdout.write(f"Your invite token: \033[31m{invite_token}\033[39m , use it in the Grafana OnCall plugin.")
+        self.stdout.write(f"Your invite token: {self.style.ERROR(invite_token)}, use it in the Grafana OnCall plugin.")


### PR DESCRIPTION
Since `make get-invite-token` typically is followed by copying the token to paste into the web interface, I automated that.

This required updating `issue_invite_for_the_frontend` to respect the styling that is implemented in `django.core.management.base.BaseCommand` - `ERROR` probably isn't conceptually the right designation for this value, but it results in (as far as my not-a-visual-designer eyes can tell) the same styling.

---

Also corrects a typo in a comment: `eqaul -> equal`