### PR TITLE
Hide direct paging integrations

### DIFF
--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -169,7 +169,8 @@ class FastAlertReceiveChannelSerializer(serializers.ModelSerializer):
         fields = ["id", "integration", "verbal_name", "deleted"]
 
     def get_deleted(self, obj):
-        return obj.deleted_at is not None
+        # Treat direct paging integrations as deleted, so integration settings are disabled on the frontend
+        return obj.deleted_at is not None or obj.integration == AlertReceiveChannel.INTEGRATION_DIRECT_PAGING
 
 
 class FilterAlertReceiveChannelSerializer(serializers.ModelSerializer):

--- a/engine/apps/api/tests/test_alert_group.py
+++ b/engine/apps/api/tests/test_alert_group.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from apps.alerts.models import AlertGroup, AlertGroupLogRecord
+from apps.alerts.models import AlertGroup, AlertGroupLogRecord, AlertReceiveChannel
 from apps.api.permissions import LegacyAccessControlRole
 
 alert_raw_request_data = {
@@ -1585,3 +1585,25 @@ def test_alert_group_paged_users(
     url = reverse("api-internal:alertgroup-detail", kwargs={"pk": new_alert_group.public_primary_key})
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
     assert response.json()["paged_users"] == [user2.short()]
+
+
+@pytest.mark.django_db
+def test_direct_paging_integration_treated_as_deleted(
+    make_organization_and_user_with_plugin_token,
+    make_alert_receive_channel,
+    alert_group_internal_api_setup,
+    make_channel_filter,
+    make_alert_group,
+    make_user_auth_headers,
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    alert_receive_channel = make_alert_receive_channel(
+        organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING
+    )
+    alert_group = make_alert_group(alert_receive_channel)
+
+    client = APIClient()
+    url = reverse("api-internal:alertgroup-detail", kwargs={"pk": alert_group.public_primary_key})
+
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+    assert response.json()["alert_receive_channel"]["deleted"] is True

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -675,7 +675,6 @@ def test_get_alert_receive_channels_direct_paging_hidden(
     make_organization_and_user_with_plugin_token, make_alert_receive_channel, make_user_auth_headers
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
-    non_direct_paging_alert_receive_channel = make_alert_receive_channel(user.organization)
     make_alert_receive_channel(user.organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
 
     client = APIClient()
@@ -684,6 +683,4 @@ def test_get_alert_receive_channels_direct_paging_hidden(
 
     # Check no direct paging integrations in the response
     assert response.status_code == status.HTTP_200_OK
-    assert non_direct_paging_alert_receive_channel.public_primary_key not in [
-        integration["id"] for integration in response.json()
-    ]
+    assert response.json() == []

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -668,3 +668,22 @@ def test_alert_receive_channel_counters_per_integration_permissions(
         response = client.get(url, format="json", **make_user_auth_headers(user, token))
 
         assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+def test_get_alert_receive_channels_direct_paging_hidden(
+    make_organization_and_user_with_plugin_token, make_alert_receive_channel, make_user_auth_headers
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    non_direct_paging_alert_receive_channel = make_alert_receive_channel(user.organization)
+    make_alert_receive_channel(user.organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
+
+    client = APIClient()
+    url = reverse("api-internal:alert_receive_channel-list")
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+
+    # Check no direct paging integrations in the response
+    assert response.status_code == status.HTTP_200_OK
+    assert non_direct_paging_alert_receive_channel.public_primary_key not in [
+        integration["id"] for integration in response.json()
+    ]

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -136,6 +136,10 @@ class AlertReceiveChannelView(
             )
             if eager:
                 queryset = self.serializer_class.setup_eager_loading(queryset)
+
+        # Hide direct paging integrations
+        queryset = queryset.exclude(integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
+
         return queryset
 
     @action(detail=True, methods=["post"], throttle_classes=[DemoAlertThrottler])

--- a/engine/apps/public_api/tests/test_integrations.py
+++ b/engine/apps/public_api/tests/test_integrations.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from apps.alerts.models import AlertReceiveChannel
 from apps.base.tests.messaging_backend import TestOnlyBackend
 
 TEST_MESSAGING_BACKEND_FIELD = TestOnlyBackend.backend_id.lower()
@@ -570,3 +571,25 @@ def test_set_default_template(
     response = client.put(url, data=data_for_update, format="json", HTTP_AUTHORIZATION=f"{token}")
     assert response.status_code == status.HTTP_200_OK
     assert response.data == expected_response
+
+
+@pytest.mark.django_db
+def test_get_list_integrations_direct_paging_hidden(
+    make_organization_and_user_with_token,
+    make_alert_receive_channel,
+    make_channel_filter,
+    make_integration_heartbeat,
+):
+    organization, user, token = make_organization_and_user_with_token()
+    non_direct_paging_integration = make_alert_receive_channel(organization)
+    make_alert_receive_channel(organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
+
+    client = APIClient()
+    url = reverse("api-public:integrations-list")
+    response = client.get(url, format="json", HTTP_AUTHORIZATION=f"{token}")
+
+    # Check no direct paging integrations in the response
+    assert response.status_code == status.HTTP_200_OK
+    assert non_direct_paging_integration.public_primary_key not in [
+        integration["id"] for integration in response.json()
+    ]

--- a/engine/apps/public_api/tests/test_integrations.py
+++ b/engine/apps/public_api/tests/test_integrations.py
@@ -581,7 +581,6 @@ def test_get_list_integrations_direct_paging_hidden(
     make_integration_heartbeat,
 ):
     organization, user, token = make_organization_and_user_with_token()
-    non_direct_paging_integration = make_alert_receive_channel(organization)
     make_alert_receive_channel(organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
 
     client = APIClient()
@@ -590,6 +589,4 @@ def test_get_list_integrations_direct_paging_hidden(
 
     # Check no direct paging integrations in the response
     assert response.status_code == status.HTTP_200_OK
-    assert non_direct_paging_integration.public_primary_key not in [
-        integration["id"] for integration in response.json()
-    ]
+    assert response.json()["results"] == []

--- a/engine/apps/public_api/views/integrations.py
+++ b/engine/apps/public_api/views/integrations.py
@@ -47,6 +47,10 @@ class IntegrationView(
         queryset = self.filter_queryset(queryset)
         queryset = self.serializer_class.setup_eager_loading(queryset)
         queryset = queryset.annotate(alert_groups_count_annotated=Count("alert_groups", distinct=True))
+
+        # Hide direct paging integrations
+        queryset = queryset.exclude(integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
+
         return queryset
 
     def get_object(self):

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -297,7 +297,10 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
             </HorizontalGroup>
 
             <HorizontalGroup>
-              <PluginLink query={{ page: 'integrations', id: incident.alert_receive_channel.id }}>
+              <PluginLink
+                disabled={incident.alert_receive_channel.deleted}
+                query={{ page: 'integrations', id: incident.alert_receive_channel.id }}
+              >
                 <Button disabled={incident.alert_receive_channel.deleted} variant="secondary" size="sm" icon="compass">
                   Go to Integration
                 </Button>


### PR DESCRIPTION
# What this PR does
Hide direct paging integrations from the web UI. Related to https://github.com/grafana/oncall/issues/823

## Checklist

- [x] Tests updated
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)
