### PR TITLE
Optimize alertgroups endpoint

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -20,7 +20,7 @@ COPY ./ ./
 
 # Collect static files and create an SQLite database
 RUN mkdir -p /var/lib/oncall
-RUN DJANGO_SETTINGS_MODULE=settings.prod_without_db DATABASE_TYPE=sqlite3 DATABASE_NAME=/var/lib/oncall/oncall.db SECRET_KEY="ThEmUsTSecretKEYforBUILDstage123" python manage.py collectstatic --no-input
+RUN DJANGO_SETTINGS_MODULE=settings.prod_without_db DATABASE_TYPE=sqlite3 DATABASE_NAME=/var/lib/oncall/oncall.db SECRET_KEY="ThEmUsTSecretKEYforBUILDstage123" SILK_PROFILER_ENABLED="True" python manage.py collectstatic --no-input
 RUN chown -R 1000:2000 /var/lib/oncall
 
 FROM base AS dev

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -1,11 +1,13 @@
 from datetime import timedelta
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, Max, Q
 from django.utils import timezone
 from django_filters import rest_framework as filters
 from django_filters.widgets import RangeWidget
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -15,9 +17,10 @@ from apps.alerts.models import Alert, AlertGroup, AlertReceiveChannel
 from apps.alerts.paging import unpage_user
 from apps.api.permissions import RBACPermission
 from apps.api.serializers.alert_group import AlertGroupListSerializer, AlertGroupSerializer
+from apps.api.serializers.team import TeamSerializer
 from apps.auth_token.auth import PluginAuthentication
 from apps.mobile_app.auth import MobileAppAuthTokenAuthentication
-from apps.user_management.models import User
+from apps.user_management.models import Team, User
 from common.api_helpers.exceptions import BadRequest
 from common.api_helpers.filters import DateRangeFilterMixin, ModelFieldFilterMixin
 from common.api_helpers.mixins import PreviewTemplateMixin, PublicPrimaryKeyMixin, TeamFilteringMixin
@@ -148,6 +151,34 @@ class AlertGroupFilter(DateRangeFilterMixin, ModelFieldFilterMixin, filters.Filt
 class AlertGroupTeamFilteringMixin(TeamFilteringMixin):
     TEAM_LOOKUP = "channel__team"
 
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            return super().retrieve(request, *args, **kwargs)
+        except NotFound:
+            queryset = AlertGroup.unarchived_objects.filter(
+                channel__in=AlertReceiveChannel.objects.filter(
+                    organization=self.request.auth.organization,
+                ),
+            ).only("public_primary_key")
+
+            try:
+                obj = queryset.get(public_primary_key=self.kwargs["pk"])
+            except ObjectDoesNotExist:
+                raise NotFound
+
+            obj_team = self._getattr_with_related(obj, self.TEAM_LOOKUP)
+
+            if obj_team is None or obj_team in self.request.user.teams.all():
+                if obj_team is None:
+                    obj_team = Team(public_primary_key=None, name="General", email=None, avatar_url=None)
+
+                return Response(
+                    data={"error_code": "wrong_team", "owner_team": TeamSerializer(obj_team).data},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+
+            return Response(data={"error_code": "wrong_team"}, status=status.HTTP_403_FORBIDDEN)
+
 
 class AlertGroupView(
     PreviewTemplateMixin,
@@ -206,14 +237,10 @@ class AlertGroupView(
 
     def get_queryset(self):
         # no select_related or prefetch_related is used at this point, it will be done on paginate_queryset.
-        alert_receive_channels_ids = list(
-            AlertReceiveChannel.objects.filter(
-                organization_id=self.request.auth.organization.id,
-                team_id=self.request.user.current_team,
-            ).values_list("id", flat=True)
-        )
         queryset = AlertGroup.unarchived_objects.filter(
-            channel_id__in=alert_receive_channels_ids,
+            channel__in=AlertReceiveChannel.objects.filter(
+                organization=self.request.auth.organization, team=self.request.user.current_team
+            ),
         ).only("id")
 
         return queryset

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -237,12 +237,6 @@ class AlertGroupView(
 
     def get_queryset(self):
         # no select_related or prefetch_related is used at this point, it will be done on paginate_queryset.
-        alert_receive_channels_ids = list(
-            AlertReceiveChannel.objects.filter(
-                organization_id=self.request.auth.organization.id,
-                team_id=self.request.user.current_team,
-            ).values_list("id", flat=True)
-        )
         queryset = AlertGroup.unarchived_objects.filter(
             channel__in=AlertReceiveChannel.objects.filter(
                 organization=self.request.auth.organization, team=self.request.user.current_team

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -206,8 +206,14 @@ class AlertGroupView(
 
     def get_queryset(self):
         # no select_related or prefetch_related is used at this point, it will be done on paginate_queryset.
+        alert_receive_channels_ids = list(
+            AlertReceiveChannel.objects.filter(
+                organization_id=self.request.auth.organization.id,
+                team_id=self.request.user.current_team,
+            ).values_list("id", flat=True)
+        )
         queryset = AlertGroup.unarchived_objects.filter(
-            channel__organization=self.request.auth.organization, channel__team=self.request.user.current_team
+            channel_id__in=alert_receive_channels_ids,
         ).only("id")
 
         return queryset


### PR DESCRIPTION
# What this PR does

Changing query to retrieve alert group in two completely different queries instead of one with `join`

new queries
```
SELECT alerts_alertreceivechannel.id
FROM alerts_alertreceivechannel
WHERE (alerts_alertreceivechannel.deleted_at IS NULL
       AND alerts_alertreceivechannel.organization_id = 8
       AND alerts_alertreceivechannel.team_id IS NULL)


SELECT `alerts_alertgroup`.`id`
FROM `alerts_alertgroup`
WHERE (`alerts_alertgroup`.`channel_id` IN (2,33,34,35,36,40,52,59,61,62,63,70,76,89,93,94,03,08,09,10,12,13,16,18,20,22,23,24,26,27,28,30,31,33,34,35,36,40,41,42,43,45,48,53,56,57,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,86,87,88,89,91,93,23,27,29,31,32,33,55,56,57,58,65,69,72,75,81,13,17,20,22,33,34,38,39,41,44,45,46,51,52,55,56,58,59,60,63,68,70,71)
       AND NOT `alerts_alertgroup`.`is_archived`
       AND NOT `alerts_alertgroup`.`is_archived`
       AND `alerts_alertgroup`.`root_alert_group_id` IS NULL
       AND ((NOT `alerts_alertgroup`.`silenced`
             AND NOT `alerts_alertgroup`.`acknowledged`
             AND NOT `alerts_alertgroup`.`resolved`)
            OR (`alerts_alertgroup`.`acknowledged`
                AND NOT `alerts_alertgroup`.`resolved`))
       AND NOT `alerts_alertgroup`.`is_archived`)
ORDER BY `alerts_alertgroup`.`id` DESC
LIMIT 26
```

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
