### PR TITLE
Update selected days to UTC before submit

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -17,7 +17,7 @@ import { Schedule, Shift } from 'models/schedule/schedule.types';
 import { getTzOffsetString } from 'models/timezone/timezone.helpers';
 import { Timezone } from 'models/timezone/timezone.types';
 import { User } from 'models/user/user.types';
-import { getDateTime, getStartOfWeek, getUTCString } from 'pages/schedule/Schedule.helpers';
+import { getDateTime, getStartOfWeek, getUTCByDay, getUTCString } from 'pages/schedule/Schedule.helpers';
 import { SelectOption } from 'state/types';
 import { useStore } from 'state/useStore';
 import { getCoords, waitForElement } from 'utils/DOM';
@@ -154,7 +154,7 @@ const RotationForm: FC<RotationFormProps> = observer((props) => {
       rolling_users: userGroups,
       interval: repeatEveryValue,
       frequency: repeatEveryPeriod,
-      by_day: repeatEveryPeriod === 0 || repeatEveryPeriod === 1 ? selectedDays : null,
+      by_day: repeatEveryPeriod === 0 || repeatEveryPeriod === 1 ? getUTCByDay(selectedDays, shiftStart) : null,
       priority_level: shiftId === 'new' ? layerPriority : shift?.priority_level,
     }),
     [

--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -154,7 +154,10 @@ const RotationForm: FC<RotationFormProps> = observer((props) => {
       rolling_users: userGroups,
       interval: repeatEveryValue,
       frequency: repeatEveryPeriod,
-      by_day: repeatEveryPeriod === 0 || repeatEveryPeriod === 1 ? getUTCByDay(selectedDays, shiftStart) : null,
+      by_day:
+        repeatEveryPeriod === 0 || repeatEveryPeriod === 1
+          ? getUTCByDay(store.scheduleStore.byDayOptions, selectedDays, shiftStart)
+          : null,
       priority_level: shiftId === 'new' ? layerPriority : shift?.priority_level,
     }),
     [

--- a/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
+++ b/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
@@ -20,14 +20,14 @@ export const getDateTime = (date: string) => {
 };
 
 export const getUTCByDay = (dayOptions: SelectOption[], by_day: string[], moment: dayjs.Dayjs) => {
-  if (by_day.length > 0 && moment.day() !== moment.utc().day()) {
+  if (by_day.length && moment.day() !== moment.utc().day()) {
     // when converting to UTC, shift starts on a different day,
     // so we need to update the by_day list
     // depending on the UTC side, move one day before or after
+    let offset = moment.utcOffset();
     let UTCDays = [];
     let byDayOptions = [];
-    Object.entries(dayOptions).forEach(([, option]) => byDayOptions.push(option.value));
-    let offset = moment.utcOffset();
+    dayOptions.forEach(({ value }) => byDayOptions.push(value));
     by_day.forEach((element) => {
       let index = byDayOptions.indexOf(element);
       if (offset < 0) {

--- a/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
+++ b/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
@@ -5,6 +5,7 @@ import { getLayersFromStore, getOverridesFromStore, getShiftsFromStore } from 'm
 import { Event, Layer } from 'models/schedule/schedule.types';
 import { Timezone } from 'models/timezone/timezone.types';
 import { RootStore } from 'state';
+import { SelectOption } from 'state/types';
 
 export const getStartOfWeek = (tz: Timezone) => {
   return dayjs().tz(tz).utcOffset() === 0 ? dayjs().utc().startOf('isoWeek') : dayjs().tz(tz).startOf('isoWeek');
@@ -18,14 +19,14 @@ export const getDateTime = (date: string) => {
   return dayjs(date);
 };
 
-export const getUTCByDay = (by_day: string[], moment: dayjs.Dayjs) => {
-  let UTCDays = [];
-  // FIXME: do this in a proper way
-  let byDayOptions = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+export const getUTCByDay = (dayOptions: SelectOption[], by_day: string[], moment: dayjs.Dayjs) => {
   if (by_day.length > 0 && moment.day() !== moment.utc().day()) {
     // when converting to UTC, shift starts on a different day,
     // so we need to update the by_day list
     // depending on the UTC side, move one day before or after
+    let UTCDays = [];
+    let byDayOptions = [];
+    Object.entries(dayOptions).forEach(([, option]) => byDayOptions.push(option.value));
     let offset = moment.utcOffset();
     by_day.forEach((element) => {
       let index = byDayOptions.indexOf(element);

--- a/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
+++ b/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
@@ -18,6 +18,30 @@ export const getDateTime = (date: string) => {
   return dayjs(date);
 };
 
+export const getUTCByDay = (by_day: string[], moment: dayjs.Dayjs) => {
+  let UTCDays = [];
+  // FIXME: do this in a proper way
+  let byDayOptions = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU'];
+  if (by_day.length > 0 && moment.day() !== moment.utc().day()) {
+    // when converting to UTC, shift starts on a different day,
+    // so we need to update the by_day list
+    // depending on the UTC side, move one day before or after
+    let offset = moment.utcOffset();
+    by_day.forEach((element) => {
+      let index = byDayOptions.indexOf(element);
+      if (offset < 0) {
+        // move one day after
+        UTCDays.push(byDayOptions[(index + 1) % 7]);
+      } else {
+        // move one day before
+        UTCDays.push(byDayOptions[(((index - 1) % 7) + 7) % 7]);
+      }
+    });
+    return UTCDays;
+  }
+  return by_day;
+};
+
 export const getColorSchemeMappingForUsers = (
   store: RootStore,
   scheduleId: string,


### PR DESCRIPTION
**What this PR does**:
Fix issue when setting up by-day shifts in a non-UTC timezone but shift start "converts" selected days to different ones when submitting as UTC