### PR TITLE
modify push notification settings + use fcm-django library

### DIFF
--- a/.github/workflows/helm_tests.yml
+++ b/.github/workflows/helm_tests.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx # We need this step for docker caching
+      - name: Set up Docker Buildx  # We need this step for docker caching
         uses: docker/setup-buildx-action@v2
 
-      - name: Build docker image locally # using github actions docker cache
+      - name: Build docker image locally  # using github actions docker cache
         uses: docker/build-push-action@v2
         with:
           context: ./engine
@@ -40,7 +40,7 @@ jobs:
         with:
           workloads: "" # all
           namespace: "" # default
-          timeout: 1000
+          timeout: 300
           max-restarts: 0
 
       - name: Bootstrap organization and integration

--- a/.github/workflows/helm_tests.yml
+++ b/.github/workflows/helm_tests.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up Docker Buildx  # We need this step for docker caching
+      - name: Set up Docker Buildx # We need this step for docker caching
         uses: docker/setup-buildx-action@v2
 
-      - name: Build docker image locally  # using github actions docker cache
+      - name: Build docker image locally # using github actions docker cache
         uses: docker/build-push-action@v2
         with:
           context: ./engine
@@ -40,7 +40,7 @@ jobs:
         with:
           workloads: "" # all
           namespace: "" # default
-          timeout: 300
+          timeout: 1000
           max-restarts: 0
 
       - name: Bootstrap organization and integration

