### PR TITLE
don't tag oncall-backend when CHANGELOG is updated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 * @grafana/grafana-oncall-backend
 
+# don't tag @grafana/grafana-oncall-backend on changes to CHANGELOG.md
+CHANGELOG.md
+
 /grafana-plugin @grafana/grafana-oncall-frontend


### PR DESCRIPTION
# What this PR does

There is no need to add `@grafana/grafana-oncall-backend` as a PR reviewer when `CHANGELOG.md` is updated

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)
