### PR TITLE
Handle no start date when calculating by day ical shift events

### DIFF
--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1113,7 +1113,7 @@ def test_merging_same_shift_events(
 
     data = {
         "start": start_date + timezone.timedelta(hours=10),
-        "rotation_start": start_date,
+        "rotation_start": start_date + timezone.timedelta(hours=10),
         "duration": timezone.timedelta(hours=2),
         "priority_level": 1,
         "frequency": CustomOnCallShift.FREQUENCY_DAILY,

--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -322,8 +322,10 @@ class CustomOnCallShift(models.Model):
             if all_rotations_checked:
                 break
 
-        # number of weeks used to cover all combinations
-        week_interval = ((last_start - orig_start).days // 7) or 1
+        week_interval = 1
+        if orig_start and last_start:
+            # number of weeks used to cover all combinations
+            week_interval = ((last_start - orig_start).days // 7) or 1
         counter = 1
         for ((user_group_id, day, _), start) in zip(combinations, starting_dates):
             users = users_queue[user_group_id]
@@ -367,7 +369,7 @@ class CustomOnCallShift(models.Model):
                 start = self.get_rotation_date(event_ical)
 
             # Make sure we respect the selected days if any when defining start date
-            if self.frequency is not None and self.by_day:
+            if self.frequency is not None and self.by_day and start is not None:
                 start_day = CustomOnCallShift.ICAL_WEEKDAY_MAP[start.weekday()]
                 if start_day not in self.by_day:
                     expected_start_day = min(CustomOnCallShift.ICAL_WEEKDAY_REVERSE_MAP[d] for d in self.by_day)

--- a/engine/apps/schedules/tests/test_custom_on_call_shift.py
+++ b/engine/apps/schedules/tests/test_custom_on_call_shift.py
@@ -1430,3 +1430,40 @@ def test_rolling_users_shift_convert_to_ical(
 
     assert on_call_shift.event_interval == len(rolling_users) * data["interval"]
     assert expected_rrule in ical_data
+
+
+@pytest.mark.django_db
+def test_rolling_users_event_daily_by_day_start_none_convert_to_ical(
+    make_organization_and_user, make_user_for_organization, make_on_call_shift, make_schedule
+):
+    organization, user_1 = make_organization_and_user()
+
+    schedule = make_schedule(organization, schedule_class=OnCallScheduleWeb)
+    now = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    today_weekday = now.weekday()
+    delta_days = (0 - today_weekday) % 7 + (7 if today_weekday == 0 else 0)
+    next_week_monday = now + timezone.timedelta(days=delta_days)
+
+    # MO
+    weekdays = [0]
+    by_day = [CustomOnCallShift.ICAL_WEEKDAY_MAP[day] for day in weekdays]
+    data = {
+        "priority_level": 1,
+        "start": now + timezone.timedelta(hours=12),
+        "rotation_start": next_week_monday,
+        "duration": timezone.timedelta(seconds=3600),
+        "frequency": CustomOnCallShift.FREQUENCY_DAILY,
+        "interval": 1,
+        "by_day": by_day,
+        "schedule": schedule,
+        "until": now,
+    }
+    rolling_users = [[user_1]]
+    on_call_shift = make_on_call_shift(
+        organization=organization, shift_type=CustomOnCallShift.TYPE_ROLLING_USERS_EVENT, **data
+    )
+    on_call_shift.add_rolling_users(rolling_users)
+
+    ical_data = on_call_shift.convert_to_ical()
+    # empty result since there is no event in the defined time range
+    assert ical_data == ""


### PR DESCRIPTION
Fixes issue when creating a by-day shift with no events in the given time range