### PR TITLE
Add escalation chain option when creating a direct page alert group

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -79,6 +79,7 @@ class Alert(models.Model):
         raw_request_data,
         enable_autoresolve=True,
         is_demo=False,
+        channel_filter=None,
         force_route_id=None,
     ):
         ChannelFilter = apps.get_model("alerts", "ChannelFilter")
@@ -87,9 +88,10 @@ class Alert(models.Model):
         AlertGroupLogRecord = apps.get_model("alerts", "AlertGroupLogRecord")
 
         group_data = Alert.render_group_data(alert_receive_channel, raw_request_data, is_demo)
-        channel_filter = ChannelFilter.select_filter(
-            alert_receive_channel, raw_request_data, title, message, force_route_id
-        )
+        if channel_filter is None:
+            channel_filter = ChannelFilter.select_filter(
+                alert_receive_channel, raw_request_data, title, message, force_route_id
+            )
 
         group, group_created = AlertGroup.all_objects.get_or_create_grouping(
             channel=alert_receive_channel,

--- a/engine/apps/alerts/paging.py
+++ b/engine/apps/alerts/paging.py
@@ -47,7 +47,7 @@ def _trigger_alert(
     if alert_receive_channel.default_channel_filter is None:
         ChannelFilter.objects.create(
             alert_receive_channel=alert_receive_channel,
-            notify_in_slack=False,
+            notify_in_slack=True,
             is_default=True,
         )
 
@@ -59,7 +59,7 @@ def _trigger_alert(
             is_default=False,
             defaults={
                 "filtering_term": f"escalate to {escalation_chain.name}",
-                "notify_in_slack": False,
+                "notify_in_slack": True,
             },
         )
 

--- a/engine/apps/alerts/tests/test_alert.py
+++ b/engine/apps/alerts/tests/test_alert.py
@@ -1,0 +1,43 @@
+import pytest
+
+from apps.alerts.models import Alert
+
+
+@pytest.mark.django_db
+def test_alert_create_default_channel_filter(make_organization, make_alert_receive_channel, make_channel_filter):
+    organization = make_organization()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    channel_filter = make_channel_filter(alert_receive_channel, is_default=True)
+
+    alert = Alert.create(
+        title="the title",
+        message="the message",
+        alert_receive_channel=alert_receive_channel,
+        raw_request_data={},
+        integration_unique_data={},
+        image_url=None,
+        link_to_upstream_details=None,
+    )
+
+    assert alert.group.channel_filter == channel_filter
+
+
+@pytest.mark.django_db
+def test_alert_create_custom_channel_filter(make_organization, make_alert_receive_channel, make_channel_filter):
+    organization = make_organization()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    make_channel_filter(alert_receive_channel, is_default=True)
+    other_channel_filter = make_channel_filter(alert_receive_channel)
+
+    alert = Alert.create(
+        title="the title",
+        message="the message",
+        alert_receive_channel=alert_receive_channel,
+        raw_request_data={},
+        integration_unique_data={},
+        image_url=None,
+        link_to_upstream_details=None,
+        channel_filter=other_channel_filter,
+    )
+
+    assert alert.group.channel_filter == other_channel_filter

--- a/engine/apps/alerts/tests/test_paging.py
+++ b/engine/apps/alerts/tests/test_paging.py
@@ -275,7 +275,7 @@ def test_direct_paging_custom_chain(
     channel_filter = ag.channel_filter_with_respect_to_escalation_snapshot
     assert channel_filter is not None
     assert not channel_filter.is_default
-    assert not channel_filter.notify_in_slack
+    assert channel_filter.notify_in_slack
     assert ag.escalation_chain_with_respect_to_escalation_snapshot == custom_chain
 
 

--- a/engine/apps/integrations/templates/html/integration_direct_paging.html
+++ b/engine/apps/integrations/templates/html/integration_direct_paging.html
@@ -1,0 +1,2 @@
+
+<p>You can create a direct page alert group from the web UI</p>

--- a/engine/config_integrations/direct_paging.py
+++ b/engine/config_integrations/direct_paging.py
@@ -1,0 +1,56 @@
+# Main
+enabled = True
+title = "Direct paging"
+slug = "direct_paging"
+short_description = None
+description = None
+is_displayed_on_web = False
+is_featured = False
+is_able_to_autoresolve = False
+is_demo_alert_enabled = False
+
+description = None
+
+# Default templates
+slack_title = """\
+*<{{ grafana_oncall_link }}|#{{ grafana_oncall_incident_id }} {{ payload.oncall.title }}>* via {{ integration_name }}
+{% if source_link %}
+ (*<{{ source_link }}|source>*)
+{% endif %}
+"""
+
+slack_message = """{{ payload.oncall.message }}
+
+created by {{ payload.oncall.author_username }}
+"""
+
+slack_image_url = None
+
+web_title = "{{ payload.oncall.title }}"
+
+web_message = """{{ payload.oncall.message }}
+{% if source_link %}
+<{{ source_link }} | Link to the original message >
+{% endif %}
+created by {{ payload.oncall.author_username }}
+"""
+
+web_image_url = slack_image_url
+
+sms_title = web_title
+
+phone_call_title = sms_title
+
+telegram_title = sms_title
+
+telegram_message = slack_message
+
+telegram_image_url = slack_image_url
+
+source_link = "{{ payload.oncall.permalink }}"
+
+grouping_id = """{{ payload }}"""
+
+resolve_condition = None
+
+acknowledge_condition = None

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -617,6 +617,7 @@ INSTALLED_ONCALL_INTEGRATIONS = [
     "config_integrations.manual",
     "config_integrations.slack_channel",
     "config_integrations.zabbix",
+    "config_integrations.direct_paging",
 ]
 
 if OSS_INSTALLATION:


### PR DESCRIPTION
Also changes the default integration used when creating an alert group for a direct page to a custom manual integration to avoid conflicts/unexpected behaviors with existing manual alerts.