### PR TITLE
Remove unused fields rendering from alert groups list serialiser

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/classic_markdown_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/classic_markdown_renderer.py
@@ -8,14 +8,17 @@ class AlertClassicMarkdownRenderer(AlertBaseRenderer):
     def templater_class(self):
         return AlertClassicMarkdownTemplater
 
-    def render(self):
+    def render(self, render_fields=["title", "message", "image_url", "source_link"]):
         templated_alert = self.templated_alert
-        rendered_alert = {
-            "title": str_or_backup(templated_alert.title, "Alert"),
-            "message": str_or_backup(templated_alert.message, ""),
-            "image_url": str_or_backup(templated_alert.image_url, None),
-            "source_link": str_or_backup(templated_alert.source_link, None),
-        }
+        rendered_alert = {}
+        if "title" in render_fields:
+            rendered_alert["title"] = str_or_backup(templated_alert.title, "Alert")
+        if "message" in render_fields:
+            rendered_alert["message"] = str_or_backup(templated_alert.message, "")
+        if "image_url" in render_fields:
+            rendered_alert["image_url"] = str_or_backup(templated_alert.image_url, None)
+        if "source_link" in render_fields:
+            rendered_alert["source_link"] = str_or_backup(templated_alert.source_link, None)
         return rendered_alert
 
 
@@ -30,5 +33,5 @@ class AlertGroupClassicMarkdownRenderer(AlertGroupBaseRenderer):
     def alert_renderer_class(self):
         return AlertClassicMarkdownRenderer
 
-    def render(self):
-        return self.alert_renderer.render()
+    def render(self, *args, **kwargs):
+        return self.alert_renderer.render(*args, **kwargs)

--- a/engine/apps/alerts/incident_appearance/renderers/web_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/web_renderer.py
@@ -8,14 +8,17 @@ class AlertWebRenderer(AlertBaseRenderer):
     def templater_class(self):
         return AlertWebTemplater
 
-    def render(self):
+    def render(self, render_fields=["title", "message", "image_url", "source_link"]):
         templated_alert = self.templated_alert
-        rendered_alert = {
-            "title": str_or_backup(templated_alert.title, "Alert"),
-            "message": str_or_backup(templated_alert.message, ""),
-            "image_url": str_or_backup(templated_alert.image_url, None),
-            "source_link": str_or_backup(templated_alert.source_link, None),
-        }
+        rendered_alert = {}
+        if "title" in render_fields:
+            rendered_alert["title"] = str_or_backup(templated_alert.title, "Alert")
+        if "message" in render_fields:
+            rendered_alert["message"] = str_or_backup(templated_alert.message, "")
+        if "image_url" in render_fields:
+            rendered_alert["image_url"] = str_or_backup(templated_alert.image_url, None)
+        if "source_link" in render_fields:
+            rendered_alert["source_link"] = str_or_backup(templated_alert.source_link, None)
         return rendered_alert
 
 
@@ -30,5 +33,5 @@ class AlertGroupWebRenderer(AlertGroupBaseRenderer):
     def alert_renderer_class(self):
         return AlertWebRenderer
 
-    def render(self):
-        return self.alert_renderer.render()
+    def render(self, *args, **kwargs):
+        return self.alert_renderer.render(*args, **kwargs)

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -88,18 +88,17 @@ class AlertGroupListSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         ]
 
     def get_render_for_web(self, obj):
-        # alert group has no alerts
         if not obj.last_alert:
             return {}
 
-        return AlertGroupWebRenderer(obj, obj.last_alert).render()
+        return AlertGroupWebRenderer(obj, obj.last_alert).render(render_fields=["title"])
 
     def get_render_for_classic_markdown(self, obj):
         # alert group has no alerts
         if not obj.last_alert:
             return {}
 
-        return AlertGroupClassicMarkdownRenderer(obj, obj.last_alert).render()
+        return AlertGroupClassicMarkdownRenderer(obj, obj.last_alert).render(render_fields=["title"])
 
     def get_related_users(self, obj):
         users_ids = set()
@@ -143,11 +142,17 @@ class AlertGroupSerializer(AlertGroupListSerializer):
 
     def get_render_for_web(self, obj):
         # alert group has no alerts
-        alert = obj.alerts.last()
-        if not alert:
+        if not obj.last_alert:
             return {}
 
-        return AlertGroupWebRenderer(obj).render()
+        return AlertGroupWebRenderer(obj, obj.last_alert).render()
+
+    def get_render_for_classic_markdown(self, obj):
+        # alert group has no alerts
+        if not obj.last_alert:
+            return {}
+
+        return AlertGroupClassicMarkdownRenderer(obj, obj.last_alert).render()
 
     def get_last_alert_at(self, obj):
         last_alert = obj.alerts.last()


### PR DESCRIPTION
# What this PR does
We render unnecessary fields which are not used by web plugin. This PR removes them
TODOS: 
- [] check if they are used on mobile app as it shares the same API
- [] render_for_web should return markdown, markdown should be converted to html on frontend side

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
