### PR TITLE
Disable unused home tab

### DIFF
--- a/docs/sources/open-source/_index.md
+++ b/docs/sources/open-source/_index.md
@@ -78,7 +78,7 @@ display_information:
   name: <YOUR_BOT_NAME>
 features:
   app_home:
-    home_tab_enabled: true
+    home_tab_enabled: false
     messages_tab_enabled: true
     messages_tab_read_only_enabled: false
   bot_user:


### PR DESCRIPTION
Set home_tab_enabled for slack app manifest