### PR TITLE
fix: use white background in qrcode

### DIFF
--- a/grafana-plugin/src/containers/MobileAppVerification/__snapshots__/MobileAppVerification.test.tsx.snap
+++ b/grafana-plugin/src/containers/MobileAppVerification/__snapshots__/MobileAppVerification.test.tsx.snap
@@ -110,6 +110,7 @@ exports[`MobileAppVerification if we disconnect the app, it disconnects and fetc
           >
             <div
               class="root root_bordered"
+              style="background: white;"
             >
               <svg
                 height="256"

--- a/grafana-plugin/src/containers/MobileAppVerification/parts/QRCode/QRCode.tsx
+++ b/grafana-plugin/src/containers/MobileAppVerification/parts/QRCode/QRCode.tsx
@@ -13,7 +13,7 @@ const QRCode: FC<Props> = (props: Props) => {
   const { value, className = '' } = props;
 
   return (
-    <Block bordered className={className}>
+    <Block bordered className={className} style={{background: 'white'}}>
       <QRCodeBase value={value} />
     </Block>
   );

--- a/grafana-plugin/src/containers/MobileAppVerification/parts/QRCode/__snapshots__/QRCode.test.tsx.snap
+++ b/grafana-plugin/src/containers/MobileAppVerification/parts/QRCode/__snapshots__/QRCode.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`QRCode it renders properly 1`] = `
 <div>
   <div
     class="root root_bordered"
+    style="background: white;"
   >
     <svg
       height="256"


### PR DESCRIPTION
# What this PR does

Surround the QR code with a white background to make it more readable.
