### PR TITLE
Move silk profiler under env variable setting

### DIFF
--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -26,6 +26,7 @@ x-env-vars: &oncall-env-vars
   GRAFANA_API_URL: http://localhost:3000
   GOOGLE_APPLICATION_CREDENTIALS: /etc/app/gcp_service_account.json
   FCM_PROJECT_ID: oncall-mobile-dev
+  SILK_PROFILER_ENABLED: True
 
 # basically this is needed because the oncall backend containers have been configured to communicate w/ grafana via
 # http://localhost:3000 (GRAFANA_API_URL). This URL is used in two scenarios:

--- a/engine/engine/urls.py
+++ b/engine/engine/urls.py
@@ -70,6 +70,7 @@ if settings.DEBUG:
         path("__debug__/", include(debug_toolbar.urls)),
     ] + urlpatterns
 
-    urlpatterns += [path("silk/", include("silk.urls", namespace="silk"))]
+if settings.SILK_PROFILER_ENABLED:
+    urlpatterns += [path(settings.SILK_PATH, include("silk.urls", namespace="silk"))]
 
 admin.site.site_header = settings.ADMIN_SITE_HEADER

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -464,14 +464,20 @@ INTERNAL_IPS = ["127.0.0.1"]
 
 SELF_IP = os.environ.get("SELF_IP")
 
-SILK_PATH = os.environ.get("SILK_PATH", "silk/")
-SILKY_AUTHENTICATION = True
-SILKY_AUTHORISATION = True
-SILKY_META = True
-SILKY_INTERCEPT_PERCENT = 1
-SILKY_MAX_RECORDED_REQUESTS = 10**4
+SILK_PROFILER_ENABLED = getenv_boolean("SILK_PROFILER_ENABLED", default=False)
+if SILK_PROFILER_ENABLED:
+    SILK_PATH = os.environ.get("SILK_PATH", "silk/")
+    SILKY_INTERCEPT_PERCENT = getenv_integer("SILKY_INTERCEPT_PERCENT", 100)
 
-INSTALLED_APPS += ["silk"]
+    INSTALLED_APPS += ["silk"]
+    MIDDLEWARE += ["silk.middleware.SilkyMiddleware"]
+
+    SILKY_AUTHENTICATION = True
+    SILKY_AUTHORISATION = True
+    SILKY_META = True
+    SILKY_MAX_RECORDED_REQUESTS = 10**4
+    SILKY_PYTHON_PROFILER = True
+
 # get ONCALL_DJANGO_ADMIN_PATH from env and add trailing / to it
 ONCALL_DJANGO_ADMIN_PATH = os.environ.get("ONCALL_DJANGO_ADMIN_PATH", "django-admin") + "/"
 

--- a/engine/settings/dev.py
+++ b/engine/settings/dev.py
@@ -26,8 +26,6 @@ MIRAGE_CIPHER_IV = os.environ.get("MIRAGE_CIPHER_IV", "tZZa+60zTZO2NRcS")
 
 TESTING = "pytest" in sys.modules or "unittest" in sys.modules
 
-SILKY_PYTHON_PROFILER = True
-
 # For any requests that come in with that header/value, request.is_secure() will return True.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
@@ -53,9 +51,6 @@ if getenv_boolean("DEV_DEBUG_VIEW_SQL_QUERIES", default=False):
             }
         },
     }
-
-SILKY_INTERCEPT_PERCENT = 100
-MIDDLEWARE += ["silk.middleware.SilkyMiddleware"]
 
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {


### PR DESCRIPTION
# What this PR does

This PR moves silk profiler under the settings flag which can be configured with env vars. It will allow us to enable silk on the clusters, e.g. dev

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
