### PR TITLE
oncall_schedule with value None

### DIFF
--- a/tools/pagerduty-migrator/migrator/resources/escalation_policies.py
+++ b/tools/pagerduty-migrator/migrator/resources/escalation_policies.py
@@ -92,14 +92,15 @@ def transform_rule(
         if schedule is None:
             continue
 
-        oncall_schedule_id = schedule["oncall_schedule"]["id"]
+        if schedule["oncall_schedule"] is not None:
+            oncall_schedule_id = schedule["oncall_schedule"]["id"]
 
-        escalation_policy = {
-            "escalation_chain_id": escalation_chain_id,
-            "type": "notify_on_call_from_schedule",
-            "notify_on_call_from_schedule": oncall_schedule_id,
-        }
-        escalation_policies.append(escalation_policy)
+            escalation_policy = {
+                "escalation_chain_id": escalation_chain_id,
+                "type": "notify_on_call_from_schedule",
+                "notify_on_call_from_schedule": oncall_schedule_id,
+            }
+            escalation_policies.append(escalation_policy)
 
     if user_targets:
         rule_users = [find_by_id(users, target["id"]) for target in user_targets]


### PR DESCRIPTION
When there is a migration of plans in pagerduty from **Business** to **Professional**, this type of error occurs.

Line https://github.com/grafana/oncall/blob/275aa94c71b18c6b14c9037247234ff76145ba39/tools/pagerduty-migrator/migrator/resources/escalation_policies.py#L95
![image](https://user-images.githubusercontent.com/20375245/208161782-5468ae6b-345b-49f3-ab52-9e2798d1b065.png)
