### PR TITLE
add make command to configure mobile app feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.1.8 (2022-12-13)
 
+### Added
+
+- Added a `make` command, `enable-mobile-app-feature-flags`, which sets the backend feature flag in `./dev/.env.dev`,
+  and updates a record in the `base_dynamicsetting` database table, which are needed to enable the mobile
+  app backend features.
+
 ### Changed
 
 - removed APNS support

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ engine-manage:
 exec-engine:
 	docker exec -it oncall_engine bash
 
+_enable-mobile-app-feature-flags:
+	$(shell ./dev/add_env_var.sh FEATURE_MOBILE_APP_INTEGRATION_ENABLED True $(DEV_ENV_FILE))
+	$(call run_engine_docker_command,python manage.py enable_mobile_app)
+
+enable-mobile-app-feature-flags: _enable-mobile-app-feature-flags stop start
+
 # The below commands are useful for running backend services outside of docker
 define backend_command
 	export `grep -v '^#' $(DEV_ENV_FILE) | xargs -0` && \

--- a/dev/README.md
+++ b/dev/README.md
@@ -120,6 +120,10 @@ make build # rebuild images (e.g. when changing requirements.txt)
 # run Django's `manage.py` script, inside of a docker container, passing `$CMD` as arguments.
 # e.g. `make engine-manage CMD="makemigrations"` - https://docs.djangoproject.com/en/4.1/ref/django-admin/#django-admin-makemigrations
 make engine-manage CMD="..."
+# sets a feature flag, related to mobile app backend functionality, in your ./dev/.env.dev
+# and sets the necessary database values
+# NOTE: you need to enable, and configure, the plugin before running this command
+make enable-mobile-app-feature-flags
 
 # this will remove all of the images, containers, volumes, and networks
 # associated with your local OnCall developer setup

--- a/dev/add_env_var.sh
+++ b/dev/add_env_var.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# https://gist.github.com/maxpoletaev/4ed25183427a2cd7e57a
+
+case "$OSTYPE" in
+    darwin*)  PLATFORM="OSX" ;;
+    linux*)   PLATFORM="LINUX" ;;
+    bsd*)     PLATFORM="BSD" ;;
+    *)        PLATFORM="UNKNOWN" ;;
+esac
+
+replace() {
+    if [[ "$PLATFORM" == "OSX" || "$PLATFORM" == "BSD" ]]; then
+        sed -i "" "$1" "$2"
+    elif [ "$PLATFORM" == "LINUX" ]; then
+        sed -i "$1" "$2"
+    fi
+}
+
+if grep -q $1 $3; then
+    # file contains string, lets replace it
+    # https://stackoverflow.com/a/42667816 - why we need the -i ''
+    replace "s~$1=.*~$1=$2~g" $3
+else
+    # file doesn't contain string, lets append it
+    echo "$1=$2" >> $3
+fi

--- a/engine/engine/management/commands/enable_mobile_app.py
+++ b/engine/engine/management/commands/enable_mobile_app.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.base.models.dynamic_setting import DynamicSetting
+from apps.user_management.models.organization import Organization
+
+
+class Command(BaseCommand):
+    note = "Note: you will also need to set the appropriate environment variables in your ./dev/.env.dev file."
+    help = f"Handles the database portion of enabling the mobile app related features. {note}"
+
+    def handle(self, *args, **options):
+        org = Organization.objects.first()
+
+        if not org:
+            raise CommandError("No organization exists. Have you enabled, and configured, the plugin?")
+
+        DynamicSetting.objects.update_or_create(
+            name="mobile_app_settings", defaults={"json_value": {"org_ids": [org.pk]}}
+        )
+
+        self.stdout.write(self.style.SUCCESS(f"Mobile app successfully enabled."))


### PR DESCRIPTION
# What this PR does

Adds a make command, `enable-mobile-app-feature-flags`, which sets the backend feature flag in `./dev/.env.dev`, and updates a record in the `base_dynamicsetting` database table, which are needed to enable the mobile app backend features.

## Which issue(s) this PR fixes

closes #963 

## Checklist

- [ ] Tests updated (N/A)
- [x] Documentation added
- [x] `CHANGELOG.md` updated
