### PR TITLE
correct values file stub for slack commandName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minor bug fix in how the value of `Organization.is_rbac_permissions_enabled` is determined
 
-### Helm Chart
-
-- Default values file and documentation now reflect the correct key to set for the Slack slash command name, `oncall.slack.commandName`.
+- Helm chart: default values file and documentation now reflect the correct key to set for the Slack slash command name, `oncall.slack.commandName`.
 
 ## v1.1.15 (2023-01-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minor bug fix in how the value of `Organization.is_rbac_permissions_enabled` is determined
 
+### Helm Chart
+
+- Default values file and documentation now reflect the correct key to set for the Slack slash command name, `oncall.slack.commandName`.
+
 ## v1.1.15 (2023-01-10)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Minor bug fix in how the value of `Organization.is_rbac_permissions_enabled` is determined
 
-- Helm chart: default values file and documentation now reflect the correct key to set for the Slack slash command name, `oncall.slack.commandName`.
+- Helm chart: default values file and documentation now reflect the correct key to set for the Slack
+  slash command name, `oncall.slack.commandName`.
 
 ## v1.1.15 (2023-01-10)
 

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/oncall/README.md
+++ b/helm/oncall/README.md
@@ -98,15 +98,19 @@ You can set up Slack connection via following variables:
 oncall:
   slack:
     enabled: true
-    command: ~
+    commandName: oncall
     clientId: ~
     clientSecret: ~
-    apiToken: ~
-    apiTokenCommon: ~
+    signingSecret: ~
+    existingSecret: ""
+    clientIdKey: ""
+    clientSecretKey: ""
+    signingSecretKey: ""
+    redirectHost: ~
 ```
 
-`oncall.slack.command` is used for changing default bot slash command,
-`oncall`. In slack, it could be called via `/<oncall.slack.command>`.
+`oncall.slack.commandName` is used for changing default bot slash command,
+`oncall`. In slack, it could be called via `/<oncall.slack.commandName>`.
 
 To set up Telegram tokem and webhook url use:
 

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -92,7 +92,7 @@ oncall:
     # enabled enable the Slack ChatOps integration for the Oncall Engine.
     enabled: false
     # command sets the Slack bot slash-command
-    command: oncall
+    commandName: oncall
     # clientId configures the Slack app OAuth2 client ID.
     # api.slack.com/apps/<yourApp> -> Basic Information -> App Credentials -> Client ID
     clientId: ~

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -91,7 +91,7 @@ oncall:
   slack:
     # enabled enable the Slack ChatOps integration for the Oncall Engine.
     enabled: false
-    # command sets the Slack bot slash-command
+    # commandName sets the Slack bot slash-command
     commandName: oncall
     # clientId configures the Slack app OAuth2 client ID.
     # api.slack.com/apps/<yourApp> -> Basic Information -> App Credentials -> Client ID


### PR DESCRIPTION
# What this PR does

The templates actually generate the SLACK_SLASH_COMMAND_NAME envvar from `.Values.oncall.slack.commandName`, not `command`. This commit changes the default values file to reflect this.

## Which issue(s) this PR fixes

#1092 

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated

^ Are these applicable with regards to updating the helm chart, not the core application? I did take the time to test both the default and changed value after this change in a kubernetes deployment.
