### PR TITLE
fix cloud sync related issue

### DIFF
--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -17,18 +17,7 @@ def sync_organization(organization):
     rbac_is_enabled = client.is_rbac_enabled_for_organization()
     organization.is_rbac_permissions_enabled = rbac_is_enabled
 
-    if organization.gcom_token:
-        gcom_client = GcomAPIClient(organization.gcom_token)
-        instance_info = gcom_client.get_instance_info(organization.stack_id)
-        if not instance_info or str(instance_info["orgId"]) != organization.org_id:
-            return
-
-        organization.stack_slug = instance_info["slug"]
-        organization.org_slug = instance_info["orgSlug"]
-        organization.org_title = instance_info["orgName"]
-        organization.region_slug = instance_info["regionSlug"]
-        organization.grafana_url = instance_info["url"]
-        organization.gcom_token_org_last_time_synced = timezone.now()
+    _sync_instance_info(organization)
 
     api_users = client.get_users(rbac_is_enabled)
 
@@ -51,6 +40,22 @@ def sync_organization(organization):
             "is_rbac_permissions_enabled",
         ]
     )
+
+
+def _sync_instance_info(organization):
+    if organization.gcom_token:
+        gcom_client = GcomAPIClient(organization.gcom_token)
+        instance_info, _ = gcom_client.get_instance_info(organization.stack_id)
+
+        if not instance_info or instance_info["orgId"] != organization.org_id:
+            return
+
+        organization.stack_slug = instance_info["slug"]
+        organization.org_slug = instance_info["orgSlug"]
+        organization.org_title = instance_info["orgName"]
+        organization.region_slug = instance_info["regionSlug"]
+        organization.grafana_url = instance_info["url"]
+        organization.gcom_token_org_last_time_synced = timezone.now()
 
 
 def sync_users_and_teams(client, api_users, organization):


### PR DESCRIPTION
this PR reverts [this change](https://github.com/grafana/oncall/commit/9e598385f492df6d7fd336c0ef441762fc4f3a72#diff-a74aa8f07a8fdc31af66559390f0fc77b66692d43e6d3c5f94311ef7eed5efabL19-L55) and removes the `str` casting that was done on the `orgId` field returned from the Grafana COM API