### PR TITLE
PD migrator: handle resource names with extra spaces

### DIFF
--- a/tools/pagerduty-migrator/migrator/report.py
+++ b/tools/pagerduty-migrator/migrator/report.py
@@ -47,7 +47,7 @@ def format_escalation_policy(policy: dict) -> str:
 
 
 def format_integration(integration: dict) -> str:
-    result = integration["service"]["name"] + " - " + integration["name"]
+    result = "{} - {}".format(integration["service"]["name"], integration["name"])
 
     if not integration["oncall_type"]:
         result = (

--- a/tools/pagerduty-migrator/migrator/resources/escalation_policies.py
+++ b/tools/pagerduty-migrator/migrator/resources/escalation_policies.py
@@ -5,7 +5,7 @@ from migrator.utils import find_by_id, transform_wait_delay
 def match_escalation_policy(policy: dict, oncall_escalation_chains: list[dict]) -> None:
     oncall_escalation_chain = None
     for candidate in oncall_escalation_chains:
-        if candidate["name"].lower() == policy["name"].lower():
+        if candidate["name"].lower().strip() == policy["name"].lower().strip():
             oncall_escalation_chain = candidate
 
     policy["oncall_escalation_chain"] = oncall_escalation_chain

--- a/tools/pagerduty-migrator/migrator/resources/integrations.py
+++ b/tools/pagerduty-migrator/migrator/resources/integrations.py
@@ -6,10 +6,12 @@ from migrator.utils import find_by_id
 def match_integration(integration: dict, oncall_integrations: list[dict]) -> None:
     oncall_integration = None
     for candidate in oncall_integrations:
-        name = "{} - {}".format(
-            integration["service"]["name"], integration["name"]
-        ).lower()
-        if candidate["name"].lower() == name:
+        name = (
+            "{} - {}".format(integration["service"]["name"], integration["name"])
+            .lower()
+            .strip()
+        )
+        if candidate["name"].lower().strip() == name:
             oncall_integration = candidate
 
     integration["oncall_integration"] = oncall_integration

--- a/tools/pagerduty-migrator/migrator/resources/schedules.py
+++ b/tools/pagerduty-migrator/migrator/resources/schedules.py
@@ -4,7 +4,7 @@ from migrator import oncall_api_client
 def match_schedule(schedule: dict, oncall_schedules: list[dict]) -> None:
     oncall_schedule = None
     for candidate in oncall_schedules:
-        if schedule["name"].lower() == candidate["name"].lower():
+        if schedule["name"].lower().strip() == candidate["name"].lower().strip():
             oncall_schedule = candidate
 
     schedule["oncall_schedule"] = oncall_schedule

--- a/tools/pagerduty-migrator/migrator/tests/test_matching_extra_spaces.py
+++ b/tools/pagerduty-migrator/migrator/tests/test_matching_extra_spaces.py
@@ -1,0 +1,32 @@
+from migrator.resources.escalation_policies import match_escalation_policy
+from migrator.resources.integrations import match_integration
+from migrator.resources.schedules import match_schedule
+
+
+def test_match_schedule_name_extra_spaces():
+    pd_schedule = {"name": " test "}
+    oncall_schedules = [{"name": "test"}]
+
+    match_schedule(pd_schedule, oncall_schedules)
+    assert pd_schedule["oncall_schedule"] == oncall_schedules[0]
+
+
+def test_match_escalation_policy_name_extra_spaces():
+    pd_escalation_policy = {"name": " test "}
+    oncall_escalation_chains = [{"name": "test"}]
+
+    match_escalation_policy(pd_escalation_policy, oncall_escalation_chains)
+    assert (
+        pd_escalation_policy["oncall_escalation_chain"] == oncall_escalation_chains[0]
+    )
+
+
+def test_match_integration_name_extra_spaces():
+    pd_integration = {
+        "service": {"name": " test service "},
+        "name": " test integration ",
+    }
+    oncall_integrations = [{"name": "test service  -  test integration"}]
+
+    match_integration(pd_integration, oncall_integrations)
+    assert pd_integration["oncall_integration"] == oncall_integrations[0]


### PR DESCRIPTION
# What this PR does
Currently PD migrator can fail with HTTP 400 error when dealing with PD resource names like " Schedule" (note the extra space). This PR makes sure that PD migrator script can handle such cases.