### PR TITLE
refactor the is_rbac_permissions_enabled check to be more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.16 (TBD)
+
+### Fixed
+
+- Minor bug fix in how the value of `Organization.is_rbac_permissions_enabled` is determined
+
 ## v1.1.15 (2023-01-10)
 
 ### Changed

--- a/engine/apps/grafana_plugin/helpers/client.py
+++ b/engine/apps/grafana_plugin/helpers/client.py
@@ -210,7 +210,7 @@ class GcomAPIClient(APIClient):
         data, _ = self.api_get(url)
         return data
 
-    def is_rbac_enabled_for_organization(self, stack_id: str) -> bool:
+    def is_rbac_enabled_for_stack(self, stack_id: str) -> bool:
         """
         NOTE: must use an "Admin" GCOM token when calling this method
         """

--- a/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
@@ -5,7 +5,7 @@ import pytest
 from apps.grafana_plugin.helpers.client import GcomAPIClient
 
 
-class TestIsRbacEnabledForOrganization:
+class TestIsRbacEnabledForStack:
     @pytest.mark.parametrize(
         "gcom_api_response,expected",
         [

--- a/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.grafana_plugin.helpers.client import GcomAPIClient
+
+
+class TestIsRbacEnabledForOrganization:
+    @pytest.mark.parametrize(
+        "gcom_api_response,expected",
+        [
+            (None, False),
+            ({}, False),
+            ({"config": {}}, False),
+            ({"config": {"feature_toggles": {}}}, False),
+            ({"config": {"feature_toggles": {"accessControlOnCall": "false"}}}, False),
+            ({"config": {"feature_toggles": {"accessControlOnCall": "true"}}}, True),
+        ],
+    )
+    @patch("apps.grafana_plugin.helpers.client.GcomAPIClient.api_get")
+    def test_it_returns_based_on_feature_toggle_value(
+        self, mocked_gcom_api_client_api_get, gcom_api_response, expected
+    ):
+        stack_id = 5
+        mocked_gcom_api_client_api_get.return_value = (gcom_api_response, {"status_code": 200})
+
+        api_client = GcomAPIClient("someFakeApiToken")
+        assert api_client.is_rbac_enabled_for_stack(stack_id) == expected
+        assert mocked_gcom_api_client_api_get.called_once_with(f"instances/{stack_id}?config=true")

--- a/engine/apps/grafana_plugin/tests/test_grafana_api_client.py
+++ b/engine/apps/grafana_plugin/tests/test_grafana_api_client.py
@@ -15,7 +15,7 @@ class TestGetUsersPermissions:
         permissions = api_client.get_users_permissions(False)
         assert len(permissions.keys()) == 0
 
-    @patch("apps.grafana_plugin.views.self_hosted_install.GrafanaAPIClient.api_get")
+    @patch("apps.grafana_plugin.helpers.client.GrafanaAPIClient.api_get")
     def test_api_call_returns_none(self, mocked_grafana_api_client_api_get):
         mocked_grafana_api_client_api_get.return_value = (None, "dfkjfdkj")
 
@@ -24,7 +24,7 @@ class TestGetUsersPermissions:
         permissions = api_client.get_users_permissions(True)
         assert len(permissions.keys()) == 0
 
-    @patch("apps.grafana_plugin.views.self_hosted_install.GrafanaAPIClient.api_get")
+    @patch("apps.grafana_plugin.helpers.client.GrafanaAPIClient.api_get")
     def test_it_properly_transforms_the_data(self, mocked_grafana_api_client_api_get):
         mocked_grafana_api_client_api_get.return_value = (
             {"1": {"grafana-oncall-app.alert-groups:read": [""], "grafana-oncall-app.alert-groups:write": [""]}},
@@ -50,7 +50,7 @@ class TestIsRbacEnabledForOrganization:
             (status.HTTP_404_NOT_FOUND, False),
         ],
     )
-    @patch("apps.grafana_plugin.views.self_hosted_install.GrafanaAPIClient.api_head")
+    @patch("apps.grafana_plugin.helpers.client.GrafanaAPIClient.api_head")
     def test_it_returns_based_on_status_code_of_head_call(
         self, mocked_grafana_api_client_api_head, grafana_api_status_code, expected
     ):

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -12,18 +12,29 @@ logger.setLevel(logging.DEBUG)
 
 
 def sync_organization(organization):
-    client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
+    grafana_api_client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
 
-    rbac_is_enabled = client.is_rbac_enabled_for_organization()
+    # NOTE: checking whether or not RBAC is enabled depends on whether we are dealing with an open-source or cloud
+    # stack. For Cloud we should make a call to the GCOM API, using an admin API token, and get the list of
+    # feature_toggles enabled for the stack. For open-source, simply make a HEAD request to the grafana instance's API
+    # and consider RBAC enabled if the list RBAC permissions endpoint returns 200. We cannot simply rely on the HEAD
+    # call in cloud because if an instance is not active, the grafana gateway will still return 200 for the
+    # HEAD request.
+    if settings.LICENSE == settings.CLOUD_LICENSE_NAME:
+        gcom_client = GcomAPIClient(settings.GRAFANA_COM_ADMIN_API_TOKEN)
+        rbac_is_enabled = gcom_client.is_rbac_enabled_for_organization()
+    else:
+        rbac_is_enabled = grafana_api_client.is_rbac_enabled_for_organization()
+
     organization.is_rbac_permissions_enabled = rbac_is_enabled
 
     _sync_instance_info(organization)
 
-    api_users = client.get_users(rbac_is_enabled)
+    api_users = grafana_api_client.get_users(rbac_is_enabled)
 
     if api_users:
         organization.api_token_status = Organization.API_TOKEN_STATUS_OK
-        sync_users_and_teams(client, api_users, organization)
+        sync_users_and_teams(grafana_api_client, api_users, organization)
     else:
         organization.api_token_status = Organization.API_TOKEN_STATUS_FAILED
 

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -22,7 +22,7 @@ def sync_organization(organization):
     # HEAD request.
     if settings.LICENSE == settings.CLOUD_LICENSE_NAME:
         gcom_client = GcomAPIClient(settings.GRAFANA_COM_ADMIN_API_TOKEN)
-        rbac_is_enabled = gcom_client.is_rbac_enabled_for_organization()
+        rbac_is_enabled = gcom_client.is_rbac_enabled_for_stack(organization.stack_id)
     else:
         rbac_is_enabled = grafana_api_client.is_rbac_enabled_for_organization()
 


### PR DESCRIPTION
# What this PR does
Checks the `is_rbac_permissions_enabled` flag differently based on whether we are dealing with an open-source, or cloud installation:
- for open-source installations, simply continue making a `HEAD` request to the list RBAC permissions Grafana API endpoint.
- for cloud installations, use the `config` object returned from `GET /instances/{instance_id}?config=true` and check whether `instance_info["config"]["feature_toggles"]["accessControlOnCall"] == "true"`

## Which issue(s) this PR fixes
Resolves the issue in hosted grafana where when a stack is inactive, the hosted grafana gateway, returns 200 to the `HEAD` request (which erroneously sets the `is_rbac_permissions_enabled` flag to `true`)

## Checklist

- [x] Tests updated (N/A)
- [ ] Documentation added
- [x] `CHANGELOG.md` updated
