### PR TITLE
Show direct paging integrations in list filter options

### DIFF
--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -671,7 +671,7 @@ def test_alert_receive_channel_counters_per_integration_permissions(
 
 
 @pytest.mark.django_db
-def test_get_alert_receive_channels_direct_paging_hidden(
+def test_get_alert_receive_channels_direct_paging_hidden_from_list(
     make_organization_and_user_with_plugin_token, make_alert_receive_channel, make_user_auth_headers
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
@@ -684,3 +684,21 @@ def test_get_alert_receive_channels_direct_paging_hidden(
     # Check no direct paging integrations in the response
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == []
+
+
+@pytest.mark.django_db
+def test_get_alert_receive_channels_direct_paging_present_for_filters(
+    make_organization_and_user_with_plugin_token, make_alert_receive_channel, make_user_auth_headers
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    alert_receive_channel = make_alert_receive_channel(
+        user.organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING
+    )
+
+    client = APIClient()
+    url = reverse("api-internal:alert_receive_channel-list")
+    response = client.get(url + "?filters=true", format="json", **make_user_auth_headers(user, token))
+
+    # Check direct paging integration is in the response
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()[0]["value"] == alert_receive_channel.public_primary_key

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -137,8 +137,9 @@ class AlertReceiveChannelView(
             if eager:
                 queryset = self.serializer_class.setup_eager_loading(queryset)
 
-        # Hide direct paging integrations
-        queryset = queryset.exclude(integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
+        # Hide direct paging integrations from the list view, but not from the filters
+        if not is_filters_request:
+            queryset = queryset.exclude(integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING)
 
         return queryset
 


### PR DESCRIPTION
# What this PR does
Changes the internal API to show direct paging integrations in list filter options.

<img width="1203" alt="Screenshot 2023-02-15 at 16 27 31" src="https://user-images.githubusercontent.com/20116910/219090234-d40d471c-ffcc-48e9-8799-e48f03681b72.png">

## Checklist

- [x] Tests updated