### PR TITLE
Improve handling of template exceptions during group data creation

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -194,6 +194,9 @@ class Alert(models.Model):
                 web_title_cache = apply_jinja_template(web_title_template, raw_request_data)
             except (JinjaTemplateError, JinjaTemplateWarning) as e:
                 web_title_cache = e.fallback_message
+                logger.warning(
+                    f"web_title_cache error on channel={alert_receive_channel.public_primary_key}: {e.fallback_message}"
+                )
         else:
             web_title_cache = None
 

--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 from uuid import uuid4
 
@@ -13,6 +14,7 @@ from apps.alerts.constants import TASK_DELAY_SECONDS
 from apps.alerts.incident_appearance.templaters import TemplateLoader
 from apps.alerts.tasks import distribute_alert, send_alert_group_signal
 from common.jinja_templater import apply_jinja_template
+from common.jinja_templater.apply_jinja_template import JinjaTemplateError, JinjaTemplateWarning
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
 logger = logging.getLogger(__name__)
@@ -86,6 +88,7 @@ class Alert(models.Model):
         AlertGroupLogRecord = apps.get_model("alerts", "AlertGroupLogRecord")
 
         group_data = Alert.render_group_data(alert_receive_channel, raw_request_data, is_demo)
+        logger.info(f"Alert created group_data={str(json.dumps(group_data))}")
         channel_filter = ChannelFilter.select_filter(
             alert_receive_channel, raw_request_data, title, message, force_route_id
         )
@@ -189,12 +192,20 @@ class Alert(models.Model):
         # set web_title_cache to web title to allow alert group searching based on web_title_cache
         web_title_template = template_manager.get_attr_template("title", alert_receive_channel, render_for="web")
         if web_title_template:
-            web_title_cache = apply_jinja_template(web_title_template, raw_request_data)
+            try:
+                web_title_cache = apply_jinja_template(web_title_template, raw_request_data)
+            except (JinjaTemplateError, JinjaTemplateWarning) as e:
+                web_title_cache = e.fallback_message
         else:
             web_title_cache = None
 
         if grouping_id_template is not None:
-            group_distinction = apply_jinja_template(grouping_id_template, raw_request_data)
+            try:
+                group_distinction = apply_jinja_template(grouping_id_template, raw_request_data)
+            except (JinjaTemplateError, JinjaTemplateWarning) as e:
+                logger.warning(
+                    f"grouping_id_template error on channel={alert_receive_channel.public_primary_key}: {e.fallback_message}"
+                )
 
         # Insert random uuid to prevent grouping of demo alerts or alerts with group_distinction=None
         if is_demo or not group_distinction:
@@ -204,13 +215,25 @@ class Alert(models.Model):
             group_distinction = hashlib.md5(str(group_distinction).encode()).hexdigest()
 
         if resolve_condition_template is not None:
-            is_resolve_signal = apply_jinja_template(resolve_condition_template, payload=raw_request_data)
+            try:
+                is_resolve_signal = apply_jinja_template(resolve_condition_template, payload=raw_request_data)
+            except (JinjaTemplateError, JinjaTemplateWarning) as e:
+                logger.warning(
+                    f"resolve_condition_template error on channel={alert_receive_channel.public_primary_key}: {e.fallback_message}"
+                )
+
             if isinstance(is_resolve_signal, str):
                 is_resolve_signal = is_resolve_signal.strip().lower() in ["1", "true", "ok"]
             else:
                 is_resolve_signal = False
         if acknowledge_condition_template is not None:
-            is_acknowledge_signal = apply_jinja_template(acknowledge_condition_template, payload=raw_request_data)
+            try:
+                is_acknowledge_signal = apply_jinja_template(acknowledge_condition_template, payload=raw_request_data)
+            except (JinjaTemplateError, JinjaTemplateWarning) as e:
+                logger.warning(
+                    f"acknowledge_condition_template error on channel={alert_receive_channel.public_primary_key}: {e.fallback_message}"
+                )
+
             if isinstance(is_acknowledge_signal, str):
                 is_acknowledge_signal = is_acknowledge_signal.strip().lower() in ["1", "true", "ok"]
             else:

--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 import logging
 from uuid import uuid4
 
@@ -88,7 +87,6 @@ class Alert(models.Model):
         AlertGroupLogRecord = apps.get_model("alerts", "AlertGroupLogRecord")
 
         group_data = Alert.render_group_data(alert_receive_channel, raw_request_data, is_demo)
-        logger.info(f"Alert created group_data={str(json.dumps(group_data))}")
         channel_filter = ChannelFilter.select_filter(
             alert_receive_channel, raw_request_data, title, message, force_route_id
         )


### PR DESCRIPTION
# What this PR does
With the addition of tighter controls on jinja templates handle exceptions while rendering group data as follows:
- Title will cache error message as title and display to user and the error will be logged
- Group distinction will be left as None and the error will be logged
- Is resolve signal will be treated as False and the error will be logged
- Is acknowledge signal will be treated as False and the error will be logged

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/1542
