### PR TITLE
add django-dbconn-retry library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add [`django-dbconn-retry` library](https://github.com/jdelic/django-dbconn-retry) to `INSTALLED_APPS` to attempt
+  to alleviate occasional `django.db.utils.OperationalError` errors
+
+### Changed
+
+### Fixed
+
 ## v1.1.20 (2023-01-30)
 
 ### Added

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -46,3 +46,4 @@ opentelemetry-instrumentation-pymysql==0.36b0
 opentelemetry-instrumentation-wsgi==0.36b0
 opentelemetry-exporter-otlp-proto-grpc==1.15.0
 pyroscope-io==0.8.1
+django-dbconn-retry==0.1.7

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -220,6 +220,7 @@ INSTALLED_APPS = [
     "social_django",
     "polymorphic",
     "fcm_django",
+    "django_dbconn_retry",
 ]
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
# What this PR does

We occasionally see `django.db.utils.OperationalError` pop up. These seem to be sporadic and for whatever reason the engine/celery processes cannot connect to the database, but succeed on subsequent requests. This results in HTTP 500s for the original requests. The `django-dbconn-retry` library states in its documentation:

> This library monkeypatches django.db.backends.base.BaseDatabaseWrapper so that when a database operation fails because the underlying TCP connection was already closed, it first tried to reconnect, instead of immediately raising an OperationException.

I would like to give this a try and see if this patches these `django.db.utils.OperationalError` errors.

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated
