### PR TITLE
Fix schedules types UI confusion

### DIFF
--- a/grafana-plugin/src/components/NewScheduleSelector/NewScheduleSelector.tsx
+++ b/grafana-plugin/src/components/NewScheduleSelector/NewScheduleSelector.tsx
@@ -50,7 +50,7 @@ const NewScheduleSelector: FC<NewScheduleSelectorProps> = (props) => {
                   </VerticalGroup>
                 </HorizontalGroup>
                 <WithPermissionControl userAction={UserActions.SchedulesWrite}>
-                  <Button variant="primary" icon="plus" onClick={getCreateScheduleClickHandler(ScheduleType.Calendar)}>
+                  <Button variant="primary" icon="plus" onClick={getCreateScheduleClickHandler(ScheduleType.API)}>
                     Create
                   </Button>
                 </WithPermissionControl>

--- a/grafana-plugin/src/components/SchedulesFilters_NEW/SchedulesFilters.tsx
+++ b/grafana-plugin/src/components/SchedulesFilters_NEW/SchedulesFilters.tsx
@@ -72,7 +72,7 @@ const SchedulesFilters = (props: SchedulesFiltersProps) => {
               { label: 'All', value: undefined },
               {
                 label: 'Web',
-                value: ScheduleType.Calendar,
+                value: ScheduleType.API,
               },
               {
                 label: 'ICal',
@@ -80,7 +80,7 @@ const SchedulesFilters = (props: SchedulesFiltersProps) => {
               },
               {
                 label: 'API',
-                value: ScheduleType.API,
+                value: ScheduleType.Calendar,
               },
             ]}
             value={value?.type}

--- a/grafana-plugin/src/models/schedule/schedule.types.ts
+++ b/grafana-plugin/src/models/schedule/schedule.types.ts
@@ -6,9 +6,9 @@ import { User } from 'models/user/user.types';
 import { UserGroup } from 'models/user_group/user_group.types';
 
 export enum ScheduleType {
-  'API',
-  'Ical',
   'Calendar',
+  'Ical',
+  'API',
 }
 
 export interface RotationFormLiveParams {

--- a/grafana-plugin/src/pages/schedules/Schedules.tsx
+++ b/grafana-plugin/src/pages/schedules/Schedules.tsx
@@ -209,7 +209,7 @@ class SchedulesPage extends React.Component<SchedulesPageProps, SchedulesPageSta
   };
 
   handleCreateSchedule = (data: Schedule) => {
-    if (data.type === ScheduleType.Calendar) {
+    if (data.type === ScheduleType.API) {
       LocationHelper.update({ page: 'schedule', id: data.id }, 'partial');
     }
   };


### PR DESCRIPTION
Reverting some changes from https://github.com/grafana/oncall/pull/958 (still, types can be confusing, maybe we need to rename things in the enum?)