### PR TITLE
code-ify dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/grafana-plugin"
+    schedule:
+      interval: "daily"
+    labels:
+      - "pr:dependencies"
+      - "pr:no changelog"
+      - "pr:no public docs"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "pr:dependencies"
+      - "pr:no changelog"
+      - "pr:no public docs"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "pr:dependencies"
+      - "pr:no changelog"
+      - "pr:no public docs"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "pr:dependencies"
+      - "pr:no changelog"
+      - "pr:no public docs"


### PR DESCRIPTION
# What this PR does

This PR is meant to code-ify our dependabot configuration. This is being done mainly to override the default labels that dependabot adds to the PRs it opens.

## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [ ] `CHANGELOG.md` updated (N/A)
