### PR TITLE
Include alert details in Grafana Incident alert-group endpoint

### DIFF
--- a/engine/apps/api_for_grafana_incident/serializers.py
+++ b/engine/apps/api_for_grafana_incident/serializers.py
@@ -3,12 +3,11 @@ import logging
 from rest_framework import serializers
 
 from apps.alerts.models import Alert, AlertGroup
-from common.api_helpers.mixins import EagerLoadingMixin
 
 logger = logging.getLogger(__name__)
 
 
-class AlertSerializer(EagerLoadingMixin, serializers.ModelSerializer):
+class AlertSerializer(serializers.ModelSerializer):
 
     id_oncall = serializers.CharField(read_only=True, source="public_primary_key")
     payload = serializers.JSONField(read_only=True, source="raw_request_data")
@@ -21,7 +20,7 @@ class AlertSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         ]
 
 
-class AlertGroupSerializer(EagerLoadingMixin, serializers.ModelSerializer):
+class AlertGroupSerializer(serializers.ModelSerializer):
 
     id = serializers.CharField(read_only=True, source="public_primary_key")
     status = serializers.SerializerMethodField(source="get_status")

--- a/engine/apps/api_for_grafana_incident/serializers.py
+++ b/engine/apps/api_for_grafana_incident/serializers.py
@@ -2,17 +2,31 @@ import logging
 
 from rest_framework import serializers
 
-from apps.alerts.models import AlertGroup
+from apps.alerts.models import Alert, AlertGroup
 from common.api_helpers.mixins import EagerLoadingMixin
 
 logger = logging.getLogger(__name__)
 
 
-class AlertGroupSerializer(EagerLoadingMixin, serializers.ModelSerializer):
+class AlertSerializer(EagerLoadingMixin, serializers.ModelSerializer):
 
     id_oncall = serializers.CharField(read_only=True, source="public_primary_key")
+    payload = serializers.JSONField(read_only=True, source="raw_request_data")
+
+    class Meta:
+        model = Alert
+        fields = [
+            "id_oncall",
+            "payload",
+        ]
+
+
+class AlertGroupSerializer(EagerLoadingMixin, serializers.ModelSerializer):
+
+    id = serializers.CharField(read_only=True, source="public_primary_key")
     status = serializers.SerializerMethodField(source="get_status")
     link = serializers.CharField(read_only=True, source="web_link")
+    alerts = AlertSerializer(many=True, read_only=True)
 
     def get_status(self, obj):
         return next(filter(lambda status: status[0] == obj.status, AlertGroup.STATUS_CHOICES))[1].lower()
@@ -20,7 +34,8 @@ class AlertGroupSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     class Meta:
         model = AlertGroup
         fields = [
-            "id_oncall",
+            "id",
             "link",
             "status",
+            "alerts",
         ]


### PR DESCRIPTION
This will be used by Grafana Incident to infer details about the
incident if alert groups are present.

Depends on #1279 