### PR TITLE
Fixed error while creating schedule and fixed Schedules types mistakes

### DIFF
--- a/grafana-plugin/src/components/NewScheduleSelector/NewScheduleSelector.tsx
+++ b/grafana-plugin/src/components/NewScheduleSelector/NewScheduleSelector.tsx
@@ -50,7 +50,7 @@ const NewScheduleSelector: FC<NewScheduleSelectorProps> = (props) => {
                   </VerticalGroup>
                 </HorizontalGroup>
                 <WithPermissionControl userAction={UserActions.SchedulesWrite}>
-                  <Button variant="primary" icon="plus" onClick={getCreateScheduleClickHandler(ScheduleType.API)}>
+                  <Button variant="primary" icon="plus" onClick={getCreateScheduleClickHandler(ScheduleType.Calendar)}>
                     Create
                   </Button>
                 </WithPermissionControl>

--- a/grafana-plugin/src/components/SchedulesFilters_NEW/SchedulesFilters.tsx
+++ b/grafana-plugin/src/components/SchedulesFilters_NEW/SchedulesFilters.tsx
@@ -72,7 +72,7 @@ const SchedulesFilters = (props: SchedulesFiltersProps) => {
               { label: 'All', value: undefined },
               {
                 label: 'Web',
-                value: ScheduleType.API,
+                value: ScheduleType.Calendar,
               },
               {
                 label: 'ICal',
@@ -80,7 +80,7 @@ const SchedulesFilters = (props: SchedulesFiltersProps) => {
               },
               {
                 label: 'API',
-                value: ScheduleType.Calendar,
+                value: ScheduleType.API,
               },
             ]}
             value={value?.type}

--- a/grafana-plugin/src/models/schedule/schedule.types.ts
+++ b/grafana-plugin/src/models/schedule/schedule.types.ts
@@ -6,9 +6,9 @@ import { User } from 'models/user/user.types';
 import { UserGroup } from 'models/user_group/user_group.types';
 
 export enum ScheduleType {
-  'Calendar',
-  'Ical',
   'API',
+  'Ical',
+  'Calendar',
 }
 
 export interface RotationFormLiveParams {

--- a/grafana-plugin/src/pages/schedule/Schedule.tsx
+++ b/grafana-plugin/src/pages/schedule/Schedule.tsx
@@ -147,9 +147,12 @@ class SchedulePage extends React.Component<SchedulePageProps, SchedulePageState>
                         )}
                         <HorizontalGroup>
                           <HorizontalGroup>
-                            <Button variant="secondary" onClick={this.handleExportClick()}>
-                              Export
-                            </Button>
+                            {schedule?.type === ScheduleType.Ical && (
+                              <Button variant="secondary" onClick={this.handleExportClick()}>
+                                Export
+                              </Button>
+                            )}
+
                             {(schedule?.type === ScheduleType.Ical || schedule?.type === ScheduleType.Calendar) && (
                               <Button variant="secondary" onClick={this.handleReloadClick(scheduleId)}>
                                 Reload

--- a/grafana-plugin/src/pages/schedules/Schedules.tsx
+++ b/grafana-plugin/src/pages/schedules/Schedules.tsx
@@ -209,8 +209,8 @@ class SchedulesPage extends React.Component<SchedulesPageProps, SchedulesPageSta
   };
 
   handleCreateSchedule = (data: Schedule) => {
-    if (data.type === ScheduleType.API) {
-      LocationHelper.update({ page: 'schedule', id: data.id }, 'replace');
+    if (data.type === ScheduleType.Calendar) {
+      LocationHelper.update({ page: 'schedule', id: data.id }, 'partial');
     }
   };
 


### PR DESCRIPTION
# What this PR does

- Fixes the crash while creating Web Schedule
- Fixes the mistake in Schedules types. Because in the backend types are a bit different, so now Web is type 2 and API is type 0

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
