### PR TITLE
Keep track of direct paging schedule/importance in logs

### DIFF
--- a/engine/apps/alerts/tests/test_paging.py
+++ b/engine/apps/alerts/tests/test_paging.py
@@ -15,8 +15,11 @@ from apps.base.models import UserNotificationPolicy
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleWeb
 
 
-def assert_log_record(alert_group, reason, log_type=AlertGroupLogRecord.TYPE_DIRECT_PAGING):
-    assert alert_group.log_records.filter(alert_group=alert_group, type=log_type, reason=reason).exists()
+def assert_log_record(alert_group, reason, log_type=AlertGroupLogRecord.TYPE_DIRECT_PAGING, expected_info=None):
+    log = alert_group.log_records.filter(alert_group=alert_group, type=log_type, reason=reason).first()
+    assert log is not None
+    if expected_info is not None:
+        assert log.get_step_specific_info() == expected_info
 
 
 def setup_always_on_call_schedule(make_schedule, make_on_call_shift, organization, team, user, extra_users=None):
@@ -185,8 +188,10 @@ def test_direct_paging_user(make_organization, make_user_for_organization):
     assert alert.title == "Help!"
     assert alert.message == "Fire"
     # notifications sent
-    assert notify_task.apply_async.called_with((user.pk, ag.pk), {"important": False})
-    assert notify_task.apply_async.called_with((other_user.pk, ag.pk), {"important": True})
+    for (u, important) in ((user, False), (other_user, True)):
+        assert notify_task.apply_async.called_with((u.pk, ag.pk), {"important": important})
+        expected_info = {"user": u.public_primary_key, "schedule": None, "important": important}
+        assert_log_record(ag, f"{from_user.username} paged user {u.username}", expected_info=expected_info)
 
 
 @pytest.mark.django_db
@@ -218,8 +223,12 @@ def test_direct_paging_schedule(
     assert_log_record(ag, f"{from_user.username} paged schedule {schedule.name}")
     assert_log_record(ag, f"{from_user.username} paged schedule {other_schedule.name}")
     # notifications sent
-    assert notify_task.apply_async.called_with((user.pk, ag.pk), {"important": False})
-    assert notify_task.apply_async.called_with((other_user.pk, ag.pk), {"important": True})
+    for (u, important, s) in ((user, False, schedule), (other_user, True, other_schedule)):
+        assert notify_task.apply_async.called_with((u.pk, ag.pk), {"important": important})
+        expected_info = {"user": u.public_primary_key, "schedule": s.public_primary_key, "important": important}
+        assert_log_record(
+            ag, f"{from_user.username} paged user {u.username} (from schedule {s.name})", expected_info=expected_info
+        )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This will eventually allow to improve responders information in an alert group detail page