### PR TITLE
Update schedules query not to defer ical fields used for on-call check

### DIFF
--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -135,9 +135,7 @@ class ScheduleView(
         organization = self.request.auth.organization
         queryset = OnCallSchedule.objects.filter(organization=organization, team=self.request.user.current_team).defer(
             # avoid requesting large text fields which are not used when listing schedules
-            "cached_ical_file_primary",
             "prev_ical_file_primary",
-            "cached_ical_file_overrides",
             "prev_ical_file_overrides",
         )
         if not is_short_request:


### PR DESCRIPTION
Do not defer cached ical fields which are later needed for calculating on-call users listed in the schedules list page.