### PR TITLE
Fix oncall schedules bug

### DIFF
--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -373,6 +373,7 @@ class CustomOnCallShift(models.Model):
                     expected_start_day = min(CustomOnCallShift.ICAL_WEEKDAY_REVERSE_MAP[d] for d in self.by_day)
                     delta = (expected_start_day - start.weekday()) % 7
                     start = start + timezone.timedelta(days=delta)
+                    self.until = self.until + timezone.timedelta(days=delta)
 
             if self.frequency == CustomOnCallShift.FREQUENCY_DAILY and self.by_day:
                 result = self._daily_by_day_to_ical(time_zone, start, users_queue)

--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -373,7 +373,8 @@ class CustomOnCallShift(models.Model):
                     expected_start_day = min(CustomOnCallShift.ICAL_WEEKDAY_REVERSE_MAP[d] for d in self.by_day)
                     delta = (expected_start_day - start.weekday()) % 7
                     start = start + timezone.timedelta(days=delta)
-                    self.until = self.until + timezone.timedelta(days=delta)
+                    if self.until is not None:
+                        self.until = self.until + timezone.timedelta(days=delta)
 
             if self.frequency == CustomOnCallShift.FREQUENCY_DAILY and self.by_day:
                 result = self._daily_by_day_to_ical(time_zone, start, users_queue)


### PR DESCRIPTION
**What this PR does**:
Calendars are not displayed if the shift's `parent end date` is earlier than the closest day of the selected day of the week.
```
2022-11-22 01:29:30 source=engine:app google_trace_id=63031bc25b7d8d1a472dc07f8ae916d5/18427678091241766406 logger=django.request Internal Server Error: /api/internal/v1/schedules
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/mixins.py", line 46, in list
    return Response(serializer.data)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 745, in data
    ret = super().data
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 246, in data
    self._data = self.to_representation(self.instance)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 663, in to_representation
    return [
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 664, in <listcomp>
    self.child.to_representation(item) for item in iterable
  File "/usr/local/lib/python3.9/site-packages/rest_polymorphic/serializers.py", line 60, in to_representation
    ret = serializer.to_representation(instance)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/serializers.py", line 515, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/fields.py", line 1882, in to_representation
    return method(value)
  File "/etc/app/apps/api/serializers/schedule_base.py", line 70, in get_on_call_now
    users_on_call = list_users_to_notify_from_ical(obj, timezone.datetime.now(timezone.utc))
  File "/etc/app/apps/schedules/ical_utils.py", line 290, in list_users_to_notify_from_ical
    return list_users_to_notify_from_ical_for_period(
  File "/etc/app/apps/schedules/ical_utils.py", line 306, in list_users_to_notify_from_ical_for_period
    events = ical_events.get_events_from_ical_between(calendar, start_datetime, end_datetime)
  File "/etc/app/apps/schedules/ical_events/proxy/ical_proxy.py", line 24, in get_events_from_ical_between
    return self.ical_adapter.get_events_from_ical_between(calendar, start_date, end_date)
  File "/etc/app/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py", line 102, in get_events_from_ical_between
    events = AmixrUnfoldableCalendar(calendar).between(
  File "/etc/app/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py", line 85, in between
   if repetition.is_in_span(span_start, span_stop):
  File "/usr/local/lib/python3.9/site-packages/recurring_ical_events.py", line 129, in is_in_span
    return time_span_contains_event(span_start, span_stop, self.start, self.stop)
  File "/usr/local/lib/python3.9/site-packages/recurring_ical_events.py", line 76, in time_span_contains_event
    assert event_start <= event_stop, "the event must sta``rt before it ends"
AssertionError: the event must start before it ends
```
**Which issue(s) this PR fixes**:

**Checklist**
- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated