### PR TITLE
Do not include event repetitions terminated before start (until rrule)

### DIFF
--- a/engine/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py
+++ b/engine/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py
@@ -80,7 +80,8 @@ class AmixrUnfoldableCalendar(UnfoldableCalendar):
                 continue
             repetitions = self.RepeatedEvent(event, span_start)
             for repetition in repetitions:
-                if compare_greater(repetition.start, span_stop):
+                if compare_greater(repetition.start, span_stop) or compare_greater(repetition.start, repetition.stop):
+                    # future repetitions could produce invalid events (because of the until rrule)
                     break
                 if repetition.is_in_span(span_start, span_stop):
                     add_event(repetition.as_vevent())

--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -373,8 +373,6 @@ class CustomOnCallShift(models.Model):
                     expected_start_day = min(CustomOnCallShift.ICAL_WEEKDAY_REVERSE_MAP[d] for d in self.by_day)
                     delta = (expected_start_day - start.weekday()) % 7
                     start = start + timezone.timedelta(days=delta)
-                    if self.until is not None:
-                        self.until = self.until + timezone.timedelta(days=delta)
 
             if self.frequency == CustomOnCallShift.FREQUENCY_DAILY and self.by_day:
                 result = self._daily_by_day_to_ical(time_zone, start, users_queue)

--- a/engine/apps/schedules/tests/test_ical_utils.py
+++ b/engine/apps/schedules/tests/test_ical_utils.py
@@ -12,7 +12,7 @@ from apps.schedules.ical_utils import (
     parse_event_uid,
     users_in_ical,
 )
-from apps.schedules.models import CustomOnCallShift, OnCallScheduleCalendar
+from apps.schedules.models import CustomOnCallShift, OnCallScheduleCalendar, OnCallScheduleWeb
 
 
 @pytest.mark.django_db
@@ -72,6 +72,39 @@ def test_list_users_to_notify_from_ical_viewers_inclusion(
     else:
         assert len(users_on_call) == 1
         assert set(users_on_call) == {user}
+
+
+@pytest.mark.django_db
+def test_list_users_to_notify_from_ical_until_terminated_event(
+    make_organization_and_user, make_user_for_organization, make_schedule, make_on_call_shift
+):
+    organization, user = make_organization_and_user()
+    other_user = make_user_for_organization(organization)
+
+    schedule = make_schedule(organization, schedule_class=OnCallScheduleWeb)
+    date = timezone.now().replace(tzinfo=None, microsecond=0)
+
+    data = {
+        "start": date,
+        "duration": timezone.timedelta(hours=4),
+        "rotation_start": date + timezone.timedelta(days=3),
+        "priority_level": 1,
+        "frequency": CustomOnCallShift.FREQUENCY_DAILY,
+        "by_day": ["SU"],
+        "interval": 1,
+        "until": date + timezone.timedelta(hours=8),
+        "schedule": schedule,
+    }
+    on_call_shift = make_on_call_shift(
+        organization=organization, shift_type=CustomOnCallShift.TYPE_ROLLING_USERS_EVENT, **data
+    )
+    on_call_shift.add_rolling_users([[user], [other_user]])
+
+    # get users on-call
+    date = date + timezone.timedelta(minutes=5)
+    # this should not raise despite the shift configuration (until < rotation start)
+    users_on_call = list_users_to_notify_from_ical(schedule, date)
+    assert users_on_call == []
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/1491