### PR TITLE
1305 backlink tosource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Incidents - Removed buttons column and replaced status with toggler ([#1237](https://github.com/grafana/oncall/issues/1237))
 - Responsiveness changes across multiple pages (Incidents, Integrations, Schedules) ([#1237](https://github.com/grafana/oncall/issues/1237))
+- Link to source was added ([1305](https://github.com/grafana/oncall-private/issues/1305))
+- Header of Incident page was reworked: clickable labels instead of just names, users section was deleted
+- Go to Integration button was deleted, because the functionality moved to clickable labels
 
 ## v1.1.23 (2023-02-06)
 

--- a/grafana-plugin/src/models/alertgroup/alertgroup.types.ts
+++ b/grafana-plugin/src/models/alertgroup/alertgroup.types.ts
@@ -86,4 +86,5 @@ interface RenderForWeb {
   message: any;
   title: any;
   image_url: string;
+  source_link: string;
 }

--- a/grafana-plugin/src/pages/incident/Incident.helpers.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.helpers.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Button, HorizontalGroup, IconButton, Tooltip, VerticalGroup } from '@grafana/ui';
+import cn from 'classnames/bind';
 
 import Avatar from 'components/Avatar/Avatar';
 import { MatchMediaTooltip } from 'components/MatchMediaTooltip/MatchMediaTooltip';
@@ -16,11 +17,18 @@ import { move } from 'state/helpers';
 import { UserActions } from 'utils/authorization';
 import { TABLE_COLUMN_MAX_WIDTH } from 'utils/consts';
 
+import styles from './Incident.module.css';
+
+const cx = cn.bind(styles);
+
 export function getIncidentStatusTag(alert: Alert) {
   switch (alert.status) {
     case IncidentStatus.Firing:
       return (
-        <Tag color={getComputedStyle(document.documentElement).getPropertyValue('--tag-danger')}>
+        <Tag
+          color={getComputedStyle(document.documentElement).getPropertyValue('--tag-danger')}
+          className={cx('status-tag')}
+        >
           <Text strong size="small">
             Firing
           </Text>
@@ -28,7 +36,10 @@ export function getIncidentStatusTag(alert: Alert) {
       );
     case IncidentStatus.Acknowledged:
       return (
-        <Tag color={getComputedStyle(document.documentElement).getPropertyValue('--tag-warning')}>
+        <Tag
+          color={getComputedStyle(document.documentElement).getPropertyValue('--tag-warning')}
+          className={cx('status-tag')}
+        >
           <Text strong size="small">
             Acknowledged
           </Text>
@@ -36,7 +47,10 @@ export function getIncidentStatusTag(alert: Alert) {
       );
     case IncidentStatus.Resolved:
       return (
-        <Tag color={getComputedStyle(document.documentElement).getPropertyValue('--tag-primary')}>
+        <Tag
+          color={getComputedStyle(document.documentElement).getPropertyValue('--tag-primary')}
+          className={cx('status-tag')}
+        >
           <Text strong size="small">
             Resolved
           </Text>
@@ -44,7 +58,10 @@ export function getIncidentStatusTag(alert: Alert) {
       );
     case IncidentStatus.Silenced:
       return (
-        <Tag color={getComputedStyle(document.documentElement).getPropertyValue('--tag-secondary')}>
+        <Tag
+          color={getComputedStyle(document.documentElement).getPropertyValue('--tag-secondary')}
+          className={cx('status-tag')}
+        >
           <Text strong size="small">
             Silenced
           </Text>

--- a/grafana-plugin/src/pages/incident/Incident.module.css
+++ b/grafana-plugin/src/pages/incident/Incident.module.css
@@ -121,3 +121,43 @@
   color: var(--secondary-text-color);
   margin-left: 4px;
 }
+
+.integration-logo {
+  margin-right: 8px;
+}
+
+.label-button {
+  padding: 0 8px;
+  font-weight: 400;
+}
+
+.label-button:disabled {
+  border: var(--border-strong);
+}
+
+.label-button-text {
+  max-width: 160px;
+  overflow: hidden;
+  position: relative;
+  display: inline-block;
+  text-align: center;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source-name {
+  display: flex;
+  align-items: center;
+}
+
+.status-tag-container {
+  margin-right: 8px;
+  display: inherit;
+}
+
+.status-tag {
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 2px;
+}

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -18,7 +18,6 @@ import cn from 'classnames/bind';
 import { observer } from 'mobx-react';
 import moment from 'moment-timezone';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import Emoji from 'react-emoji-render';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import reactStringReplace from 'react-string-replace';
 
@@ -55,7 +54,7 @@ import { UserActions } from 'utils/authorization';
 import { PLUGIN_ROOT } from 'utils/consts';
 import sanitize from 'utils/sanitize';
 
-import { getActionButtons, getIncidentStatusTag, renderRelatedUsers } from './Incident.helpers';
+import { getActionButtons, getIncidentStatusTag } from './Incident.helpers';
 
 import styles from './Incident.module.css';
 
@@ -214,6 +213,14 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
     const integration = store.alertReceiveChannelStore.getIntegration(incident.alert_receive_channel);
 
     const showLinkTo = !incident.dependent_alert_groups.length && !incident.root_alert_group && !incident.resolved;
+
+    const integrationNameWithoutEmojies =
+      incident.alert_receive_channel.verbal_name.indexOf(':') >= 0
+        ? incident.alert_receive_channel.verbal_name.substring(
+            0,
+            incident.alert_receive_channel.verbal_name.indexOf(':')
+          )
+        : incident.alert_receive_channel.verbal_name.replace(/\p{Emoji}/gu, '');
     return (
       <Block withBackground className={cx('block')}>
         <VerticalGroup>
@@ -270,11 +277,59 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
           </HorizontalGroup>
           <div className={cx('info-row')}>
             <HorizontalGroup>
-              {getIncidentStatusTag(incident)} | <Emoji text={incident.alert_receive_channel.verbal_name} />|
-              <IntegrationLogo integration={integration} scale={0.1} />
-              {integration && <Text type="secondary"> {integration?.display_name}</Text>}
-              {integration && '|'}
-              <Text type="secondary">{renderRelatedUsers(incident, true)}</Text>
+              <div className={cx('status-tag-container')}>{getIncidentStatusTag(incident)}</div>
+              <PluginLink
+                disabled={incident.alert_receive_channel.deleted}
+                query={{ page: 'integrations', id: incident.alert_receive_channel.id }}
+              >
+                <Button
+                  disabled={incident.alert_receive_channel.deleted}
+                  variant="secondary"
+                  fill="outline"
+                  size="sm"
+                  className={cx('label-button')}
+                  icon="plug"
+                >
+                  <Tooltip
+                    placement="top"
+                    content={
+                      integrationNameWithoutEmojies.length > 30 ? integrationNameWithoutEmojies : 'Go to Integration'
+                    }
+                  >
+                    <div className={cx('label-button-text')}>{integrationNameWithoutEmojies}</div>
+                  </Tooltip>
+                </Button>
+              </PluginLink>
+
+              {integration && (
+                <>
+                  <Tooltip
+                    placement="top"
+                    content={
+                      incident.render_for_web.source_link === null
+                        ? `The integration doesn't have direct link to the source.`
+                        : 'Go to source'
+                    }
+                  >
+                    <a href={incident.render_for_web.source_link} target="_blank" rel="noreferrer">
+                      <Button
+                        variant="secondary"
+                        fill="outline"
+                        size="sm"
+                        disabled={incident.render_for_web.source_link === null}
+                        className={cx('label-button')}
+                      >
+                        <div className={cx('label-button-text', 'source-name')}>
+                          <div className={cx('integration-logo')}>
+                            <IntegrationLogo integration={integration} scale={0.08} />
+                          </div>
+                          {integration?.display_name}
+                        </div>
+                      </Button>
+                    </a>
+                  </Tooltip>
+                </>
+              )}
             </HorizontalGroup>
           </div>
           <HorizontalGroup justify="space-between" className={cx('buttons-row')}>
@@ -297,14 +352,6 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
             </HorizontalGroup>
 
             <HorizontalGroup>
-              <PluginLink
-                disabled={incident.alert_receive_channel.deleted}
-                query={{ page: 'integrations', id: incident.alert_receive_channel.id }}
-              >
-                <Button disabled={incident.alert_receive_channel.deleted} variant="secondary" size="sm" icon="compass">
-                  Go to Integration
-                </Button>
-              </PluginLink>
               <Button
                 disabled={incident.alert_receive_channel.deleted}
                 variant="secondary"


### PR DESCRIPTION
# What this PR does
- Header of Incident page was reworked: clickable labels instead of just names, users section was deleted
- Go to Integration button was deleted, because the functionality moved to clickable labels
- Link to source was added
- 
## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/1305

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ v] `CHANGELOG.md` updated
