### PR TITLE
add curl and bash to oncall engine docker image

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -2,9 +2,10 @@ FROM python:3.9-slim-buster AS base
 RUN apt-get update && apt-get install -y \
     python3-dev \
     gcc \
-    libpq-dev \
     libmariadb-dev \
-    netcat
+    netcat \
+    curl \
+    bash
 
 WORKDIR /etc/app
 COPY ./requirements.txt ./


### PR DESCRIPTION
# What this PR does

Currently unable to exec into a k8s pod. I believe this is because `bash` is missing from the Docker image after switching from alpine to debian buster. Debugging this by adding in `bash`.