### PR TITLE
Add a filter by involved users to alert groups page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add involved users filter to alert groups listing page (+ mine shortcut)
+
 ### Changed
 
 - Improve logging for creating contact point for Grafana Alerting integration

--- a/grafana-plugin/src/containers/IncidentsFilters/IncidentsFilters.tsx
+++ b/grafana-plugin/src/containers/IncidentsFilters/IncidentsFilters.tsx
@@ -71,6 +71,7 @@ class IncidentsFilters extends Component<IncidentsFiltersProps, IncidentsFilters
       } else {
         newQuery = {
           status: [IncidentStatus.New, IncidentStatus.Acknowledged],
+          mine: false,
         };
       }
 


### PR DESCRIPTION
Related to #1119 

It also adds a shortcut to filter current user's related alert groups (alert groups user was notified by, or in which user participated). Make the filter visible by default, with a false value.