### PR TITLE
Helm: define engine update strategy in values.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added ability to change engine deployment update strategy via values in helm chart.
 - removed APNS support
 - changed the `django-push-notification` library from the `iskhakov` fork to the [`grafana` fork](https://github.com/grafana/django-push-notifications).
   This new fork basically patches an issue which affected the database migrations of this django app (previously the

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/oncall/templates/engine/deployment.yaml
+++ b/helm/oncall/templates/engine/deployment.yaml
@@ -10,10 +10,7 @@ spec:
     matchLabels:
       {{- include "oncall.engine.selectorLabels" . | nindent 6 }}
   strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 0
-    type: RollingUpdate
+    {{- toYaml .Values.engine.updateStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -29,6 +29,14 @@ engine:
     #   cpu: 100m
     #   memory: 128Mi
 
+  ## Deployment update strategy
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  updateStrategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+    type: RollingUpdate
+
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}


### PR DESCRIPTION
# What this PR does
Now it is possible to change engine deployment update strategy in values.yaml.
## Which issue(s) this PR fixes
This is due to #334 and #316, as with rolling update, race conditions might happen when there is still an old engine pod running.