### PR TITLE
trigger github actions jobs on merge_group event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
       - dev
   pull_request:
+  # You can use the merge_group event to trigger your GitHub Actions workflow when
+  # a pull request is added to a merge queue
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -2,9 +2,13 @@ name: snyk
 
 on:
   push:
-    branches: [ main,dev ]
+    branches: [main, dev]
   pull_request:
-    branches: [ main,dev ]
+    branches: [main, dev]
+  # You can use the merge_group event to trigger your GitHub Actions workflow when
+  # a pull request is added to a merge queue
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
 
 jobs:
   security-scan:
@@ -13,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - uses: actions/setup-node@v3
         with:
           node-version: 14.17.0

--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
       - dev
+  # You can use the merge_group event to trigger your GitHub Actions workflow when
+  # a pull request is added to a merge queue
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
 
 jobs:
   verfiy-changelog-updated:

--- a/.github/workflows/verify-public-docs-updated.yml
+++ b/.github/workflows/verify-public-docs-updated.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
       - dev
+  # You can use the merge_group event to trigger your GitHub Actions workflow when
+  # a pull request is added to a merge queue
+  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
+  merge_group:
 
 jobs:
   verify-public-docs-updated:


### PR DESCRIPTION
Get the repo ready to support the [pull request merge queue](https://github.blog/changelog/2021-10-27-pull-request-merge-queue-limited-beta/):
<img width="777" alt="Screenshot 2023-02-20 at 14 48 44" src="https://user-images.githubusercontent.com/9406895/220125516-4b2f7245-fb6d-4517-933e-d9cf86308661.png">
