### PR TITLE
Update message when user needs to connect their profile

### DIFF
--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -520,8 +520,8 @@ class SlackEventApiEndpointView(APIView):
             return
 
         text = (
-            "The information in workspace is read-only. To be able to intercat with OnCall alert groups you need to connect a personal account.\n"
-            "Please go to the *Grafana* -> *OnCall* -> *Users*, "
+            "The information in this workspace is read-only. To be able to interact with OnCall alert groups you need to connect a personal account.\n"
+            "Please go to *Grafana* -> *OnCall* -> *Users*, "
             "choose *your profile* and click the *connect* button.\n"
             ":rocket: :rocket: :rocket:"
         )

--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -520,7 +520,7 @@ class SlackEventApiEndpointView(APIView):
             return
 
         text = (
-            "The information in this workspace is read-only. To be able to interact with OnCall alert groups you need to connect a personal account.\n"
+            "The information in this workspace is read-only. To interact with OnCall alert groups you need to connect a personal account.\n"
             "Please go to *Grafana* -> *OnCall* -> *Users*, "
             "choose *your profile* and click the *connect* button.\n"
             ":rocket: :rocket: :rocket:"


### PR DESCRIPTION
# What this PR does

This just tweaks the message users get when they try to interact via slack but haven't connected their profile, it fixes a typo and streamlines the text.
