### PR TITLE
Disable listing alert groups using Grafana Incident API 

### DIFF
--- a/engine/apps/api_for_grafana_incident/views.py
+++ b/engine/apps/api_for_grafana_incident/views.py
@@ -1,4 +1,4 @@
-from rest_framework.viewsets import ReadOnlyModelViewSet
+from rest_framework import mixins, viewsets
 
 from apps.alerts.models import AlertGroup
 from apps.auth_token.auth import GrafanaIncidentStaticKeyAuth
@@ -6,7 +6,13 @@ from apps.auth_token.auth import GrafanaIncidentStaticKeyAuth
 from .serializers import AlertGroupSerializer
 
 
-class AlertGroupsView(ReadOnlyModelViewSet):
+class RetrieveViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+    """
+    A viewset that provides only `retrieve` actions.
+    """
+
+
+class AlertGroupsView(RetrieveViewSet):
     authentication_classes = (GrafanaIncidentStaticKeyAuth,)
     queryset = AlertGroup.unarchived_objects.all()
     serializer_class = AlertGroupSerializer


### PR DESCRIPTION
Grafana Incident API only ever accesses individual alert groups by ID.
Using the /api/gi/v1/alert-groups endpoint without an ID would list every
single alert group in the database (from what I can tell), since the auth
isn't org-specific.

This is a precursor to another PR which adds more details to the alert group
serializer, which makes the query more resource intensive, so I thought it
best to disable listing first.