--- a/dev/README.md
+++ b/dev/README.md
@@ -13,6 +13,7 @@
   - [Could not build wheels for cryptography which use PEP 517 and cannot be installed directly](#could-not-build-wheels-for-cryptography-which-use-pep-517-and-cannot-be-installed-directly)
   - [django.db.utils.OperationalError: (1366, "Incorrect string value")](#djangodbutilsoperationalerror-1366-incorrect-string-value)
   - [/bin/sh: line 0: cd: grafana-plugin: No such file or directory](#binsh-line-0-cd-grafana-plugin-no-such-file-or-directory)
+  - [Encountered error while trying to install package - grpcio](#encountered-error-while-trying-to-install-package---grpcio)
 - [IDE Specific Instructions](#ide-specific-instructions)
   - [PyCharm](#pycharm)
 
@@ -278,6 +279,34 @@ clear everything in docker by resetting or:
 
 ```bash
 make cleanup
+```
+
+### Encountered error while trying to install package - grpcio
+
+**Problem:**
+
+We are currently using a library, `fcm-django`, which has a dependency on `grpcio`. Google does not provide `grpcio`
+wheels built for Apple Silicon Macs. The best solution so far has been to use a `conda` virtualenv. There's apparently
+a lot of community work put into making packages play well with M1/arm64 architecture.
+
+```bash
+pip install -r requirements.txt
+...
+   note: This error originates from a subprocess, and is likely not a problem with pip.
+error: legacy-install-failure
+
+× Encountered error while trying to install package.
+╰─> grpcio
+...
+```
+
+**Solution:**
+
+Use a `conda` virtualenv, and then run the following when installing the engine dependencies/
+[See here for more details](https://stackoverflow.com/a/74307636/3902555)
+
+```bash
+GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=1 GRPC_PYTHON_BUILD_SYSTEM_ZLIB=1 pip install -r requirements.txt
 ```
 
 ## IDE Specific Instructions

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -47,6 +47,7 @@ services:
       labels: *oncall-labels
     environment:
       ONCALL_API_URL: http://host.docker.internal:8080
+      MOBILE_APP_QR_INTERVAL_QUEUE: 290000 # 4 minutes and 50 seconds
     volumes:
       - ./grafana-plugin:/etc/app
       - /etc/app/node_modules

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -24,6 +24,7 @@ x-env-files: &oncall-env-files
 x-env-vars: &oncall-env-vars
   BROKER_TYPE: ${BROKER_TYPE}
   GRAFANA_API_URL: http://localhost:3000
+  GOOGLE_APPLICATION_CREDENTIALS: /etc/app/gcp_service_account.json
 
 # basically this is needed because the oncall backend containers have been configured to communicate w/ grafana via
 # http://localhost:3000 (GRAFANA_API_URL). This URL is used in two scenarios:

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -105,6 +105,21 @@ services:
     profiles:
       - engine
 
+  flower:
+    container_name: flower
+    labels: *oncall-labels
+    image: mher/flower:1.2.0
+    environment:
+      # TODO: make this work properly w/ BROKER_TYPE env var
+      CELERY_BROKER_URL: "redis://redis:6379/0"
+    ports:
+      - "5555:5555"
+    depends_on:
+      oncall_celery:
+        condition: service_started
+    profiles:
+      - engine
+
   oncall_db_migration:
     container_name: oncall_db_migration
     labels: *oncall-labels

--- a/engine/.gitignore
+++ b/engine/.gitignore
@@ -3,3 +3,4 @@ extensions/
 uwsgi-local.ini
 celerybeat-schedule
 *.db
+gcp_service_account.json

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -3,9 +3,6 @@ RUN apk add bash python3-dev build-base linux-headers pcre-dev mariadb-connector
 
 WORKDIR /etc/app
 COPY ./requirements.txt ./
-# upgrading pip should speed up grpcio installation
-# see here for more information - https://github.com/grpc/grpc/issues/22815#issuecomment-621984140
-RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 # we intentionally have two COPY commands, this is to have the requirements.txt in a separate build step

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -3,6 +3,9 @@ RUN apk add bash python3-dev build-base linux-headers pcre-dev mariadb-connector
 
 WORKDIR /etc/app
 COPY ./requirements.txt ./
+# upgrading pip should speed up grpcio installation
+# see here for more information - https://github.com/grpc/grpc/issues/22815#issuecomment-621984140
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 # we intentionally have two COPY commands, this is to have the requirements.txt in a separate build step

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,8 +1,9 @@
-FROM python:3.9-alpine3.16 AS base
-RUN apk add bash python3-dev build-base linux-headers pcre-dev mariadb-connector-c-dev openssl-dev libffi-dev git
+FROM python:3.9-slim-buster AS base
+RUN apt-get update && apt-get install -y python3-dev gcc
 
 WORKDIR /etc/app
 COPY ./requirements.txt ./
+RUN pip install --upgrade pip
 RUN pip install -r requirements.txt
 
 # we intentionally have two COPY commands, this is to have the requirements.txt in a separate build step
@@ -16,7 +17,7 @@ RUN DJANGO_SETTINGS_MODULE=settings.prod_without_db DATABASE_TYPE=sqlite3 DATABA
 RUN chown -R 1000:2000 /var/lib/oncall
 
 FROM base AS dev
-RUN apk add sqlite mysql-client postgresql-client
+RUN apt-get install -y sqlite3 default-mysql-client postgresql-client
 
 FROM dev AS dev-enterprise
 RUN pip install -r requirements-enterprise-docker.txt

--- a/engine/apps/mobile_app/backend.py
+++ b/engine/apps/mobile_app/backend.py
@@ -1,7 +1,7 @@
 import json
 
 from django.conf import settings
-from push_notifications.models import GCMDevice
+from fcm_django.models import FCMDevice
 
 from apps.base.messaging import BaseMessagingBackend
 from apps.mobile_app.tasks import notify_user_async
@@ -35,7 +35,7 @@ class MobileAppBackend(BaseMessagingBackend):
         token.delete()
 
         # delete push notification related info for user
-        GCMDevice.objects.filter(user=user).delete()
+        FCMDevice.objects.filter(user=user).delete()
 
     def serialize_user(self, user):
         from apps.mobile_app.models import MobileAppAuthToken

--- a/engine/apps/mobile_app/fcm_relay.py
+++ b/engine/apps/mobile_app/fcm_relay.py
@@ -1,4 +1,5 @@
-from push_notifications.gcm import send_message
+# from firebase_admin.messaging import Message
+# from fcm_django.models import FCMDevice
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -6,6 +7,7 @@ from rest_framework.views import APIView
 REQUIRED_FIELDS = {"registration_ids", "notification", "data"}
 
 
+# TODO: update thie
 class FCMRelayView(APIView):
     def post(self, request):
         """
@@ -17,10 +19,11 @@ class FCMRelayView(APIView):
         if not REQUIRED_FIELDS.issubset(request.data.keys()):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        registration_ids = request.data["registration_ids"]
-        data = {
-            **request.data["data"],
-            **request.data["notification"],
-        }
+        # registration_ids = request.data["registration_ids"]
+        # data = {
+        #     **request.data["data"],
+        #     **request.data["notification"],
+        # }
 
-        return send_message(registration_ids=registration_ids, data=data, cloud_type="FCM")
+        # return FCMDevice.objects.send_message(Message(), False, ["registration_ids"])
+        return "TODO:"

--- a/engine/apps/mobile_app/models.py
+++ b/engine/apps/mobile_app/models.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
@@ -7,7 +8,7 @@ from apps.auth_token import constants, crypto
 from apps.auth_token.models import BaseAuthToken
 from apps.user_management.models import Organization, User
 
-MOBILE_APP_AUTH_VERIFICATION_TOKEN_TIMEOUT_SECONDS = 60
+MOBILE_APP_AUTH_VERIFICATION_TOKEN_TIMEOUT_SECONDS = 60 * (5 if settings.DEBUG else 1)
 
 
 def get_expire_date():

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -1,6 +1,17 @@
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from push_notifications.models import GCMDevice
+from fcm_django.models import FCMDevice
+from firebase_admin.messaging import (
+    AndroidConfig,
+    AndroidNotification,
+    APNSConfig,
+    APNSPayload,
+    Aps,
+    ApsAlert,
+    CriticalSound,
+    Message,
+    Notification,
+)
 
 from apps.alerts.models import AlertGroup
 from apps.mobile_app.alert_rendering import get_push_notification_message
@@ -34,10 +45,10 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk, critical)
         logger.warning(f"User notification policy {notification_policy_pk} does not exist")
         return
 
-    gcm_devices_to_notify = GCMDevice.objects.filter(user=user)
+    device_to_notify = FCMDevice.objects.filter(user=user).first()
 
     # create an error log in case user has no devices set up
-    if not gcm_devices_to_notify.exists():
+    if not device_to_notify:
         UserNotificationPolicyLogRecord.objects.create(
             author=user,
             type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED,
@@ -47,66 +58,76 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk, critical)
             notification_step=notification_policy.step,
             notification_channel=notification_policy.notify_by,
         )
-        logger.info(f"Error while sending a mobile push notification: user {user_pk} has no devices set up")
+        logger.info(f"Error while sending a mobile push notification: user {user_pk} has no device set up")
         return
 
     message = get_push_notification_message(alert_group)
     thread_id = f"{alert_group.channel.organization.public_primary_key}:{alert_group.public_primary_key}"
     alert_title = f"Critical page: {message}" if critical else message
-    # TODO: this is what will be shown in the app badge (little red bubble w/ number)
-    # is this the proper thing we want to show? or is there a more valuable metric to use?
-    number_of_alert_groups_firing = alert_group.alerts.count()
+    number_of_alerts = alert_group.alerts.count()
 
-    extra = {
-        "orgId": alert_group.channel.organization.public_primary_key,
-        "orgName": alert_group.channel.organization.stack_slug,
-        "alertGroupId": alert_group.public_primary_key,
-        "status": alert_group.status,
-        "apns": {
-            # for possible iOS values, see here
-            # https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943365
-            "aps": {
-                "badge": number_of_alert_groups_firing,
-                "sound": {
-                    "critical": 1 if critical else 0,
-                    "name": "ambulance.aiff" if critical else "bingbong.aiff",
-                    "volume": 1,
-                },
-                "interruption-level": "critical" if critical else "time-sensitive",
-                "alert": {
-                    "title": alert_title,
-                    # TODO: do we want these attributes?
-                    # "subtitle": "",
-                    # "body": "",
-                },
-            },
+    # TODO: we should update this to check if FCM_RELAY is set and conditionally make a call here..
+
+    message = Message(
+        token=device_to_notify.registration_id,
+        notification=Notification(
+            title=alert_title,
+            body="this is the alert body",
+        ),
+        data={
+            # from the docs..
+            # A dictionary of data fields (optional). All keys and values in the dictionary must be strings
+            #
+            # alert_group.status is an int so it must be casted...
+            "orgId": alert_group.channel.organization.public_primary_key,
+            "orgName": alert_group.channel.organization.stack_slug,
+            "alertGroupId": alert_group.public_primary_key,
+            "status": str(alert_group.status),
         },
-        "android": {
-            # for possible Android settings, see here
-            # https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidconfig
-            "priority": "HIGH",
-            "notification": {
-                "title": alert_title,
-                # TODO: do we want the body attribute?
-                "body": "",
-                "ticker": alert_title,
-                "sound": "ambulance.mp3" if critical else "bingbong.mp3",
-                "click_action": "CRITICAL_NOTIFICATION" if critical else "DEFAULT",
-                "visibility": "PUBLIC",
-                "notification_priority": "PRIORITY_MAX" if critical else "PRIORITY_HIGH",
-                "notification_count": number_of_alert_groups_firing,
-                # NOTE: we'll ignore vibrate_timings for now, but we could use it to make a weird vibration
-                # pattern for critical notifications
-                "vibrate_timings": [],
-            },
-        },
-    }
-
-    logger.info(f"Sending push notification with message: {message}; thread-id: {thread_id}; extra: {extra}")
-
-    fcm_response = gcm_devices_to_notify.send_message(
-        message, thread_id=thread_id, category="USER_NEW_ALERT_GROUP", extra=extra
+        android=AndroidConfig(
+            priority="high",
+            notification=AndroidNotification(
+                ticker=alert_title,
+                tag=thread_id,
+                sound="ambulance.mp3" if critical else "bingbong.mp3",
+                default_sound=False,
+                click_action="CRITICAL_NOTIFICATION" if critical else "DEFAULT",
+                visibility="public",
+                priority="max" if critical else "high",
+                notification_count=number_of_alerts,
+                # NOTE: we'll ignore light_settings and vibrate_timings_millis for now
+                # but we could use it to make a weird vibration/light
+                # patterns for critical notifications
+                # light_settings=LightSettings(),
+                # vibrate_timings_millis=[],
+            ),
+        ),
+        apns=APNSConfig(
+            payload=APNSPayload(
+                aps=Aps(
+                    thread_id=thread_id,
+                    badge=number_of_alerts,
+                    alert=ApsAlert(
+                        title=alert_title,
+                        subtitle="yooo this is a subtitle",
+                        body="hello this is the body",
+                    ),
+                    sound=CriticalSound(
+                        critical=1 if critical else 0,
+                        name="ambulance.aiff" if critical else "bingbong.aiff",
+                        volume=1,
+                    ),
+                    custom_data={
+                        "interruption-level": "critical" if critical else "time-sensitive",
+                    },
+                ),
+            ),
+        ),
     )
+
+    logger.info(f"Sending push notification with message: {message}; thread-id: {thread_id};")
+
+    fcm_response = device_to_notify.send_message(message)
 
     # NOTE: we may want to further handle the response from FCM, but for now lets simply log it out
     # https://firebase.google.com/docs/cloud-messaging/http-server-ref#interpret-downstream

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -95,6 +95,7 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk, critical)
                 visibility="public",
                 priority="max" if critical else "high",
                 notification_count=number_of_alerts,
+                channel_id="critical" if critical else "default"
                 # NOTE: we'll ignore light_settings and vibrate_timings_millis for now
                 # but we could use it to make a weird vibration/light
                 # patterns for critical notifications

--- a/engine/apps/mobile_app/views.py
+++ b/engine/apps/mobile_app/views.py
@@ -1,25 +1,15 @@
-from push_notifications.api.rest_framework import GCMDeviceAuthorizedViewSet, GCMDeviceSerializer
+from fcm_django.api.rest_framework import FCMDeviceAuthorizedViewSet as BaseFCMDeviceAuthorizedViewSet
 from rest_framework import status
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
-from rest_framework.serializers import HiddenField
 from rest_framework.views import APIView
 
 from apps.mobile_app.auth import MobileAppAuthTokenAuthentication, MobileAppVerificationTokenAuthentication
 from apps.mobile_app.models import MobileAppAuthToken
 
 
-class FCMDeviceAuthorizedViewSet(GCMDeviceAuthorizedViewSet):
-    class FCMDeviceSerializer(GCMDeviceSerializer):
-        """
-        GCMDevice has cloud_message_type equal to "GCM" by default, in this serializer cloud_message_type is always set
-        to "FCM" no matter what was provided in the request.
-        """
-
-        cloud_message_type = HiddenField(default="FCM")
-
+class FCMDeviceAuthorizedViewSet(BaseFCMDeviceAuthorizedViewSet):
     authentication_classes = (MobileAppAuthTokenAuthentication,)
-    serializer_class = FCMDeviceSerializer
 
 
 class MobileAppAuthTokenAPIView(APIView):

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -33,7 +33,7 @@ django-log-request-id==1.6.0
 django-polymorphic==3.0.0
 django-rest-polymorphic==0.1.9
 pre-commit==2.15.0
-https://github.com/grafana/django-push-notifications/archive/refs/tags/3.0.0-fix-migration.tar.gz
+https://github.com/grafana/fcm-django/archive/refs/tags/v1.0.12r1.tar.gz
 django-mirage-field==1.3.0
 django-mysql==4.6.0
 PyMySQL==1.0.2

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -205,6 +205,7 @@ INSTALLED_APPS = [
     "apps.slack",
     "apps.telegram",
     "apps.twilioapp",
+    "apps.mobile_app",
     "apps.api",
     "apps.api_for_grafana_incident",
     "apps.base",
@@ -553,7 +554,6 @@ if FEATURE_MOBILE_APP_INTEGRATION_ENABLED:
 
     INSTALLED_APPS += [
         "fcm_django",
-        "apps.mobile_app",
     ]
 
     FIREBASE_APP = initialize_app()

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -205,7 +205,6 @@ INSTALLED_APPS = [
     "apps.slack",
     "apps.telegram",
     "apps.twilioapp",
-    "apps.mobile_app",
     "apps.api",
     "apps.api_for_grafana_incident",
     "apps.base",
@@ -216,7 +215,6 @@ INSTALLED_APPS = [
     "debug_toolbar",
     "social_django",
     "polymorphic",
-    "push_notifications",
 ]
 
 REST_FRAMEWORK = {
@@ -546,18 +544,31 @@ GRAFANA_API_KEY_NAME = "Grafana OnCall"
 
 EXTRA_MESSAGING_BACKENDS = []
 if FEATURE_MOBILE_APP_INTEGRATION_ENABLED:
+    from firebase_admin import initialize_app
+
     EXTRA_MESSAGING_BACKENDS += [
         ("apps.mobile_app.backend.MobileAppBackend", 5),
         ("apps.mobile_app.backend.MobileAppCriticalBackend", 6),
     ]
 
-PUSH_NOTIFICATIONS_SETTINGS = {
-    "FCM_API_KEY": os.getenv("FCM_API_KEY"),
-    "FCM_POST_URL": os.getenv("FCM_POST_URL", default="https://fcm.googleapis.com/fcm/send"),
-    "USER_MODEL": "user_management.User",
-    "UPDATE_ON_DUPLICATE_REG_ID": True,
-}
+    INSTALLED_APPS += [
+        "fcm_django",
+        "apps.mobile_app",
+    ]
+
+    FIREBASE_APP = initialize_app()
+
 FCM_RELAY_ENABLED = getenv_boolean("FCM_RELAY_ENABLED", default=False)
+FCM_DJANGO_SETTINGS = {
+    # an instance of firebase_admin.App to be used as default for all fcm-django requests
+    # default: None (the default Firebase app)
+    "DEFAULT_FIREBASE_APP": None,
+    "APP_VERBOSE_NAME": "OnCall",
+    "ONE_DEVICE_PER_USER": True,
+    "DELETE_INACTIVE_DEVICES": False,
+    "UPDATE_ON_DUPLICATE_REG_ID": True,
+    "USER_MODEL": "user_management.User",
+}
 
 SELF_HOSTED_SETTINGS = {
     "STACK_ID": 5,

--- a/grafana-plugin/src/containers/MobileAppVerification/MobileAppVerification.tsx
+++ b/grafana-plugin/src/containers/MobileAppVerification/MobileAppVerification.tsx
@@ -22,7 +22,9 @@ type Props = {
 };
 
 const INTERVAL_MIN_THROTTLING = 500;
-const INTERVAL_QUEUE_QR = 50000;
+const INTERVAL_QUEUE_QR = process.env.MOBILE_APP_QR_INTERVAL_QUEUE
+  ? parseInt(process.env.MOBILE_APP_QR_INTERVAL_QUEUE, 10)
+  : 50000;
 const INTERVAL_POLLING = 5000;
 const BACKEND = 'MOBILE_APP';
 

--- a/grafana-plugin/webpack.config.js
+++ b/grafana-plugin/webpack.config.js
@@ -142,6 +142,7 @@ module.exports.getWebpackConfig = (config, options) => {
        */
       new webpack.EnvironmentPlugin({
         ONCALL_API_URL: null,
+        MOBILE_APP_QR_INTERVAL_QUEUE: null,
       }),
     ],
 


### PR DESCRIPTION
# What this PR does

- swaps out `django-push-notifications` for [`fcm-django`](https://github.com/grafana/fcm-django). Again.. this is a fork of the parent repo for exactly the same reason.. the migrations point to `auth_user` without letting us use our own user model, this has been patched in the `grafana` fork. The reason why we are using `fcm-django` vs `django-push-notifications` is that the latter does not support the new FCM API, only the "legacy" API. The legacy FCM API does not support certain push notification settings that we would like to use.
- modifies the iOS/Android specific push notification settings
- adds a `flower` pod in the `docker-compose-developer.yml`, useful for debugging tasks locally
- sets the mobile app verification token TTL to 5 minutes when developing locally. The default of 1 minute makes working with device emulators really tricky..

## Other stuff

This PR also swaps out the base image in `engine/Dockerfile` from `python:3.9-alpine3.16` to `python:3.9-slim-buster`.

As to why.. in short, with the introduction of the `fcm-django` library there is now a peer-dependency on [`grpcio`](https://github.com/grpc/grpc) (which is used by `firebase_admin`.. which I am using in this PR to interact directly with Firebase Cloud Messaging (FCM)). `grpcio` does not publish wheels (read: compiled binaries) for the Alpine distro. It does publish wheels for Debian and hence `pip install -r requirements.txt` does not need to build this library from the source distribution.

This is a [known "issue"](https://github.com/grpc/grpc/issues/22815#issuecomment-1107874367) and the recommended solution in the community is to.. not use alpine.

These were the numbers, when building the image locally, in terms of image size and build time:

|                                             | Local image size (uncompressed  | Build time |
| ------------------------- | -------------------------------------- | ---------- |
| `python:3.9-alpine3.16`   | 785MB  | 320s |
| `python:3.9-slim-buster` | 1.05GB  | 90s   |

