### PR TITLE
Add doc-validator workflow

### DIFF
--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -12,4 +12,4 @@ jobs:
       - name: "Checkout code"
         uses: "actions/checkout@v3"
       - name: "Run doc-validator tool"
-        run: "doc-validator --skip-image-validation ./docs/sources /docs/oncall/latest"
+        run: "doc-validator --skip-image-validation docs/sources /docs/oncall/latest"

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -1,0 +1,15 @@
+name: "doc-validator"
+on:
+  pull_request:
+    paths: ["docs/sources/**"]
+  workflow_dispatch:
+jobs:
+  doc-validator:
+    runs-on: "ubuntu-latest"
+    container:
+      image: "grafana/doc-validator:v1.9.0"
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v3"
+      - name: "Run doc-validator tool"
+        run: "doc-validator --skip-image-validation ./docs/sources /docs/oncall/latest"

--- a/.github/workflows/doc-validator.yml
+++ b/.github/workflows/doc-validator.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths: ["docs/sources/**"]
   workflow_dispatch:
+  # You can use the merge_group event to trigger your GitHub Actions workflow when
+  # a pull request is added to a merge queue
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
+
 jobs:
   doc-validator:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "docs/sources/**"
   workflow_dispatch:
+
 jobs:
   test:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "docs/sources/**"
   workflow_dispatch:
+
 jobs:
   test:
     runs-on: "ubuntu-latest"

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ title: Grafana OnCall
 weight: 1000
 ---
 
-# Grafana OnCall documentation
+# Grafana OnCall
 
 <img src="/static/img/docs/oncall/oncall-logo.png" class="no-shadow" width="700px">
 

--- a/docs/sources/calendar-schedules/_index.md
+++ b/docs/sources/calendar-schedules/_index.md
@@ -60,5 +60,4 @@ Use the Grafana OnCall Terraform provider to manage schedules within your “as-
 via Terraform are automatically added to your schedules in Grafana OnCall. Similar to the iCal import, these schedules
 read-only and cannot be edited from the UI.
 
