### PR TITLE
Add a dummy step for declare incident button in slack

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py
@@ -312,13 +312,14 @@ class AlertGroupSlackRenderer(AlertGroupBaseRenderer):
                 resolution_notes_button["text"]["text"] = "Add Resolution notes"
             buttons.append(resolution_notes_button)
 
-            # Incident button
+            # Declare Incident button
             if self.alert_group.channel.organization.is_grafana_incident_enabled:
                 incident_button = {
                     "type": "button",
                     "text": {"type": "plain_text", "text": ":fire: Declare Incident", "emoji": True},
                     "value": "declare_incident",
                     "url": self.alert_group.declare_incident_link,
+                    "action_id": ScenarioStep.get_step("declare_incident", "DeclareIncidentStep").routing_uid(),
                 }
                 buttons.append(incident_button)
         else:

--- a/engine/apps/slack/scenarios/declare_incident.py
+++ b/engine/apps/slack/scenarios/declare_incident.py
@@ -1,0 +1,23 @@
+from apps.slack.scenarios import scenario_step
+
+
+class DeclareIncidentStep(scenario_step.ScenarioStep):
+    tags = [
+        scenario_step.ScenarioStep.TAG_INCIDENT_ROUTINE,
+    ]
+
+    def process_scenario(self, slack_user_identity, slack_team_identity, payload, action=None):
+        """
+        Slack sends a POST request to the backend upon clicking a button with a redirect link to Incident.
+        This is a dummy step, that is used to prevent raising 'Step is undefined' exception.
+        """
+
+
+STEPS_ROUTING = [
+    {
+        "payload_type": scenario_step.PAYLOAD_TYPE_BLOCK_ACTIONS,
+        "block_action_type": scenario_step.BLOCK_ACTION_TYPE_BUTTON,
+        "block_action_id": DeclareIncidentStep.routing_uid(),
+        "step": DeclareIncidentStep,
+    },
+]

--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -15,11 +15,12 @@ from apps.api.permissions import RBACPermission
 from apps.auth_token.auth import PluginAuthentication
 from apps.base.utils import live_settings
 from apps.slack.scenarios.alertgroup_appearance import STEPS_ROUTING as ALERTGROUP_APPEARANCE_ROUTING
+
+# Importing routes from scenarios
+from apps.slack.scenarios.declare_incident import STEPS_ROUTING as DECLARE_INCIDENT_ROUTING
 from apps.slack.scenarios.distribute_alerts import STEPS_ROUTING as DISTRIBUTION_STEPS_ROUTING
 from apps.slack.scenarios.invited_to_channel import STEPS_ROUTING as INVITED_TO_CHANNEL_ROUTING
 from apps.slack.scenarios.manual_incident import STEPS_ROUTING as MANUAL_INCIDENT_ROUTING
-
-# Importing routes from scenarios
 from apps.slack.scenarios.onboarding import STEPS_ROUTING as ONBOARDING_STEPS_ROUTING
 from apps.slack.scenarios.profile_update import STEPS_ROUTING as PROFILE_UPDATE_ROUTING
 from apps.slack.scenarios.resolution_note import STEPS_ROUTING as RESOLUTION_NOTE_ROUTING
@@ -68,6 +69,7 @@ SCENARIOS_ROUTES.extend(SLACK_USERGROUP_UPDATE_ROUTING)
 SCENARIOS_ROUTES.extend(CHANNEL_ROUTING)
 SCENARIOS_ROUTES.extend(PROFILE_UPDATE_ROUTING)
 SCENARIOS_ROUTES.extend(MANUAL_INCIDENT_ROUTING)
+SCENARIOS_ROUTES.extend(DECLARE_INCIDENT_ROUTING)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Add a dummy step for declare incident button to prevent raising 'Step is undefined' exception because Slack sends a POST request to the backend upon clicking a button with a redirect link to Incident.
This pr doesn't change any functionality
