### PR TITLE
Add utility function to get readonly db key if defined

### DIFF
--- a/engine/apps/slack/models/slack_message.py
+++ b/engine/apps/slack/models/slack_message.py
@@ -68,12 +68,8 @@ class SlackMessage(models.Model):
                     f"It is strange!"
                 )
                 return None
-            # Re-take object to switch connection from readonly db to master.
             self._slack_team_identity = self.organization.slack_team_identity
-
-            _self = SlackMessage.objects.get(pk=self.pk)
-            _self._slack_team_identity = _self.organization.slack_team_identity
-            _self.save()
+            self.save()
         return self._slack_team_identity
 
     def get_alert_group(self):

--- a/engine/common/database.py
+++ b/engine/common/database.py
@@ -1,0 +1,15 @@
+import random
+
+from django.conf import settings
+
+
+def get_random_readonly_database_key_if_present_otherwise_default() -> str:
+    """
+    This function returns a string, representing a key in the DATABASES django settings.
+    If settings.READONLY_DATABASES is set, and non-empty, it randomly chooses one of the read-only databases,
+    otherwise it falls back to "default".
+    """
+    using_db = "default"
+    if hasattr(settings, "READONLY_DATABASES") and len(settings.READONLY_DATABASES) > 0:
+        using_db = random.choice(list(settings.READONLY_DATABASES.keys()))
+    return using_db

--- a/engine/common/database.py
+++ b/engine/common/database.py
@@ -8,6 +8,8 @@ def get_random_readonly_database_key_if_present_otherwise_default() -> str:
     This function returns a string, representing a key in the DATABASES django settings.
     If settings.READONLY_DATABASES is set, and non-empty, it randomly chooses one of the read-only databases,
     otherwise it falls back to "default".
+
+    This is primarily intended to be used for django's QuerySet.using() function
     """
     using_db = "default"
     if hasattr(settings, "READONLY_DATABASES") and len(settings.READONLY_DATABASES) > 0:

--- a/engine/common/tests/test_database.py
+++ b/engine/common/tests/test_database.py
@@ -1,0 +1,21 @@
+from django.test import override_settings
+
+from common.database import get_random_readonly_database_key_if_present_otherwise_default
+
+MOCK_READ_ONLY_DATABASES = {
+    "foo": "asdfkdjkdfjkdf",
+    "bar": "nmcvnmcvmnvc",
+}
+
+
+class TestGetRandomReadOnlyDatabaseKeyIfPresentOtherwiseDefault:
+    @override_settings(READONLY_DATABASES=MOCK_READ_ONLY_DATABASES)
+    def test_it_randomly_chooses_a_readonly_database(self) -> None:
+        assert get_random_readonly_database_key_if_present_otherwise_default() in MOCK_READ_ONLY_DATABASES
+
+    @override_settings(READONLY_DATABASES={})
+    def test_it_falls_back_to_default_if_readonly_databases_is_set_but_empty(self) -> None:
+        assert get_random_readonly_database_key_if_present_otherwise_default() == "default"
+
+    def test_it_falls_back_to_default_if_readonly_databases_is_not_set(self) -> None:
+        assert get_random_readonly_database_key_if_present_otherwise_default() == "default"


### PR DESCRIPTION
# What this PR does

This is a minor refactor before implementing https://github.com/grafana/oncall-private/issues/1558.

Additionally, it cleans up a few spots where we do this:
```
# Re-take in case we are in the readonly db context.
```
We currently don't read anything from a read-only database, so this should be not necessary.

## Checklist

- [x] Tests updated
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)