-To learn more, read our [Get started with Grafana OnCall and Terraform](
-<https://grafana.com/blog/2022/08/29/get-started-with-grafana-oncall-and-terraform/>) blog post.
+To learn more, read our [Get started with Grafana OnCall and Terraform](https://grafana.com/blog/2022/08/29/get-started-with-grafana-oncall-and-terraform/) blog post.

--- a/docs/sources/calendar-schedules/web-schedule/_index.md
+++ b/docs/sources/calendar-schedules/web-schedule/_index.md
@@ -12,7 +12,7 @@ keywords:
 weight: 100
 ---
 
-# About web-based schedules
+# Web-based schedules
 
 Grafana OnCall allows you to map out recurring on-call coverage and automate the escalation of alert notifications to
 on-call users. Configure and manage on-call schedules directly in the Grafana OnCall plugin to easily customize
@@ -23,7 +23,7 @@ This topic provides an overview of key components and features.
 For information on how to create a schedule in Grafana OnCall, refer to
 [Create an on-call schedule]({{< relref "create-schedule" >}})
 
->**Note**: User permissions determine which components of Grafana OnCall are available to you.
+> **Note**: User permissions determine which components of Grafana OnCall are available to you.
 
 ## Schedule settings
 
@@ -54,6 +54,6 @@ on this calendar will take precedence over the rotations calendar.
 ## Schedule export
 
 Export on-call schedules from Grafana OnCall to your preferred calendar app with a one-time secret iCal URL. The
-schedule export allows you to view on-call shifts alongside the rest of your schedule.  
+schedule export allows you to view on-call shifts alongside the rest of your schedule.
 
 For more information, refer to [Export on-call schedules]({{< relref "calendar-export" >}})

--- a/docs/sources/calendar-schedules/web-schedule/create-schedule/index.md
+++ b/docs/sources/calendar-schedules/web-schedule/create-schedule/index.md
@@ -13,7 +13,7 @@ keywords:
 weight: 300
 ---
 
-# Create on-call schedules in Grafana OnCall
+# Create on-call schedules
 
 Schedules allow you to map out recurring on-call coverage and automate the escalation of alert notifications to
 currently on-call users. With Grafana OnCall, you can customize rotations with a live schedule preview to visualize
@@ -39,7 +39,7 @@ To create a new on-call schedule:
 1. Provide a name and review available schedule settings
 1. When you’re done, click **Create Schedule**
 
->**Note:** You can edit your schedule settings at any time.
+> **Note:** You can edit your schedule settings at any time.
 
 ### Add a rotation to your on-call schedule
 
@@ -51,9 +51,9 @@ To add a rotation to an on-call schedule:
 1. From your newly created schedule, click **+ Add rotation** and select **New Layer**.
 1. Complete the rotation creation form according to your rotation parameters.
 1. Add users to the rotation from the dropdown.
-You can separate users into user groups to rotate through individual users per shift.
-User groups that contain
-multiple users results in all users in the group being included in corresponding shifts.
+   You can separate users into user groups to rotate through individual users per shift.
+   User groups that contain
+   multiple users results in all users in the group being included in corresponding shifts.
 1. When you’re satisfied with the rotation preview, click **Create**.
 
 ### Add an on-call schedule to escalation chains

--- a/docs/sources/configure-user-settings/_index.md
+++ b/docs/sources/configure-user-settings/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - /docs/oncall/latest/configure-user-settings/
-canonical: https://grafana.com/docs/oncall/latest/configure-user-setting/
+canonical: https://grafana.com/docs/oncall/latest/configure-user-settings/
 keywords:
   - Grafana Cloud
   - Permission

--- a/docs/sources/escalation-policies/configure-routes/index.md
+++ b/docs/sources/escalation-policies/configure-routes/index.md
@@ -14,7 +14,7 @@ title: Configure and manage routes
 weight: 300
 ---
 
-# Configure and manage Routes
+# Configure and manage routes
 
 Set up escalation chains and routes to configure escalation behavior for alert group notifications.
 

--- a/docs/sources/integrations/available-integrations/_index.md
+++ b/docs/sources/integrations/available-integrations/_index.md
@@ -9,7 +9,7 @@ keywords:
   - on-call
   - Alertmanager
   - Prometheus
-title: Currently available integrations for Grafana OnCall
+title: Available integrations
 weight: 100
 ---
 

--- a/docs/sources/integrations/available-integrations/configure-grafana-alerting/index.md
+++ b/docs/sources/integrations/available-integrations/configure-grafana-alerting/index.md
@@ -41,7 +41,7 @@ which Grafana OnCall is being managed.
    OnCall as well as the required contact point in Alerting.
 
    > **Note:** You must connect the contact point with a notification policy. For more information, see
-   > [Contact points in Grafana Alerting](https://grafana.com/docs/grafana/latest/alerting/unified-alerting/contact-points/)
+   > [Contact points in Grafana Alerting](/docs/grafana/latest/alerting/unified-alerting/contact-points/)
 
 1. Determine the escalation chain for the new integration by either selecting an existing one or by creating a new
    escalation chain.
@@ -65,6 +65,6 @@ OnCall is being managed:
 7. Choose the contact point type `webhook`, then paste the URL generated in step 3 into the URL field.
 
    > **Note:** You must connect the contact point with a notification policy. For more information,
-   > see [Contact points in Grafana Alerting](https://grafana.com/docs/grafana/latest/alerting/unified-alerting/contact-points/).
+   > see [Contact points in Grafana Alerting](/docs/grafana/latest/alerting/unified-alerting/contact-points/).
 
 8. Click the **Edit** (pencil) icon, then click **Test**. This will send a test alert to Grafana OnCall.

--- a/docs/sources/integrations/available-integrations/configure-webhook/index.md
+++ b/docs/sources/integrations/available-integrations/configure-webhook/index.md
@@ -10,11 +10,11 @@ keywords:
   - on-call
   - Alertmanager
   - Prometheus
-title: Webhook integration for Grafana OnCall
+title: Webhook integrations
 weight: 700
 ---
 
-# Webhook integrations for Grafana OnCall
+# Webhook integrations
 
 Grafana OnCall directly supports many integrations, those that aren’t currently listed in the Integrations menu can be
 connected using the webhook integration and configured alert templates.

--- a/docs/sources/oncall-api-reference/_index.md
+++ b/docs/sources/oncall-api-reference/_index.md
@@ -2,11 +2,11 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/
-title: Grafana OnCall HTTP API reference
+title: HTTP API reference
 weight: 1500
 ---
 
-# HTTP API Reference
+# HTTP API reference
 
 Use the following guidelines for the Grafana OnCall API.
 

--- a/docs/sources/oncall-api-reference/alertgroups.md
+++ b/docs/sources/oncall-api-reference/alertgroups.md
@@ -6,7 +6,9 @@ title: Alert groups HTTP API
 weight: 400
 ---
 
-# List alert groups
+# Alert groups HTTP API
+
+## List alert groups
 
 ```shell
 curl "{{API_URL}}/api/v1/alert_groups/" \
@@ -53,7 +55,7 @@ These available filter parameters should be provided as `GET` arguments:
 
 `GET {{API_URL}}/api/v1/alert_groups/`
 
-# Delete alert groups
+## Delete alert groups
 
 ```shell
 curl "{{API_URL}}/api/v1/alert_groups/I68T24C13IFW1/" \

--- a/docs/sources/oncall-api-reference/alerts.md
+++ b/docs/sources/oncall-api-reference/alerts.md
@@ -6,7 +6,9 @@ title: Alerts HTTP API
 weight: 100
 ---
 
-# List Alerts
+# Alerts HTTP API
+
+## List Alerts
 
 ```shell
 curl "{{API_URL}}/api/v1/alerts/" \

--- a/docs/sources/oncall-api-reference/escalation_chains.md
+++ b/docs/sources/oncall-api-reference/escalation_chains.md
@@ -2,11 +2,13 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/escalation_chains/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_chains/
-title: Escalation Chains HTTP API
+title: Escalation chains HTTP API
 weight: 200
 ---
 
-# Create an escalation chain
+# Escalation chains HTTP API
+
+## Create an escalation chain
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_chains/" \
@@ -37,7 +39,7 @@ The above command returns JSON structured in the following way:
 
 `POST {{API_URL}}/api/v1/escalation_chains/`
 
-# Get an escalation chain
+## Get an escalation chain
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_chains/F5JU6KJET33FE/" \
@@ -60,7 +62,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/escalation_chains/<ESCALATION_CHAIN_ID>/`
 
-# List escalation chains
+## List escalation chains
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_chains/" \
@@ -90,7 +92,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/escalation_chains/`
 
-# Delete an escalation chain
+## Delete an escalation chain
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_chains/F5JU6KJET33FE/" \

--- a/docs/sources/oncall-api-reference/escalation_policies.md
+++ b/docs/sources/oncall-api-reference/escalation_policies.md
@@ -2,11 +2,13 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/escalation_policies/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_policies/
-title: Escalation Policies HTTP API
+title: Escalation policies HTTP API
 weight: 300
 ---
 
-# Create an escalation policy
+# Escalation policies HTTP API
+
+## Create an escalation policy
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_policies/" \
@@ -55,7 +57,7 @@ The above command returns JSON structured in the following way:
 
 `POST {{API_URL}}/api/v1/escalation_policies/`
 
-# Get an escalation policy
+## Get an escalation policy
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_policies/E3GA6SJETWWJS/" \
@@ -80,7 +82,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/escalation_policies/<ESCALATION_POLICY_ID>/`
 
-# List escalation policies
+## List escalation policies
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_policies/" \
@@ -123,7 +125,7 @@ The following available filter parameter should be provided as a `GET` argument:
 
 `GET {{API_URL}}/api/v1/escalation_policies/`
 
-# Delete an escalation policy
+## Delete an escalation policy
 
 ```shell
 curl "{{API_URL}}/api/v1/escalation_policies/E3GA6SJETWWJS/" \

--- a/docs/sources/oncall-api-reference/integrations.md
+++ b/docs/sources/oncall-api-reference/integrations.md
@@ -6,7 +6,9 @@ title: Integrations HTTP API
 weight: 500
 ---
 
-# Create an integration
+# Integrations HTTP API
+
+## Create an integration
 
 ```shell
 curl "{{API_URL}}/api/v1/integrations/" \
@@ -81,7 +83,7 @@ For example, to learn how to integrate Grafana OnCall with Alertmanager see
 
 `POST {{API_URL}}/api/v1/integrations/`
 
-# Get integration
+## Get integration
 
 ```shell
 curl "{{API_URL}}/api/v1/integrations/CFRPV98RPR1U8/" \
@@ -151,7 +153,7 @@ This endpoint retrieves an integration. Integrations are sources of alerts and a
 
 `GET {{API_URL}}/api/v1/integrations/<INTEGRATION_ID>/`
 
-# List integrations
+## List integrations
 
 ```shell
 curl "{{API_URL}}/api/v1/integrations/" \
@@ -226,7 +228,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/integrations/`
 
-# Update integration
+## Update integration
 
 ```shell
 curl "{{API_URL}}/api/v1/integrations/CFRPV98RPR1U8/" \
@@ -298,7 +300,7 @@ The above command returns JSON structured in the following way:
 
 `PUT {{API_URL}}/api/v1/integrations/<INTEGRATION_ID>/`
 
-# Delete integration
+## Delete integration
 
 Deleted integrations will stop recording new alerts from monitoring. Integration removal won't trigger removal of
 related alert groups or alerts.

--- a/docs/sources/oncall-api-reference/on_call_shifts.md
+++ b/docs/sources/oncall-api-reference/on_call_shifts.md
@@ -6,7 +6,9 @@ title: OnCall shifts HTTP API
 weight: 600
 ---
 
-# Create an OnCall shift
+# OnCall shifts HTTP API
+
+## Create an OnCall shift
 
 ```shell
 curl "{{API_URL}}/api/v1/on_call_shifts/" \
@@ -73,7 +75,7 @@ Please see [RFC 5545](https://tools.ietf.org/html/rfc5545#section-3.3.10) for mo
 
 `POST {{API_URL}}/api/v1/on_call_shifts/`
 
-# Get OnCall shifts
+## Get OnCall shifts
 
 ```shell
 curl "{{API_URL}}/api/v1/on_call_shifts/OH3V5FYQEYJ6M/" \
@@ -102,7 +104,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/on_call_shifts/<ON_CALL_SHIFT_ID>/`
 
-# List OnCall shifts
+## List OnCall shifts
 
 ```shell
 curl "{{API_URL}}/api/v1/on_call_shifts/" \
@@ -160,7 +162,7 @@ The following available filter parameters should be provided as `GET` arguments:
 
 `GET {{API_URL}}/api/v1/on_call_shifts/`
 
-# Update OnCall shift
+## Update OnCall shift
 
 ```shell
 curl "{{API_URL}}/api/v1/on_call_shifts/OH3V5FYQEYJ6M/" \
@@ -199,7 +201,7 @@ The above command returns JSON structured in the following way:
 
 `PUT {{API_URL}}/api/v1/on_call_shifts/<ON_CALL_SHIFT_ID>/`
 
-# Delete OnCall shift
+## Delete OnCall shift
 
 ```shell
 curl "{{API_URL}}/api/v1/on_call_shifts/OH3V5FYQEYJ6M/" \

--- a/docs/sources/oncall-api-reference/outgoing_webhooks.md
+++ b/docs/sources/oncall-api-reference/outgoing_webhooks.md
@@ -6,7 +6,7 @@ title: Outgoing webhooks HTTP API
 weight: 700
 ---
 
-# Outgoing webhooks (actions)
+# Outgoing webhooks HTTP API
 
 Used in escalation policies with type `trigger_action`.
 

--- a/docs/sources/oncall-api-reference/personal_notification_rules.md
+++ b/docs/sources/oncall-api-reference/personal_notification_rules.md
@@ -2,11 +2,13 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/personal_notification_rules/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/personal_notification_rules/
-title: Personal Notification Rules HTTP API
+title: Personal notification rules HTTP API
 weight: 800
 ---
 
-# Post a personal notification rule
+# Personal notification rules HTTP API
+
+## Post a personal notification rule
 
 ```shell
 curl "{{API_URL}}/api/v1/personal_notification_rules/" \
@@ -47,7 +49,7 @@ The above command returns JSON structured in the following way:
 
 `POST {{API_URL}}/api/v1/personal_notification_rules/`
 
-# Get personal notification rule
+## Get personal notification rule
 
 ```shell
 curl "{{API_URL}}/api/v1/personal_notification_rules/ND9EHN5LN1DUU/" \
@@ -73,7 +75,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/personal_notification_rules/<PERSONAL_NOTIFICATION_RULE_ID>/`
 
-# List personal notification rules
+## List personal notification rules
 
 ```shell
 curl "{{API_URL}}/api/v1/personal_notification_rules/" \
@@ -132,7 +134,7 @@ The following available filter parameters should be provided as `GET` arguments:
 
 `GET {{API_URL}}/api/v1/personal_notification_rules/`
 
-# Delete a personal notification rule
+## Delete a personal notification rule
 
 ```shell
 curl "{{API_URL}}/api/v1/personal_notification_rules/NWAL6WFJNWDD8/" \

--- a/docs/sources/oncall-api-reference/postmortem_messages.md
+++ b/docs/sources/oncall-api-reference/postmortem_messages.md
@@ -3,11 +3,13 @@ aliases:
   - /docs/oncall/latest/oncall-api-reference/postmortem_messages/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/postmortem_messages/
 draft: true
-title: Postmortem Messages HTTP API
+title: Postmortem messages HTTP API
 weight: 900
 ---
 
-# Create a postmortem message
+# Postmortem messages HTTP API
+
+## Create a postmortem message
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortem_messages/" \
@@ -37,7 +39,7 @@ The above command returns JSON structured in the following way:
 
 `POST {{API_URL}}/api/v1/postmortem_messages/`
 
-# Get a postmortem message
+## Get a postmortem message
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortem_messages/M4BTQUS3PRHYQ/" \
@@ -63,7 +65,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/postmortem_messages/<POSTMORTEM_MESSAGE_ID>/`
 
-# List postmortem messages
+## List postmortem messages
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortem_messages/" \
@@ -100,7 +102,7 @@ The following available filter parameter should be provided as a `GET` argument:
 
 `GET {{API_URL}}/api/v1/postmortem_messages/`
 
-# Update a postmortem message
+## Update a postmortem message
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortem_messages/M4BTQUS3PRHYQ/" \
@@ -129,7 +131,7 @@ The above command returns JSON structured in the following way:
 
 `PUT {{API_URL}}/api/v1/postmortem_messages/<POSTMORTEM_MESSAGE_ID>/`
 
-# Delete a postmortem message
+## Delete a postmortem message
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortem_messages/M4BTQUS3PRHYQ/" \

--- a/docs/sources/oncall-api-reference/postmortems.md
+++ b/docs/sources/oncall-api-reference/postmortems.md
@@ -7,7 +7,9 @@ title: Postmortem HTTP API
 weight: 1000
 ---
 
-# Create a postmortem
+# Postmortem HTTP API
+
+## Create a postmortem
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortems/" \
@@ -35,7 +37,7 @@ The above command returns JSON structured in the following way:
 
 `POST {{API_URL}}/api/v1/postmortems/`
 
-# Get a postmortem
+## Get a postmortem
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortems/P658FE5K87EWZ/" \
@@ -69,7 +71,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/postmortems/<POSTMORTEM_ID>/`
 
-# List postmortems
+## List postmortems
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortems/" \
@@ -114,7 +116,7 @@ The following available filter parameter should be provided with a `GET` argumen
 
 `GET {{API_URL}}/api/v1/postmortems/`
 
-# Update a postmortem
+## Update a postmortem
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortems/P658FE5K87EWZ/" \
@@ -141,7 +143,7 @@ The above command returns JSON structured in the following way:
 
 `PUT {{API_URL}}/api/v1/postmortems/<POSTMORTEM_ID>/`
 
-# Delete a postmortem
+## Delete a postmortem
 
 ```shell
 curl "{{API_URL}}/api/v1/postmortems/P658FE5K87EWZ/" \

--- a/docs/sources/oncall-api-reference/routes.md
+++ b/docs/sources/oncall-api-reference/routes.md
@@ -6,7 +6,9 @@ title: Routes HTTP API
 weight: 1100
 ---
 
-# Create a route
+# Routes HTTP API
+
+## Create a route
 
 ```shell
 curl "{{API_URL}}/api/v1/routes/" \
@@ -63,7 +65,7 @@ Routes allow you to direct different alerts to different messenger channels and 
 
 `POST {{API_URL}}/api/v1/routes/`
 
-# Get a route
+## Get a route
 
 ```shell
 curl "{{API_URL}}/api/v1/routes/RIYGUJXCPFHXY/" \
@@ -92,7 +94,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/routes/<ROUTE_ID>/`
 
-# List routes
+## List routes
 
 ```shell
 curl "{{API_URL}}/api/v1/routes/" \
@@ -144,7 +146,7 @@ The following available filter parameters should be provided as `GET` arguments:
 
 `GET {{API_URL}}/api/v1/routes/`
 
-# Update route
+## Update route
 
 ```shell
 curl "{{API_URL}}/api/v1/routes/RIYGUJXCPFHXY/" \
@@ -180,7 +182,7 @@ The above command returns JSON structured in the following way:
 
 `PUT {{API_URL}}/api/v1/routes/<ROUTE_ID>/`
 
-# Delete a route
+## Delete a route
 
 ```shell
 curl "{{API_URL}}/api/v1/routes/RIYGUJXCPFHXY/" \

--- a/docs/sources/oncall-api-reference/schedules.md
+++ b/docs/sources/oncall-api-reference/schedules.md
@@ -6,7 +6,9 @@ title: Schedule HTTP API
 weight: 1200
 ---
 
-# Create a schedule
+# Schedule HTTP API
+
+## Create a schedule
 
 ```shell
 curl "{{API_URL}}/api/v1/schedules/" \
@@ -60,7 +62,7 @@ The above command returns JSON structured in the following way:
 
 `POST {{API_URL}}/api/v1/schedules/`
 
-# Get a schedule
+## Get a schedule
 
 ```shell
 curl "{{API_URL}}/api/v1/schedules/SBM7DV7BKFUYU/" \
@@ -91,7 +93,7 @@ The above command returns JSON structured in the following way:
 
 `GET {{API_URL}}/api/v1/schedules/<SCHEDULE_ID>/`
 
-# List schedules
+## List schedules
 
 ```shell
 curl "{{API_URL}}/api/v1/schedules/" \
@@ -147,7 +149,7 @@ The following available filter parameter should be provided as a `GET` argument:
 
 `GET {{API_URL}}/api/v1/schedules/`
 
-# Update a schedule
+## Update a schedule
 
 ```shell
 curl "{{API_URL}}/api/v1/schedules/SBM7DV7BKFUYU/" \
@@ -185,7 +187,7 @@ The above command returns JSON structured in the following way:
 
 `PUT {{API_URL}}/api/v1/schedules/<SCHEDULE_ID>/`
 
-# Delete a schedule
+## Delete a schedule
 
 ```shell
 curl "{{API_URL}}/api/v1/schedules/SBM7DV7BKFUYU/" \

--- a/docs/sources/oncall-api-reference/slack_channels.md
+++ b/docs/sources/oncall-api-reference/slack_channels.md
@@ -2,11 +2,13 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/slack_channels/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/slack_channels/
-title: Slack Channels HTTP API
+title: Slack channels HTTP API
 weight: 1300
 ---
 
-# List Slack Channels
+# Slack channels HTTP API
+
+## List Slack channels
 
 ```shell
 curl "{{API_URL}}/api/v1/slack_channels/" \

--- a/docs/sources/oncall-api-reference/user_groups.md
+++ b/docs/sources/oncall-api-reference/user_groups.md
@@ -2,13 +2,15 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/user_groups/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/user_groups/
-title: OnCall User Groups HTTP API
+title: User groups HTTP API
 weight: 1400
 ---
 
+# User groups HTTP API
+
 <!--Used in escalation policies with type = `notify_user_group` and in schedules.-->
 
-# List user groups
+## List user groups
 
 ```shell
 curl "{{API_URL}}/api/v1/user_groups/" \

--- a/docs/sources/oncall-api-reference/users.md
+++ b/docs/sources/oncall-api-reference/users.md
@@ -2,11 +2,13 @@
 aliases:
   - /docs/oncall/latest/oncall-api-reference/users/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/users/
-title: Grafana OnCall Users HTTP API
+title: Users HTTP API
 weight: 1500
 ---
 
-# Get a user
+# Users HTTP API
+
+## Get a user
 
 This endpoint retrieves the user object.
 
@@ -49,7 +51,7 @@ Use `{{API_URL}}/api/v1/users/current` to retrieve the current user.
 | `username` | Yes/org | User username                                                      |
 | `role`     |   No    | One of: `user`, `observer`, `admin`.                               |
 
-# List Users
+## List Users
 
 ```shell
 curl "{{API_URL}}/api/v1/users/" \

--- a/docs/sources/open-source/_index.md
+++ b/docs/sources/open-source/_index.md
@@ -3,11 +3,11 @@ aliases:
   - /docs/oncall/latest/open-source/
 keywords:
   - Open Source
-title: Open Source
+title: Open source guide
 weight: 300
 ---
 
-# Grafana OnCall open source guide
+# Open source guide
 
 Grafana OnCall is a developer-friendly incident response tool that's available to Grafana open source and Grafana Cloud
 users. The OSS version of Grafana OnCall provides the same reliable on-call management solution along with the


### PR DESCRIPTION
`doc-validator` codifies best practices for technical documentation at Grafana.
Linting errors are defined in
https://github.com/grafana/technical-documentation/blob/main/tools/cmd/doc-validator/errata.hcl.

The errors enumerated in the errata file are under active development and are intended to be helpful in explaining reasoning and fixes for linting issues.

Not all errors meet this goal yet, so please report any errors that are confusing, seem to lack motivation, or are hard to resolve.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>