### PR TITLE
Fix cloud connection frontend bug

### DIFF
--- a/grafana-plugin/src/state/rootBaseStore/index.ts
+++ b/grafana-plugin/src/state/rootBaseStore/index.ts
@@ -98,10 +98,20 @@ export class RootBaseStore {
   // stores
 
   async updateBasicData() {
-    const storeUpdatePromises = [
+    const updateFeatures = async () => {
+      await this.updateFeatures();
+
+      // Only fetch cloud connection status when cloud connection feature is enabled on OSS instance
+      // Note that this.hasFeature can only be called after this.updateFeatures()
+      if (this.hasFeature(AppFeature.CloudConnection)) {
+        await this.cloudStore.loadCloudConnectionStatus();
+      }
+    };
+
+    return Promise.all([
       this.teamStore.loadCurrentTeam(),
       this.grafanaTeamStore.updateItems(),
-      this.updateFeatures(),
+      updateFeatures(),
       this.userStore.updateNotificationPolicyOptions(),
       this.userStore.updateNotifyByOptions(),
       this.alertReceiveChannelStore.updateAlertReceiveChannelOptions(),
@@ -109,14 +119,7 @@ export class RootBaseStore {
       this.escalationPolicyStore.updateWebEscalationPolicyOptions(),
       this.escalationPolicyStore.updateEscalationPolicyOptions(),
       this.escalationPolicyStore.updateNumMinutesInWindowOptions(),
-    ];
-
-    // Only fetch cloud connection status when cloud connection feature is enabled on OSS instance
-    if (this.hasFeature(AppFeature.CloudConnection)) {
-      storeUpdatePromises.push(this.cloudStore.loadCloudConnectionStatus());
-    }
-
-    return Promise.all(storeUpdatePromises);
+    ]);
   }
 
   setupPluginError(errorMsg: string) {


### PR DESCRIPTION
# What this PR does
Fixes a bug on the frontend when `this.cloudStore.loadCloudConnectionStatus()` fails to run due to features list not being updated yet in `updateBasicData` while initially loading the plugin page.