### PR TITLE
add github action to verify that changelog has been updated

### DIFF
--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -14,5 +14,6 @@ jobs:
         with:
           fileName: CHANGELOG.md
           noChangelogLabel: no changelog
+          checkNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -1,0 +1,22 @@
+name: Verify CHANGELOG updated
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+      - dev
+
+jobs:
+  verfiy-changelog-updated:
+    name: Verify CHANGELOG updated
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Changelog check
+        uses: Zomzog/changelog-checker@v1.2.0
+        with:
+          fileName: CHANGELOG.md
+          noChangelogLabel: no changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Changelog check
-        uses: Zomzog/changelog-checker@v1.2.0
+        uses: Zomzog/changelog-checker@v1.3.0
         with:
           fileName: CHANGELOG.md
           noChangelogLabel: no changelog

--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -1,11 +1,7 @@
 name: Verify CHANGELOG updated
 
 on:
-  pull_request:
-    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - main
-      - dev
+  - pull_request
 
 jobs:
   verfiy-changelog-updated:

--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -1,7 +1,11 @@
 name: Verify CHANGELOG updated
 
 on:
-  - pull_request
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+      - dev
 
 jobs:
   verfiy-changelog-updated:


### PR DESCRIPTION
# What this PR does

Add a GitHub Action to check that the `CHANGELOG.md` has been updated. If no `CHANGELOG.md` change is required, simply add the "no changelog" label to your PR, which will effectively skip this check.