### PR TITLE
don't show user tabs they aren't authorized to see

### DIFF
--- a/grafana-plugin/src/containers/AlertRules/AlertRules.tsx
+++ b/grafana-plugin/src/containers/AlertRules/AlertRules.tsx
@@ -37,7 +37,7 @@ import { MaintenanceType } from 'models/maintenance/maintenance.types';
 import { WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
 import { openNotification } from 'utils';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 import sanitize from 'utils/sanitize';
 
 import styles from './AlertRules.module.css';
@@ -223,7 +223,7 @@ class AlertRules extends React.Component<AlertRulesProps, AlertRulesState> {
                     <Tooltip placement="top" content="Stop maintenance mode">
                       <Button
                         className="grey-button"
-                        disabled={!store.isUserActionAllowed(UserActions.MaintenanceWrite)}
+                        disabled={!isUserActionAllowed(UserActions.MaintenanceWrite)}
                         fill="text"
                         icon="square-shape"
                         onClick={this.handleStopMaintenance}
@@ -236,7 +236,7 @@ class AlertRules extends React.Component<AlertRulesProps, AlertRulesState> {
                         maintenance_type: MaintenanceType.alert_receive_channel,
                         alert_receive_channel: alertReceiveChannel.id,
                       }}
-                      disabled={!store.isUserActionAllowed(UserActions.MaintenanceWrite)}
+                      disabled={!isUserActionAllowed(UserActions.MaintenanceWrite)}
                     >
                       <WithPermissionControl userAction={UserActions.MaintenanceWrite}>
                         <IconButton
@@ -244,7 +244,7 @@ class AlertRules extends React.Component<AlertRulesProps, AlertRulesState> {
                           size="sm"
                           tooltip="Setup maintenance mode"
                           tooltipPlacement="top"
-                          disabled={!store.isUserActionAllowed(UserActions.MaintenanceWrite)}
+                          disabled={!isUserActionAllowed(UserActions.MaintenanceWrite)}
                         />
                       </WithPermissionControl>
                     </PluginLink>

--- a/grafana-plugin/src/containers/AlertRules/parts/connectors/SlackConnector.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/connectors/SlackConnector.tsx
@@ -12,7 +12,7 @@ import { PRIVATE_CHANNEL_NAME } from 'models/slack_channel/slack_channel.config'
 import { getSlackChannelName } from 'models/slack_channel/slack_channel.helpers';
 import { SlackChannel } from 'models/slack_channel/slack_channel.types';
 import { useStore } from 'state/useStore';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import styles from './index.module.css';
 
@@ -94,7 +94,7 @@ const SlackConnector = (props: SlackConnectorProps) => {
           ) : teamStore.currentTeam?.slack_channel?.id ? (
             <Text type="secondary">
               This is the default slack channel{' '}
-              <PluginLink query={{ page: 'chat-ops' }} disabled={!store.isUserActionAllowed(UserActions.ChatOpsWrite)}>
+              <PluginLink query={{ page: 'chat-ops' }} disabled={!isUserActionAllowed(UserActions.ChatOpsWrite)}>
                 <WithPermissionControl userAction={UserActions.ChatOpsUpdateSettings}>
                   <Button variant="primary" size="sm" fill="text">
                     Change in Slack settings

--- a/grafana-plugin/src/containers/ApiTokenSettings/ApiTokenSettings.tsx
+++ b/grafana-plugin/src/containers/ApiTokenSettings/ApiTokenSettings.tsx
@@ -12,7 +12,7 @@ import { WithPermissionControl } from 'containers/WithPermissionControl/WithPerm
 import { ApiToken } from 'models/api_token/api_token.types';
 import { WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import ApiTokenForm from './ApiTokenForm';
 
@@ -93,7 +93,7 @@ class ApiTokens extends React.Component<ApiTokensProps, any> {
           showHeader={!isMobile}
           data={apiTokens}
           emptyText={
-            store.isUserActionAllowed(UserActions.APIKeysWrite)
+            isUserActionAllowed(UserActions.APIKeysWrite)
               ? apiTokens
                 ? 'No tokens found'
                 : 'Loading...'

--- a/grafana-plugin/src/containers/DefaultPageLayout/DefaultPageLayout.tsx
+++ b/grafana-plugin/src/containers/DefaultPageLayout/DefaultPageLayout.tsx
@@ -11,7 +11,7 @@ import { getIfChatOpsConnected } from 'containers/DefaultPageLayout/helper';
 import { AppFeature } from 'state/features';
 import { useStore } from 'state/useStore';
 import LocationHelper from 'utils/LocationHelper';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 import { GRAFANA_LICENSE_OSS } from 'utils/consts';
 import { useForceUpdate } from 'utils/hooks';
 import { getItem, setItem } from 'utils/localStorage';
@@ -131,7 +131,7 @@ const DefaultPageLayout: FC<DefaultPageLayoutProps> = observer((props) => {
         {Boolean(
           currentTeam &&
             currentUser &&
-            store.isUserActionAllowed(UserActions.UserSettingsWrite) &&
+            isUserActionAllowed(UserActions.UserSettingsWrite) &&
             (!isPhoneVerified || !isChatOpsConnected) &&
             !getItem(AlertID.CONNECTIVITY_WARNING)
         ) && (

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/CloudPhoneSettings/CloudPhoneSettings.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/CloudPhoneSettings/CloudPhoneSettings.tsx
@@ -10,7 +10,7 @@ import { AppFeature } from 'state/features';
 import { WithStoreProps } from 'state/types';
 import { useStore } from 'state/useStore';
 import { withMobXProviderContext } from 'state/withStore';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 interface CloudPhoneSettingsProps extends WithStoreProps {
   userPk?: User['pk'];
@@ -119,7 +119,7 @@ const CloudPhoneSettings = observer((props: CloudPhoneSettingsProps) => {
 
   return (
     <>
-      {store.isUserActionAllowed(UserActions.OtherSettingsWrite) ? (
+      {isUserActionAllowed(UserActions.OtherSettingsWrite) ? (
         <VerticalGroup spacing="lg">
           <HorizontalGroup justify="space-between">
             <Text.Title level={3}>OnCall use Grafana Cloud for SMS and phone call notifications</Text.Title>

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/PhoneVerification/PhoneVerification.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/PhoneVerification/PhoneVerification.tsx
@@ -11,7 +11,7 @@ import { User } from 'models/user/user.types';
 import { AppFeature } from 'state/features';
 import { useStore } from 'state/useStore';
 import { openErrorNotification } from 'utils';
-import { UserAction, UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserAction, UserActions } from 'utils/authorization';
 
 import styles from './PhoneVerification.module.css';
 
@@ -142,7 +142,7 @@ const PhoneVerification = observer((props: PhoneVerificationProps) => {
     phone === user.verified_phone_number || (!isCodeSent && !isPhoneValid) || !isTwilioConfigured;
 
   const isPhoneDisabled = !!user.verified_phone_number;
-  const isCodeFieldDisabled = !isCodeSent || !store.isUserActionAllowed(action);
+  const isCodeFieldDisabled = !isCodeSent || !isUserActionAllowed(action);
   const showToggle = user.verified_phone_number && isCurrentUser;
 
   if (showForgetScreen) {

--- a/grafana-plugin/src/containers/WithPermissionControl/WithPermissionControl.tsx
+++ b/grafana-plugin/src/containers/WithPermissionControl/WithPermissionControl.tsx
@@ -4,8 +4,7 @@ import { Tooltip } from '@grafana/ui';
 import cn from 'classnames/bind';
 import { observer } from 'mobx-react';
 
-import { useStore } from 'state/useStore';
-import { UserAction } from 'utils/authorization';
+import { isUserActionAllowed, UserAction } from 'utils/authorization';
 
 import styles from './WithPermissionControl.module.css';
 
@@ -21,9 +20,7 @@ interface WithPermissionControlProps {
 export const WithPermissionControl = observer((props: WithPermissionControlProps) => {
   const { userAction, children, className } = props;
 
-  const store = useStore();
-
-  const disabledByPermissions = !store.isUserActionAllowed(userAction);
+  const disabledByPermissions = !isUserActionAllowed(userAction);
 
   const onClickCallback = useCallback(
     (event: any) => {

--- a/grafana-plugin/src/containers/WithPermissionControl2/WithPermissionControl.tsx
+++ b/grafana-plugin/src/containers/WithPermissionControl2/WithPermissionControl.tsx
@@ -3,8 +3,7 @@ import React, { ReactElement, useMemo } from 'react';
 import { Tooltip } from '@grafana/ui';
 import { observer } from 'mobx-react';
 
-import { useStore } from 'state/useStore';
-import { UserAction } from 'utils/authorization';
+import { isUserActionAllowed, UserAction } from 'utils/authorization';
 
 interface WithPermissionControlProps {
   userAction: UserAction;
@@ -14,9 +13,7 @@ interface WithPermissionControlProps {
 export const WithPermissionControl = observer((props: WithPermissionControlProps) => {
   const { userAction, children } = props;
 
-  const store = useStore();
-
-  const disabled = !store.isUserActionAllowed(userAction);
+  const disabled = !isUserActionAllowed(userAction);
 
   const element = useMemo(() => children(disabled), [disabled]);
 

--- a/grafana-plugin/src/models/user/user.ts
+++ b/grafana-plugin/src/models/user/user.ts
@@ -8,7 +8,7 @@ import { makeRequest } from 'network';
 import { Mixpanel } from 'services/mixpanel';
 import { RootStore } from 'state';
 import { move } from 'state/helpers';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import { getTimezone, prepareForUpdate } from './user.helpers';
 import { User } from './user.types';
@@ -56,7 +56,7 @@ export class UserStore extends BaseStore {
     const response = await makeRequest('/user/', {});
 
     let timezone;
-    if (!response.timezone && this.rootStore.isUserActionAllowed(UserActions.UserSettingsWrite)) {
+    if (!response.timezone && isUserActionAllowed(UserActions.UserSettingsWrite)) {
       timezone = dayjs.tz.guess();
       this.update(response.pk, { timezone });
     }

--- a/grafana-plugin/src/pages/outgoing_webhooks/OutgoingWebhooks.test.tsx
+++ b/grafana-plugin/src/pages/outgoing_webhooks/OutgoingWebhooks.test.tsx
@@ -35,8 +35,12 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('state/useStore', () => ({
   useStore: () => ({
     outgoingWebhookStore: outgoingWebhookStore(),
-    isUserActionAllowed: jest.fn().mockReturnValue(true),
   }),
+}));
+
+jest.mock('utils/authorization', () => ({
+  ...jest.requireActual('utils/authorization'),
+  isUserActionAllowed: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('@grafana/runtime', () => ({
@@ -45,7 +49,6 @@ jest.mock('@grafana/runtime', () => ({
 
 describe('OutgoingWebhooks', () => {
   const storeMock = {
-    isUserActionAllowed: jest.fn().mockReturnValue(true),
     outgoingWebhookStore: outgoingWebhookStore(),
   };
 

--- a/grafana-plugin/src/pages/outgoing_webhooks/OutgoingWebhooks.tsx
+++ b/grafana-plugin/src/pages/outgoing_webhooks/OutgoingWebhooks.tsx
@@ -23,7 +23,7 @@ import { pages } from 'pages';
 import { PageProps, WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
 import LocationHelper from 'utils/LocationHelper';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import styles from './OutgoingWebhooks.module.css';
 
@@ -132,7 +132,7 @@ class OutgoingWebhooks extends React.Component<OutgoingWebhooksProps, OutgoingWe
                         <PluginLink
                           partial
                           query={{ id: 'new' }}
-                          disabled={!store.isUserActionAllowed(UserActions.OutgoingWebhooksWrite)}
+                          disabled={!isUserActionAllowed(UserActions.OutgoingWebhooksWrite)}
                         >
                           <WithPermissionControl userAction={UserActions.OutgoingWebhooksWrite}>
                             <Button variant="primary" icon="plus">

--- a/grafana-plugin/src/pages/routes.tsx
+++ b/grafana-plugin/src/pages/routes.tsx
@@ -1,6 +1,3 @@
-import { AppRootProps } from '@grafana/data';
-
-import { PageDefinition } from 'pages';
 import EscalationsChainsPage from 'pages/escalation-chains/EscalationChains';
 import IncidentPage from 'pages/incident/Incident';
 import IncidentsPage from 'pages/incidents/Incidents';
@@ -16,21 +13,6 @@ import CloudPage from 'pages/settings/tabs/Cloud/CloudPage';
 import LiveSettingsPage from 'pages/settings/tabs/LiveSettings/LiveSettingsPage';
 import Test from 'pages/test/Test';
 import UsersPage from 'pages/users/Users';
-
-export interface NavMenuItem {
-  meta: AppRootProps['meta'];
-  pages: { [id: string]: PageDefinition };
-  path: string;
-  page: string;
-  grafanaUser: {
-    orgRole: 'Viewer' | 'Editor' | 'Admin';
-  };
-  enableLiveSettings: boolean;
-  enableCloudPage: boolean;
-  enableNewSchedulesPage: boolean;
-  backendLicense: string;
-  onNavChanged: any;
-}
 
 export interface NavRoute {
   id: string;

--- a/grafana-plugin/src/pages/schedule/Schedule.tsx
+++ b/grafana-plugin/src/pages/schedule/Schedule.tsx
@@ -24,7 +24,7 @@ import { pages } from 'pages';
 import { PageProps, WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
 import LocationHelper from 'utils/LocationHelper';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import { getStartOfWeek } from './Schedule.helpers';
 
@@ -106,7 +106,7 @@ class SchedulePage extends React.Component<SchedulePageProps, SchedulePageState>
     const schedule = scheduleStore.items[scheduleId];
 
     const disabled =
-      !store.isUserActionAllowed(UserActions.SchedulesWrite) ||
+      !isUserActionAllowed(UserActions.SchedulesWrite) ||
       schedule?.type !== ScheduleType.API ||
       shiftIdToShowRotationForm ||
       shiftIdToShowOverridesForm;

--- a/grafana-plugin/src/pages/settings/SettingsPage.tsx
+++ b/grafana-plugin/src/pages/settings/SettingsPage.tsx
@@ -11,7 +11,7 @@ import { isTopNavbar } from 'plugin/GrafanaPluginRootPage.helpers';
 import { AppFeature } from 'state/features';
 import { RootBaseStore } from 'state/rootBaseStore';
 import { withMobXProviderContext } from 'state/withStore';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import { SettingsPageTab } from './SettingsPage.types';
 import CloudPage from './tabs/Cloud/CloudPage';
@@ -52,8 +52,8 @@ class SettingsPage extends React.Component<SettingsPageProps, SettingsPageState>
 
     const hasLiveSettings = store.hasFeature(AppFeature.LiveSettings);
     const hasCloudPage = store.hasFeature(AppFeature.CloudConnection);
-    const showCloudPage = hasCloudPage && store.isUserActionAllowed(UserActions.OtherSettingsWrite);
-    const showLiveSettings = hasLiveSettings && store.isUserActionAllowed(UserActions.OtherSettingsRead);
+    const showCloudPage = hasCloudPage && isUserActionAllowed(UserActions.OtherSettingsWrite);
+    const showLiveSettings = hasLiveSettings && isUserActionAllowed(UserActions.OtherSettingsRead);
 
     if (isTopNavbar()) {
       return (

--- a/grafana-plugin/src/pages/settings/tabs/LiveSettings/LiveSettingsPage.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/LiveSettings/LiveSettingsPage.tsx
@@ -13,7 +13,7 @@ import { WithPermissionControl } from 'containers/WithPermissionControl/WithPerm
 import { GlobalSetting } from 'models/global_setting/global_setting.types';
 import { WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import { PLACEHOLDER } from './LiveSettings.config';
 import { normalizeValue, prepareForUpdate } from './LiveSettings.helpers';
@@ -145,7 +145,6 @@ class LiveSettings extends React.Component<LiveSettingsProps, LiveSettingsState>
   };
 
   renderValue = (item: GlobalSetting) => {
-    const { store } = this.props;
     const { hideValues } = this.state;
 
     if (item.value === true || item.value === false) {
@@ -165,7 +164,7 @@ class LiveSettings extends React.Component<LiveSettingsProps, LiveSettingsState>
         <Text
           copyable={!item.is_secret && Boolean(item.value)}
           onTextChange={this.getEditValueChangeHandler(item)}
-          editable={store.isUserActionAllowed(UserActions.OtherSettingsWrite)}
+          editable={isUserActionAllowed(UserActions.OtherSettingsWrite)}
           clearBeforeEdit={item.is_secret}
           hidden={hideValues}
         >

--- a/grafana-plugin/src/pages/users/Users.tsx
+++ b/grafana-plugin/src/pages/users/Users.tsx
@@ -24,7 +24,7 @@ import { pages } from 'pages';
 import { PageProps, WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
 import LocationHelper from 'utils/LocationHelper';
-import { UserActions } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 import { getUserRowClassNameFn } from './Users.helpers';
 
@@ -74,7 +74,7 @@ class Users extends React.Component<UsersProps, UsersState> {
     const { usersFilters, page } = this.state;
     const { userStore } = store;
 
-    if (!store.isUserActionAllowed(UserActions.UserSettingsWrite)) {
+    if (!isUserActionAllowed(UserActions.UserSettingsWrite)) {
       return;
     }
 
@@ -83,9 +83,7 @@ class Users extends React.Component<UsersProps, UsersState> {
   };
 
   componentDidUpdate(prevProps: UsersProps) {
-    const { store } = this.props;
-
-    if (!this.initialUsersLoaded && store.isUserActionAllowed(UserActions.UserSettingsWrite)) {
+    if (!this.initialUsersLoaded && isUserActionAllowed(UserActions.UserSettingsWrite)) {
       this.updateUsers();
       this.initialUsersLoaded = true;
     }
@@ -190,7 +188,7 @@ class Users extends React.Component<UsersProps, UsersState> {
                       </Button>
                     </PluginLink>
                   </div>
-                  {store.isUserActionAllowed(UserActions.UserSettingsRead) ? (
+                  {isUserActionAllowed(UserActions.UserSettingsRead) ? (
                     <>
                       <div className={cx('user-filters-container')}>
                         <UsersFilters
@@ -287,7 +285,7 @@ class Users extends React.Component<UsersProps, UsersState> {
 
     return (
       <VerticalGroup justify="center">
-        <PluginLink partial query={{ id: user.pk }} disabled={!store.isUserActionAllowed(action)}>
+        <PluginLink partial query={{ id: user.pk }} disabled={!isUserActionAllowed(action)}>
           <WithPermissionControl userAction={action}>
             <Button
               className={cx({

--- a/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
+++ b/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
@@ -22,6 +22,7 @@ import { pages } from 'pages';
 import { routes } from 'pages/routes';
 import { rootStore } from 'state';
 import { useStore } from 'state/useStore';
+import { isUserActionAllowed } from 'utils/authorization';
 import { useQueryParams, useQueryPath } from 'utils/hooks';
 
 dayjs.extend(utc);
@@ -85,7 +86,7 @@ export const Root = observer((props: AppRootProps) => {
   }
 
   const { action: pagePermissionAction } = pages[page];
-  const userHasAccess = pagePermissionAction ? store.isUserActionAllowed(pagePermissionAction) : true;
+  const userHasAccess = pagePermissionAction ? isUserActionAllowed(pagePermissionAction) : true;
 
   return (
     <DefaultPageLayout {...props}>

--- a/grafana-plugin/src/state/rootBaseStore/index.ts
+++ b/grafana-plugin/src/state/rootBaseStore/index.ts
@@ -27,10 +27,9 @@ import { Timezone } from 'models/timezone/timezone.types';
 import { UserStore } from 'models/user/user';
 import { UserGroupStore } from 'models/user_group/user_group';
 import { makeRequest } from 'network';
-import { NavMenuItem } from 'pages/routes';
 import { AppFeature } from 'state/features';
 import PluginState from 'state/plugin';
-import { UserActions, isUserActionAllowed } from 'utils/authorization';
+import { isUserActionAllowed, UserActions } from 'utils/authorization';
 
 // ------ Dashboard ------ //
 
@@ -72,9 +71,6 @@ export class RootBaseStore {
 
   @observable
   onCallApiUrl: string;
-
-  @observable
-  navMenuItem: NavMenuItem;
 
   // --------------------------
 
@@ -162,7 +158,7 @@ export class RootBaseStore {
         return this.setupPluginError('🚫 OnCall has temporarily disabled signup of new users. Please try again later.');
       }
 
-      if (!this.isUserActionAllowed(UserActions.PluginsInstall)) {
+      if (!isUserActionAllowed(UserActions.PluginsInstall)) {
         return this.setupPluginError(
           '🚫 An Admin in your organization must sign on and setup OnCall before it can be used'
         );
@@ -198,8 +194,6 @@ export class RootBaseStore {
 
     this.appLoading = false;
   }
-
-  isUserActionAllowed = isUserActionAllowed;
 
   hasFeature(feature: string | AppFeature) {
     // todo use AppFeature only

--- a/grafana-plugin/src/state/rootBaseStore/rootBaseStore.test.ts
+++ b/grafana-plugin/src/state/rootBaseStore/rootBaseStore.test.ts
@@ -1,11 +1,14 @@
 import { OnCallAppPluginMeta } from 'types';
 
 import PluginState from 'state/plugin';
-import { UserActions } from 'utils/authorization';
+import { UserActions, isUserActionAllowed as isUserActionAllowedOriginal } from 'utils/authorization';
 
 import { RootBaseStore } from './';
 
 jest.mock('state/plugin');
+jest.mock('utils/authorization');
+
+const isUserActionAllowed = isUserActionAllowedOriginal as jest.Mock<ReturnType<typeof isUserActionAllowedOriginal>>;
 
 const PluginInstallAction = UserActions.PluginsInstall;
 
@@ -122,7 +125,7 @@ describe('rootBaseStore', () => {
       version: 'asdfasdf',
       license: 'asdfasdf',
     });
-    rootBaseStore.isUserActionAllowed = jest.fn().mockReturnValueOnce(false);
+    isUserActionAllowed.mockReturnValueOnce(false);
     PluginState.installPlugin = jest.fn().mockResolvedValueOnce(null);
 
     // test
@@ -132,8 +135,8 @@ describe('rootBaseStore', () => {
     expect(PluginState.checkIfPluginIsConnected).toHaveBeenCalledTimes(1);
     expect(PluginState.checkIfPluginIsConnected).toHaveBeenCalledWith(onCallApiUrl);
 
-    expect(rootBaseStore.isUserActionAllowed).toHaveBeenCalledTimes(1);
-    expect(rootBaseStore.isUserActionAllowed).toHaveBeenCalledWith(PluginInstallAction);
+    expect(isUserActionAllowed).toHaveBeenCalledTimes(1);
+    expect(isUserActionAllowed).toHaveBeenCalledWith(PluginInstallAction);
 
     expect(PluginState.installPlugin).toHaveBeenCalledTimes(0);
 
@@ -159,7 +162,7 @@ describe('rootBaseStore', () => {
       version: 'asdfasdf',
       license: 'asdfasdf',
     });
-    rootBaseStore.isUserActionAllowed = jest.fn().mockReturnValueOnce(true);
+    isUserActionAllowed.mockReturnValueOnce(true);
     PluginState.installPlugin = jest.fn().mockResolvedValueOnce(null);
     rootBaseStore.userStore.loadCurrentUser = mockedLoadCurrentUser;
 
@@ -170,8 +173,8 @@ describe('rootBaseStore', () => {
     expect(PluginState.checkIfPluginIsConnected).toHaveBeenCalledTimes(1);
     expect(PluginState.checkIfPluginIsConnected).toHaveBeenCalledWith(onCallApiUrl);
 
-    expect(rootBaseStore.isUserActionAllowed).toHaveBeenCalledTimes(1);
-    expect(rootBaseStore.isUserActionAllowed).toHaveBeenCalledWith(PluginInstallAction);
+    expect(isUserActionAllowed).toHaveBeenCalledTimes(1);
+    expect(isUserActionAllowed).toHaveBeenCalledWith(PluginInstallAction);
 
     expect(PluginState.installPlugin).toHaveBeenCalledTimes(1);
     expect(PluginState.installPlugin).toHaveBeenCalledWith();
@@ -198,7 +201,7 @@ describe('rootBaseStore', () => {
       version: 'asdfasdf',
       license: 'asdfasdf',
     });
-    rootBaseStore.isUserActionAllowed = jest.fn().mockReturnValueOnce(true);
+    isUserActionAllowed.mockReturnValueOnce(true);
     PluginState.installPlugin = jest.fn().mockRejectedValueOnce(installPluginError);
     PluginState.getHumanReadableErrorFromOnCallError = jest.fn().mockReturnValueOnce(humanReadableErrorMsg);
 
@@ -209,8 +212,8 @@ describe('rootBaseStore', () => {
     expect(PluginState.checkIfPluginIsConnected).toHaveBeenCalledTimes(1);
     expect(PluginState.checkIfPluginIsConnected).toHaveBeenCalledWith(onCallApiUrl);
 
-    expect(rootBaseStore.isUserActionAllowed).toHaveBeenCalledTimes(1);
-    expect(rootBaseStore.isUserActionAllowed).toHaveBeenCalledWith(PluginInstallAction);
+    expect(isUserActionAllowed).toHaveBeenCalledTimes(1);
+    expect(isUserActionAllowed).toHaveBeenCalledWith(PluginInstallAction);
 
     expect(PluginState.installPlugin).toHaveBeenCalledTimes(1);
     expect(PluginState.installPlugin).toHaveBeenCalledWith();


### PR DESCRIPTION
**What this PR does**:
Previously the top tab bar (eg. "Alert Groups", "Users", etc) would show user tabs that they weren't authorized to see. This PR will hide tabs that user's don't have access to.

**Which issue(s) this PR fixes**:

In addition it:
- removes `RootBaseStore.isUserActionAllowed` as this was simply a reference to the `isUserActionAllowed` function from `utils/authorization`. When I wanted to access this method in `pages/index.ts` I needed to have an instance of a `RootBaseStore` which seemed awkward. Refactored all references to `RootBaseStore.isUserActionAllowed`.
- removed `NavMenuItem` from `pages/routes.tsx` and `RootBaseStore.navMenuItem` attribute. Neither of these seemed referenced in `oncall` and `oncall-private` repos. I wanted to remove `NavMenuItem` initially because I saw it made a reference to Admin/Editor/Viewer..

**Checklist**
- [x] Tests updated
- [x] Documentation added (N/A)
- [x] `CHANGELOG.md` updated (this is related to recent RBAC work,  no need to update)