### PR TITLE
Added existingSecret support for mysql and redis

### DIFF
--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -182,6 +182,8 @@ externalMysql:
   db_name:
   user:
   password:
+  existingSecret: ""
+  passwordKey: ""
 ```
 
 ### Connect external PostgreSQL
@@ -246,6 +248,8 @@ redis:
 externalRedis:
   host:
   password:
+  existingSecret: ""
+  passwordKey: ""
 ```
 
 ## Update

--- a/helm/oncall/templates/secrets.yaml
+++ b/helm/oncall/templates/secrets.yaml
@@ -11,14 +11,14 @@ data:
   {{ template "snippet.oncall.secret.mirageSecretKey" . }}: {{ randAlphaNum 40 | b64enc | quote }}
 {{- end }}
 ---
-{{ if and (not .Values.mariadb.enabled) (eq .Values.database.type "mysql") -}}
+{{ if and (not .Values.mariadb.enabled) (eq .Values.database.type "mysql") (not .Values.externalMysql.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "oncall.fullname" . }}-mysql-external
 type: Opaque
 data:
-  mariadb-root-password: {{ required "externalMysql.password is required if not mariadb.enabled" .Values.externalMysql.password | b64enc | quote }}
+  mariadb-root-password: {{ required "externalMysql.password is required if not mariadb.enabled and not externalMysql.existingSecret" .Values.externalMysql.password | b64enc | quote }}
 {{- end }}
 ---
 {{ if and (eq .Values.broker.type "rabbitmq") (not .Values.rabbitmq.enabled) (not .Values.externalRabbitmq.existingSecret) -}}
@@ -31,14 +31,14 @@ data:
   rabbitmq-password: {{ required "externalRabbitmq.password is required if not rabbitmq.enabled and not externalRabbitmq.existingSecret" .Values.externalRabbitmq.password | b64enc | quote }}
 {{- end }}
 ---
-{{ if not .Values.redis.enabled -}}
+{{ if and (not .Values.redis.enabled) (not .Values.externalRedis.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "oncall.fullname" . }}-redis-external
 type: Opaque
 data:
-  redis-password: {{ required "externalRedis.password is required if not redis.enabled" .Values.externalRedis.password | b64enc | quote }}
+  redis-password: {{ required "externalRedis.password is required if not redis.enabled and not externalRedis.existingSecret" .Values.externalRedis.password | b64enc | quote }}
 {{- end }}
 ---
 {{ if and .Values.oncall.smtp.enabled .Values.oncall.smtp.password -}}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -227,6 +227,10 @@ externalMysql:
   db_name:
   user:
   password:
+  # use an existing secret for the database password
+  existingSecret: ""
+  # the key in the secret containing the database password
+  passwordKey: ""
 
 # PostgreSQL is included into this release for the convenience.
 # It is recommended to host it separately from this release
@@ -280,6 +284,10 @@ redis:
 externalRedis:
   host:
   password:
+  # use an existing secret for the redis password
+  existingSecret: ""
+  # the key in the secret containing the redis password
+  passwordKey: ""
 
 # Grafana is included into this release for the convenience.
 # It is recommended to host it separately from this release


### PR DESCRIPTION
# What this PR does
Adds existingSecret support for mysql and redis;
Fixes layout of templates/_env.tpl for redis to follow the same format across the whole file (main snippet -> snippets for fields)

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/955

## Checklist

- [ ] Tests updated
- [x] Documentation added
- [ ] `CHANGELOG.md` updated

Not sure is CHANGELOG should be updated, but can do this easily if required.