### PR TITLE
helm chart v1.0.13 - update appVersion to v1.1.5 + change image.pullPolicy to "Always"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Got 500 error when saving Outgoing Webhook ([#890](https://github.com/grafana/oncall/issues/890))
+- v1.0.13 helm chart - update the OnCall backend pods image pull policy to "Always" (and explicitly set tag to `latest`).
+  This should resolve some recent issues experienced where the frontend/backend versions are not aligned.
 
 ### Changed
 

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -2,25 +2,23 @@ apiVersion: v2
 name: oncall
 description: Developer-friendly incident response with brilliant Slack integration
 
-
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.12
+version: 1.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.1.0"
+appVersion: "v1.1.5"
 dependencies:
   - name: cert-manager
     version: v1.8.0
     repository: https://charts.jetstack.io
     condition: cert-manager.enabled
-
   - name: mariadb
     version: 11.0.10
     repository: https://charts.bitnami.com/bitnami

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -7,7 +7,7 @@ base_url: example.com
 image:
   # Grafana OnCall docker image repository
   repository: grafana/oncall
-  tag: latest
+  tag:
   pullPolicy: Always
 
 # Whether to create additional service for external connections

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -7,8 +7,8 @@ base_url: example.com
 image:
   # Grafana OnCall docker image repository
   repository: grafana/oncall
-  tag:
-  pullPolicy: IfNotPresent
+  tag: latest
+  pullPolicy: Always
 
 # Whether to create additional service for external connections
 # ClusterIP service is always created
@@ -147,7 +147,7 @@ env: {}
 # Enable ingress object for external access to the resources
 ingress:
   enabled: true
-#  className: ""
+  #  className: ""
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/issuer: "letsencrypt-prod"
@@ -155,8 +155,8 @@ ingress:
     - hosts:
         - "{{ .Values.base_url }}"
       secretName: certificate-tls
-  # Extra paths to prepend to the host configuration. If using something 
-  # like an ALB ingress controller, you may want to configure SSL redirects 
+  # Extra paths to prepend to the host configuration. If using something
+  # like an ALB ingress controller, you may want to configure SSL redirects
   extraPaths: []
   # - path: /*
   #   backend:
@@ -206,16 +206,16 @@ mariadb:
     database: oncall
   primary:
     extraEnvVars:
-    - name: MARIADB_COLLATE
-      value: utf8mb4_unicode_ci
-    - name: MARIADB_CHARACTER_SET
-      value: utf8mb4
+      - name: MARIADB_COLLATE
+        value: utf8mb4_unicode_ci
+      - name: MARIADB_CHARACTER_SET
+        value: utf8mb4
   secondary:
     extraEnvVars:
-    - name: MARIADB_COLLATE
-      value: utf8mb4_unicode_ci
-    - name: MARIADB_CHARACTER_SET
-      value: utf8mb4
+      - name: MARIADB_COLLATE
+        value: utf8mb4_unicode_ci
+      - name: MARIADB_CHARACTER_SET
+        value: utf8mb4
 
 # Make sure to create the database with the following parameters:
 # CREATE DATABASE oncall CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;


### PR DESCRIPTION
# What this PR does
Instructs helm deployments to always pull the latest `grafana/oncall` image.

## Which issue(s) this PR fixes

This resolves some issues reported by the community where the plugin was not able to be configured. I was able to reproduce this locally by running 1.1.5 of the plugin in the UI, and `grafana/oncall:1.1.0` (the default that my helm deployment decided to use). With this version combination I was unable to successfully configure the plugin (likely due to some changes in [v1.1.3](https://github.com/grafana/oncall/releases/tag/v1.1.3)).

When I switched the engine image pull policy to "Always" and updated my helm deployment, this fixed the issue.

## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added
- [x] `CHANGELOG.md` updated
