### PR TITLE
docker-compose small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We prepared multiple environments:
 3. Launch services:
 
    ```bash
-   docker-compose up -d
+   docker-compose pull && docker-compose up -d
    ```
 
 4. Go to [OnCall Plugin Configuration](http://localhost:3000/plugins/grafana-oncall-app), using log in credentials

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -181,7 +181,7 @@ services:
     container_name: mysql
     labels: *oncall-labels
     image: mysql:5.7
-    platform: linux/x86_64
+    platform: linux/amd64
     command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
     environment:
@@ -208,7 +208,7 @@ services:
     container_name: mysql_to_create_grafana_db
     labels: *oncall-labels
     image: mysql:5.7
-    platform: linux/x86_64
+    platform: linux/amd64
     command: bash -c "mysql -h mysql -uroot -pempty -e 'CREATE DATABASE IF NOT EXISTS grafana CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
     depends_on:
       mysql:


### PR DESCRIPTION
- Make sure the latest docker image is used for hobby setup by running `docker-compose pull` before `docker-compose up`
- Use `linux/amd64` as mysql platform in `docker-compose-developer.yml`, should fix Apple Silicon issues