### PR TITLE
tag @grafana/docs-oncall instead of oncall-backend for docs related changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 CHANGELOG.md
 
 /grafana-plugin @grafana/grafana-oncall-frontend
+/docs @grafana/docs-oncall


### PR DESCRIPTION
Adding in reference to #1239.

@grafana/docs-oncall should be tagged as a PR reviewer for changes to `/docs` rahter than @grafana/grafana-oncall-backend.