### PR TITLE
remove duplicate call in UI to GET /alert_receive_channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Slack slash command allowing to trigger a direct page via a manually created alert group
 
+### Fixed
+
+- Removed duplicate API call, in the UI on plugin initial load, to `GET /api/internal/v1/alert_receive_channels`
+
 ## v1.1.18 (2023-01-18)
 
 ### Added
@@ -26,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Modified how the `Organization.is_rbac_permissions_enabled` flag is set,
-based on whether we are dealing with an open-source, or cloud installation
+  based on whether we are dealing with an open-source, or cloud installation
 - Backend implementation to support direct user/schedule paging
 - Changed documentation links to open in new window
 - Remove helm chart signing

--- a/grafana-plugin/src/state/rootBaseStore/index.ts
+++ b/grafana-plugin/src/state/rootBaseStore/index.ts
@@ -115,7 +115,6 @@ export class RootBaseStore {
       this.userStore.updateNotificationPolicyOptions(),
       this.userStore.updateNotifyByOptions(),
       this.alertReceiveChannelStore.updateAlertReceiveChannelOptions(),
-      this.alertReceiveChannelStore.updateAlertReceiveChannelOptions(),
       this.escalationPolicyStore.updateWebEscalationPolicyOptions(),
       this.escalationPolicyStore.updateEscalationPolicyOptions(),
       this.escalationPolicyStore.updateNumMinutesInWindowOptions(),


### PR DESCRIPTION
# What this PR does

Related to [this PR comment](https://github.com/grafana/oncall/pull/1164#discussion_r1082337697) from @maskin25 
 
## Which issue(s) this PR fixes

**Before**
![Screenshot 2023-01-20 at 14 24 07](https://user-images.githubusercontent.com/9406895/213706172-1f219346-7e88-4e10-b2f3-c37590ecb43d.png)

**After**
![Screenshot 2023-01-20 at 14 26 05](https://user-images.githubusercontent.com/9406895/213706194-d95fc5f0-1494-4efc-ae92-31f1771ec490.png)


## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated
