### PR TITLE
Add dot between integration name and alert title in phone call

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/phone_call_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/phone_call_renderer.py
@@ -13,7 +13,7 @@ class AlertPhoneCallRenderer(AlertBaseRenderer):
 class AlertGroupPhoneCallRenderer(AlertGroupBaseRenderer):
     TEMPLATE = (
         "You are invited to check an incident from Grafana OnCall. "
-        "Alert via {integration_name} with title {title} triggered {alert_count} times"
+        "Alert via {integration_name}. With title {title} triggered {alert_count} times"
     )
 
     @property

--- a/engine/apps/alerts/tests/test_alert_group.py
+++ b/engine/apps/alerts/tests/test_alert_group.py
@@ -40,7 +40,7 @@ def test_render_for_phone_call(
 
     expected_verbose_name = (
         f"You are invited to check an incident from Grafana OnCall. "
-        f"Alert via {alert_receive_channel.verbal_name} - Grafana with title TestAlert triggered 1 times"
+        f"Alert via {alert_receive_channel.verbal_name} - Grafana. With title TestAlert triggered 1 times"
     )
     rendered_text = AlertGroupPhoneCallRenderer(alert_group).render()
     assert expected_verbose_name in rendered_text


### PR DESCRIPTION
**What this PR does**:
Add dot between integration name and alert title in phone call, to make it more clear

**Which issue(s) this PR fixes**:
https://github.com/grafana/oncall/issues/851
