### PR TITLE
Make job-migrate ttlSecondsAfterFinished customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to update values that may be invalid
 - Add a `permalinks.web` field, which is a permalink to the alert group web app page, to the alert group internal/public
   API responses
+- Added the ability to customize job-migrate `ttlSecondsAfterFinished` field in the helm chart
 
 ### Fixed
 

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.13
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -7,7 +7,9 @@ metadata:
     {{- include "oncall.engine.labels" . | nindent 4 }}
 spec:
   backoffLimit: 15
-  ttlSecondsAfterFinished: 20
+  {{- if .Values.migrate.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migrate.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ printf "%s-migrate-%s" (include "oncall.engine.fullname" .) (now | date "2006-01-02-15-04-05") }}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -140,6 +140,7 @@ oncall:
 # Whether to run django database migrations automatically
 migrate:
   enabled: true
+  ttlSecondsAfterFinished: 20
 
 # Additional env variables to add to deployments
 env: {}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -140,6 +140,7 @@ oncall:
 # Whether to run django database migrations automatically
 migrate:
   enabled: true
+  # TTL can be unset by setting ttlSecondsAfterFinished: ""
   ttlSecondsAfterFinished: 20
 
 # Additional env variables to add to deployments


### PR DESCRIPTION
# What this PR does

Currently, `.spec.ttlSecondsAfterFinished` field is hardcoded within the template. This PR allows to customize this field without changing the default functionality of the app.

Having a ttl set can cause sync issues if the app is deployed via GitOps tools such as ArgoCD. https://github.com/argoproj/argo-cd/discussions/8247

To disable TTL mechanism entirely, we can set `ttlSecondsAfterFinished` to `""` or `null` in `values.yaml`.

From kubernetes [docs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs):

> If the field is unset, this Job won't be cleaned up by the TTL controller after it finishes.

## Which issue(s) this PR fixes

## Checklist

- [x] Tests updated
- [x] Documentation added
- [x] `CHANGELOG.md` updated
