### PR TITLE
only grant admins read/write access to public api keys

### DIFF
--- a/engine/apps/api/permissions/__init__.py
+++ b/engine/apps/api/permissions/__init__.py
@@ -140,10 +140,10 @@ class RBACPermission(permissions.BasePermission):
         )
 
         API_KEYS_READ = LegacyAccessControlCompatiblePermission(
-            Resources.API_KEYS, Actions.READ, LegacyAccessControlRole.VIEWER
+            Resources.API_KEYS, Actions.READ, LegacyAccessControlRole.ADMIN
         )
         API_KEYS_WRITE = LegacyAccessControlCompatiblePermission(
-            Resources.API_KEYS, Actions.WRITE, LegacyAccessControlRole.EDITOR
+            Resources.API_KEYS, Actions.WRITE, LegacyAccessControlRole.ADMIN
         )
 
         NOTIFICATIONS_READ = LegacyAccessControlCompatiblePermission(

--- a/engine/apps/api/tests/test_public_api_tokens.py
+++ b/engine/apps/api/tests/test_public_api_tokens.py
@@ -11,8 +11,8 @@ from apps.api.permissions import LegacyAccessControlRole
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
-        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_public_api_tokens_retrieve_permissions(
@@ -37,8 +37,8 @@ def test_public_api_tokens_retrieve_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
-        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
 def test_public_api_tokens_list_permissions(
@@ -63,7 +63,7 @@ def test_public_api_tokens_list_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_201_CREATED),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_201_CREATED),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -94,7 +94,7 @@ def test_public_api_tokens_create_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )

--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -260,9 +260,6 @@
           { "action": "grafana-oncall-app.maintenance:read" },
           { "action": "grafana-oncall-app.maintenance:write" },
 
-          { "action": "grafana-oncall-app.api-keys:read" },
-          { "action": "grafana-oncall-app.api-keys:write" },
-
           { "action": "grafana-oncall-app.notifications:read" },
 
           { "action": "grafana-oncall-app.notification-settings:read" },
@@ -290,7 +287,6 @@
           { "action": "grafana-oncall-app.chatops:read" },
           { "action": "grafana-oncall-app.outgoing-webhooks:read" },
           { "action": "grafana-oncall-app.maintenance:read" },
-          { "action": "grafana-oncall-app.api-keys:read" },
           { "action": "grafana-oncall-app.notification-settings:read" },
           { "action": "grafana-oncall-app.user-settings:read" },
           { "action": "grafana-oncall-app.other-settings:read" }
@@ -317,7 +313,6 @@
           { "action": "grafana-oncall-app.chatops:read" },
           { "action": "grafana-oncall-app.outgoing-webhooks:read" },
           { "action": "grafana-oncall-app.maintenance:read" },
-          { "action": "grafana-oncall-app.api-keys:read" },
           { "action": "grafana-oncall-app.notification-settings:read" },
           { "action": "grafana-oncall-app.user-settings:read" },
           { "action": "grafana-oncall-app.other-settings:read" }

--- a/grafana-plugin/src/utils/authorization/index.ts
+++ b/grafana-plugin/src/utils/authorization/index.ts
@@ -135,8 +135,8 @@ export const UserActions: { [action in Actions]: UserAction } = {
   MaintenanceRead: constructAction(Resource.MAINTENANCE, Action.READ, OrgRole.Viewer),
   MaintenanceWrite: constructAction(Resource.MAINTENANCE, Action.WRITE, OrgRole.Editor),
 
-  APIKeysRead: constructAction(Resource.API_KEYS, Action.READ, OrgRole.Viewer),
-  APIKeysWrite: constructAction(Resource.API_KEYS, Action.WRITE, OrgRole.Editor),
+  APIKeysRead: constructAction(Resource.API_KEYS, Action.READ, OrgRole.Admin),
+  APIKeysWrite: constructAction(Resource.API_KEYS, Action.WRITE, OrgRole.Admin),
 
   NotificationsRead: constructAction(Resource.NOTIFICATIONS, Action.READ, OrgRole.Editor),
 


### PR DESCRIPTION
# What this PR does

Previously we only allowed Admins to read/write OnCall public API keys, this PR reverts the current behaviour back to that:
![image](https://user-images.githubusercontent.com/9406895/205848535-87c4f2cd-3fb8-4c80-a692-88d52ff312c3.png)


## Which issue(s) this PR fixes

## Checklist

- [x] Tests updated
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A; this change should be "rolled into" the recent RBAC commit)
