### PR TITLE
Use organization ISSUE_COMMANDS_TOKEN with reduced scope

### DIFF
--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -3,7 +3,7 @@ on:
   issues:
     types: [labeled]
   pull_request:
-    types: [labeled]    
+    types: [labeled]
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -18,6 +18,6 @@ jobs:
         run: npm install --production --prefix ./actions
       - name: Run Commands
         uses: ./actions/commands
-        with:          
-          token: ${{secrets.GH_ISSUE_COMMANDS}}
+        with:
+          token: ${{secrets.ISSUE_COMMANDS_TOKEN}}
           configPath: issue_and_pr_commands


### PR DESCRIPTION
The new token is set at an organization level so it does not require repository administrators to rotate the token. It also has the minimal classic PAT permissions to facilitate the workflow.

It has expiry but that expiry is reported via email to the engineering organization and the IT Helpdesk have permissions to regenerate the token when expiration is imminent.

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>