### PR TITLE
Revert #1189: Return single query in alertgroups endpoint

### DIFF
--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -153,13 +153,10 @@ class AlertGroupTeamFilteringMixin(TeamFilteringMixin):
         try:
             return super().retrieve(request, *args, **kwargs)
         except NotFound:
-            alert_receive_channels_ids = list(
-                AlertReceiveChannel.objects.filter(
-                    organization_id=self.request.auth.organization.id,
-                ).values_list("id", flat=True)
-            )
             queryset = AlertGroup.unarchived_objects.filter(
-                channel__in=alert_receive_channels_ids,
+                channel__in=AlertReceiveChannel.objects.filter(
+                    organization=self.request.auth.organization,
+                ),
             ).only("public_primary_key")
 
             try:
@@ -238,14 +235,10 @@ class AlertGroupView(
 
     def get_queryset(self):
         # no select_related or prefetch_related is used at this point, it will be done on paginate_queryset.
-        alert_receive_channels_ids = list(
-            AlertReceiveChannel.objects.filter(
-                organization_id=self.request.auth.organization.id,
-                team_id=self.request.user.current_team,
-            ).values_list("id", flat=True)
-        )
         queryset = AlertGroup.unarchived_objects.filter(
-            channel__in=alert_receive_channels_ids,
+            channel__in=AlertReceiveChannel.objects.filter(
+                organization=self.request.auth.organization, team=self.request.user.current_team
+            ),
         ).only("id")
 
         return queryset


### PR DESCRIPTION
# What this PR does

I've tried to return single query with JOIN and such request works very slow on dev
```
mysql> SELECT `alerts_alertgroup`.`id`
    -> FROM `alerts_alertgroup`
    -> WHERE (`alerts_alertgroup`.`channel_id` IN
    ->          (SELECT U0.`id`
    ->           FROM `alerts_alertreceivechannel` U0
    ->           WHERE (NOT (U0.`integration` = "maintenance")
    ->                  AND U0.`deleted_at` IS NULL
    ->                  AND U0.`organization_id` = 8
    ->                  AND U0.`team_id` IS NULL))
    ->        AND NOT `alerts_alertgroup`.`is_archived`
    ->        AND NOT `alerts_alertgroup`.`is_archived`
    ->        AND `alerts_alertgroup`.`root_alert_group_id` IS NULL
    ->        AND ((`alerts_alertgroup`.`silenced` = 0
    ->              AND `alerts_alertgroup`.`acknowledged` = 0
    ->              AND `alerts_alertgroup`.`resolved` = 0)
    ->             OR (`alerts_alertgroup`.`acknowledged` = 1
    ->                 AND `alerts_alertgroup`.`resolved` = 0))
    ->        AND NOT `alerts_alertgroup`.`is_archived`)
    -> ORDER BY `alerts_alertgroup`.`id` DESC
    -> LIMIT 26;
+---------+
| id      |
+---------+
| 1847813 |
| 1847812 |
| 1847811 |
| 1847810 |
| 1847806 |
| 1847805 |
| 1847804 |
| 1847802 |
| 1847801 |
| 1847800 |
| 1847799 |
| 1847794 |
| 1847793 |
| 1847790 |
| 1847774 |
| 1847768 |
| 1847759 |
| 1847758 |
| 1844136 |
| 1844122 |
| 1844120 |
| 1844119 |
| 1844116 |
| 1844115 |
| 1844114 |
| 1844113 |
+---------+
26 rows in set (6.55 sec)
```

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
