### PR TITLE
Fix local dev setup slowness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,17 @@ engine-manage:
 exec-engine:
 	docker exec -it oncall_engine bash
 
+_backend-debug-enable:
+	$(shell ./dev/add_env_var.sh DEBUG True $(DEV_ENV_FILE))
+	$(shell ./dev/add_env_var.sh SILK_PROFILER_ENABLED True $(DEV_ENV_FILE))
+
+_backend-debug-disable:
+	$(shell ./dev/add_env_var.sh DEBUG False $(DEV_ENV_FILE))
+	$(shell ./dev/add_env_var.sh SILK_PROFILER_ENABLED False $(DEV_ENV_FILE))
+
+backend-debug-enable: _backend-debug-enable stop start
+backend-debug-disable: _backend-debug-disable stop start
+
 _enable-mobile-app-feature-flags:
 	$(shell ./dev/add_env_var.sh FEATURE_MOBILE_APP_INTEGRATION_ENABLED True $(DEV_ENV_FILE))
 	$(call run_engine_docker_command,python manage.py enable_mobile_app)

--- a/dev/README.md
+++ b/dev/README.md
@@ -105,8 +105,9 @@ volume mounted inside the container.
 In order to setup [`django-silk`](https://github.com/jazzband/django-silk) for local profiling, perform the following
 steps:
 
-1. `make engine-manage CMD="createsuperuser"` - follow CLI prompts to create a Django superuser
-2. Visit <http://localhost:8080/django-admin> and login using the credentials you created in step #2
+1. `make backend-debug-enable`
+2. `make engine-manage CMD="createsuperuser"` - follow CLI prompts to create a Django superuser
+3. Visit <http://localhost:8080/django-admin> and login using the credentials you created in step #2
 
 You should now be able to visit <http://localhost:8080/silk/> and see the Django Silk UI.
 See the `django-silk` documentation [here](https://github.com/jazzband/django-silk) for more information.
@@ -153,6 +154,9 @@ make engine-manage CMD="..."
 # and sets the necessary database values
 # NOTE: you need to enable, and configure, the plugin before running this command
 make enable-mobile-app-feature-flags
+
+make backend-debug-enable # enable Django's debug mode and Silk profiling (this is disabled by default for performance reasons)
+make backend-debug-disable # disable Django's debug mode and Silk profiling
 
 # this will remove all of the images, containers, volumes, and networks
 # associated with your local OnCall developer setup

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -63,7 +63,7 @@ services:
     labels: *oncall-labels
     build: *oncall-build-args
     restart: always
-    command: "python manage.py runserver 0.0.0.0:8080"
+    command: sh -c "uwsgi --disable-logging --py-autoreload 3 --ini uwsgi.ini"
     env_file: *oncall-env-files
     environment: *oncall-env-vars
     volumes: *oncall-volumes

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -26,7 +26,6 @@ x-env-vars: &oncall-env-vars
   GRAFANA_API_URL: http://localhost:3000
   GOOGLE_APPLICATION_CREDENTIALS: /etc/app/gcp_service_account.json
   FCM_PROJECT_ID: oncall-mobile-dev
-  SILK_PROFILER_ENABLED: True
 
 # basically this is needed because the oncall backend containers have been configured to communicate w/ grafana via
 # http://localhost:3000 (GRAFANA_API_URL). This URL is used in two scenarios:

--- a/engine/engine/management/commands/start_celery.py
+++ b/engine/engine/management/commands/start_celery.py
@@ -11,7 +11,7 @@ def restart_celery(*args, **kwargs):
     global WORKER_ID
     kill_worker_cmd = "celery -A engine control shutdown"
     subprocess.call(shlex.split(kill_worker_cmd))
-    start_worker_cmd = "celery -A engine worker -l info --concurrency=20 -Q celery,retry -n {}".format(WORKER_ID)
+    start_worker_cmd = "celery -A engine worker -l info --concurrency=3 -Q celery,retry -n {}".format(WORKER_ID)
     subprocess.call(shlex.split(start_worker_cmd))
     WORKER_ID = 1 + WORKER_ID
 

--- a/engine/settings/dev.py
+++ b/engine/settings/dev.py
@@ -5,7 +5,8 @@ import sys
 
 from .base import *
 
-DEBUG = True
+# DEBUG is disabled by default because it can cause slowness when making several consecutive requests
+DEBUG = getenv_boolean("DEBUG", default=False)
 
 if DATABASE_TYPE == DatabaseTypes.SQLITE3:
     DATABASES["default"]["NAME"] = DATABASE_NAME or "oncall_dev.db"


### PR DESCRIPTION
# What this PR does
Fixes an issue when a local dev setup becomes extremely slow.

- Set `DEBUG` and `SILK_PROFILER_ENABLED` to `False` by default + add utility make commands to toggle it
- Use `uwsgi` instead of Django's built-in `runserver` for local dev setup
- Limit Celery concurrency to 3 for local dev setup (previously was 20, used >1GB RAM on my machine)
