### PR TITLE
swap psycopg2-binary to psycopg2 in requirements.txt

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     gcc \
     libmariadb-dev \
+    libpq-dev \
     netcat \
     curl \
     bash

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -37,7 +37,7 @@ https://github.com/grafana/fcm-django/archive/refs/tags/v1.0.12r1.tar.gz
 django-mirage-field==1.3.0
 django-mysql==4.6.0
 PyMySQL==1.0.2
-psycopg2-binary==2.9.3
+psycopg2==2.9.3
 emoji==1.7.0
 regex==2021.11.2
 psutil==5.9.4


### PR DESCRIPTION
Fixes issue when running OnCall locally, on an M1 Mac, and using PostgreSQL as the database. (ie. `COMPOSE_PROFILES=postgres...`). Currently getting:
```bash
django.db.utils.OperationalError: SCRAM authentication requires libpq version 10 or above
```

I also tried simply adding `libpq-dev` to the `Dockerfile` but this change alone does not solve the issue. See [here](https://github.com/MobSF/Mobile-Security-Framework-MobSF/issues/1898) for a similar reported issue on GitHub.

**Root Cause**
This issue is caused because `psycopg2-binary` 2.9.3 [doesn't provide](https://pypi.org/project/psycopg2-binary/2.9.3/#files) binary wheels for MacOS arm64; binary wheels for MacOS are only provided for Intel x86 64 bits ([reference](https://stackoverflow.com/a/71653850/3902555)).