### PR TITLE
Update SCHEDULES_WRITE fallback role to EDITOR

### DIFF
--- a/engine/apps/api/permissions/__init__.py
+++ b/engine/apps/api/permissions/__init__.py
@@ -109,7 +109,7 @@ class RBACPermission(permissions.BasePermission):
             Resources.SCHEDULES, Actions.READ, LegacyAccessControlRole.VIEWER
         )
         SCHEDULES_WRITE = LegacyAccessControlCompatiblePermission(
-            Resources.SCHEDULES, Actions.WRITE, LegacyAccessControlRole.ADMIN
+            Resources.SCHEDULES, Actions.WRITE, LegacyAccessControlRole.EDITOR
         )
         SCHEDULES_EXPORT = LegacyAccessControlCompatiblePermission(
             Resources.SCHEDULES, Actions.EXPORT, LegacyAccessControlRole.EDITOR

--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -926,7 +926,7 @@ def test_create_on_call_shift_override_invalid_data(on_call_shift_internal_api_s
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_201_CREATED),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_201_CREATED),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -958,7 +958,7 @@ def test_on_call_shift_create_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -1080,7 +1080,7 @@ def test_on_call_shift_retrieve_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -1185,7 +1185,7 @@ def test_on_call_shift_days_options_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1204,7 +1204,7 @@ def test_filter_events_invalid_type(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -1242,7 +1242,7 @@ def test_schedule_create_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -1360,7 +1360,7 @@ def test_schedule_retrieve_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_204_NO_CONTENT),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_204_NO_CONTENT),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -1436,7 +1436,7 @@ def test_events_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
         (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
     ],
 )

--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -250,6 +250,7 @@
           { "action": "grafana-oncall-app.escalation-chains:read" },
 
           { "action": "grafana-oncall-app.schedules:read" },
+          { "action": "grafana-oncall-app.schedules:write" },
           { "action": "grafana-oncall-app.schedules:export" },
 
           { "action": "grafana-oncall-app.chatops:read" },

--- a/grafana-plugin/src/utils/authorization/index.ts
+++ b/grafana-plugin/src/utils/authorization/index.ts
@@ -122,7 +122,7 @@ export const UserActions: { [action in Actions]: UserAction } = {
   EscalationChainsWrite: constructAction(Resource.ESCALATION_CHAINS, Action.WRITE, OrgRole.Admin),
 
   SchedulesRead: constructAction(Resource.SCHEDULES, Action.READ, OrgRole.Viewer),
-  SchedulesWrite: constructAction(Resource.SCHEDULES, Action.WRITE, OrgRole.Admin),
+  SchedulesWrite: constructAction(Resource.SCHEDULES, Action.WRITE, OrgRole.Editor),
   SchedulesExport: constructAction(Resource.SCHEDULES, Action.WRITE, OrgRole.Editor),
 
   ChatOpsRead: constructAction(Resource.CHATOPS, Action.READ, OrgRole.Viewer),


### PR DESCRIPTION
Fix for `EDITOR` users not having perms to be considered oncall in a schedule (because of changes in RBAC and the related fallback config). 