### PR TITLE
Add check for MANIFEST.txt after signing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,7 @@ steps:
       - apt-get install zip
       - cd grafana-plugin
       - yarn sign
+      - if [ ! -f dist/MANIFEST.txt ]; then echo "Sign failed, MANIFEST.txt not created, aborting." && exit 1; fi
       - yarn ci-build:finish
       - yarn ci-package
       - cd ci/dist
@@ -194,6 +195,7 @@ steps:
       - apt-get install zip
       - cd grafana-plugin
       - yarn sign
+      - if [ ! -f dist/MANIFEST.txt ]; then echo "Sign failed, MANIFEST.txt not created, aborting." && exit 1; fi
       - yarn ci-build:finish
       - yarn ci-package
       - cd ci/dist
@@ -415,6 +417,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: f77d17560f910f1a99ab8230674dc25c226d2b3c73cb90e63e53fb8ba760d57a
+hmac: 662c2be2ccdd106ae4f23a557f981ef601d9693b0333e0bcda7189ddf16fb49a
 
 ...


### PR DESCRIPTION
Add a check in drone so build fails if plugin is not successfully signed.