### PR TITLE
Remove DynamicSetting usage for mobile app backend on OSS

### DIFF
--- a/engine/apps/mobile_app/backend.py
+++ b/engine/apps/mobile_app/backend.py
@@ -53,6 +53,10 @@ class MobileAppBackend(BaseMessagingBackend):
 
     @staticmethod
     def is_enabled_for_organization(organization):
+        # Setting FEATURE_MOBILE_APP_INTEGRATION_ENABLED to True is enough to enable mobile app on OSS instances
+        if settings.LICENSE == settings.OPEN_SOURCE_LICENSE_NAME:
+            return True
+
         mobile_app_settings, _ = DynamicSetting.objects.get_or_create(
             name="mobile_app_settings", defaults={"json_value": {"org_ids": []}}
         )


### PR DESCRIPTION
# What this PR does
Make so there's no need to populate `mobile_app_settings` DynamicSetting when using the OSS license to turn on the mobile app backend.