### PR TITLE
add small script + github action to check that public docs updated

### DIFF
--- a/.github/verify-public-docs-updated.sh
+++ b/.github/verify-public-docs-updated.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+ENGINE_DIR="engine"
+UI_DIR="grafana-plugin"
+PUBLIC_DOCS_DIR="docs"
+
+DIRS_CHANGED=$(git diff HEAD~1 --name-only | xargs dirname | sort | uniq) # https://stackoverflow.com/a/73149899/3902555
+
+if [[ $DIRS_CHANGED =~ $ENGINE_DIR ]] || [[ $DIRS_CHANGED =~ $UI_DIR ]]; then
+  echo "Changes were made to the ${ENGINE_DIR} and/or ${UI_DIR} directories"
+
+  # check if we have any changes to the public docs directory as well. If not,
+  if [[ ! $DIRS_CHANGED =~ $PUBLIC_DOCS_DIR ]]; then
+    echo "Changes were not made to the public documentation (${PUBLIC_DOCS_DIR} directory). Either update the documentation accordingly with your changes, or add the 'no public docs' label if changes to the public docs are not necessary for your PR."
+    exit 1
+  else
+    echo "Changes were also made to the public documentation. Thank you!"
+    exit 0
+  fi
+
+else
+  echo "Changes were not made to either the ${ENGINE_DIR} or ${UI_DIR} directories"
+fi

--- a/.github/workflows/verify-public-docs-updated.yml
+++ b/.github/workflows/verify-public-docs-updated.yml
@@ -1,0 +1,20 @@
+name: Verify public documentation updated
+
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+      - dev
+
+jobs:
+  verify-public-docs-updated:
+    name: Verify public documentation updated
+    # Don't run this job if the "no public docs" label is applied to the PR
+    # https://github.com/orgs/community/discussions/26712#discussioncomment-3253012
+    if: "!contains(github.event.pull_request.labels.*.name, 'no public docs')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Public documentation checker
+        run: ./.github/verify-public-docs-updated.sh


### PR DESCRIPTION
# What this PR does

This PR adds a new GitHub Action which will run on PRs against `dev` and `main`. The GitHub action will not run if the label of "no public docs" has been applied to the PR in question:

Otherwise, it will check to see if any changes were made to either the `engine` or `grafana-plugin` directories. If so, it will then check whether changes were also made to the `docs` directory. If not, it will fail the job and block the build.


**No changes made to "engine" or "grafana-plugin" directories**
![Screenshot 2023-01-20 at 13 06 50](https://user-images.githubusercontent.com/9406895/213692033-0be96f8e-82df-44af-9d96-db765bc457ad.png)

**Job skipped when "no public docs" label applied to PR**
![Screenshot 2023-01-20 at 13 08 46](https://user-images.githubusercontent.com/9406895/213691850-c38ad20a-3236-4dcd-9577-dcc4c39c6d4a.png)

**Changes made to "engine" and/or "grafana-plugin" directories and public docs also updated**
![Screenshot 2023-01-20 at 13 07 19](https://user-images.githubusercontent.com/9406895/213691936-c28a2bb2-0d92-42b6-8d78-381b919821cb.png)

**Changes made to "engine" and/or "grafana-plugin" directories but public docs were not updated**
![Screenshot 2023-01-20 at 13 06 09](https://user-images.githubusercontent.com/9406895/213691977-4eaf7f63-3cc0-481b-97a9-5920481e958e.png)


## Which issue(s) this PR fixes

N/A

## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)
