### PR TITLE
fix failing lint github actions job due to issue w/ isort version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.12.0
     hooks:
       - id: isort
         files: ^engine


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR fixes

`lint` github action jobs on all builds are failing right now ([example](https://github.com/grafana/oncall/actions/runs/4042567074/jobs/6950923821#step:6:16)) because of [this issue](https://github.com/PyCQA/isort/issues/2077) with `isort`

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
