### PR TITLE
Revert "Rework schedules cached ical file values"

### DIFF
--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -128,11 +128,9 @@ class OnCallSchedule(PolymorphicModel):
         """Returns list of calendars. Primary calendar should always be the first"""
         calendar_primary = None
         calendar_overrides = None
-        # if self._ical_file_(primary|overrides) is None -> no cache, will trigger a refresh
-        # if self._ical_file_(primary|overrides) == "" -> cached value for an empty schedule
-        if self._ical_file_primary:
+        if self._ical_file_primary is not None:
             calendar_primary = icalendar.Calendar.from_ical(self._ical_file_primary)
-        if self._ical_file_overrides:
+        if self._ical_file_overrides is not None:
             calendar_overrides = icalendar.Calendar.from_ical(self._ical_file_overrides)
         return calendar_primary, calendar_overrides
 
@@ -565,8 +563,7 @@ class OnCallScheduleCalendar(OnCallSchedule):
         """
         Generate iCal events file from custom on-call shifts (created via API)
         """
-        # default to empty string since it is not possible to have a no-events ical file
-        ical = ""
+        ical = None
         if self.custom_on_call_shifts.exists():
             end_line = "END:VCALENDAR"
             calendar = Calendar()
@@ -597,8 +594,7 @@ class OnCallScheduleWeb(OnCallSchedule):
 
     def _generate_ical_file_from_shifts(self, qs, extra_shifts=None, allow_empty_users=False):
         """Generate iCal events file from custom on-call shifts."""
-        # default to empty string since it is not possible to have a no-events ical file
-        ical = ""
+        ical = None
         if qs.exists() or extra_shifts is not None:
             if extra_shifts is None:
                 extra_shifts = []

--- a/engine/apps/schedules/tests/test_on_call_schedule.py
+++ b/engine/apps/schedules/tests/test_on_call_schedule.py
@@ -965,35 +965,3 @@ def test_filter_events_none_cache_unchanged(
     events = schedule.filter_events("UTC", start_date, days=5, filter_by=OnCallSchedule.TYPE_ICAL_PRIMARY)
     expected = []
     assert events == expected
-
-
-@pytest.mark.django_db
-def test_schedules_ical_shift_cache(make_organization, make_schedule):
-    organization = make_organization()
-    schedule = make_schedule(organization, schedule_class=OnCallScheduleWeb)
-
-    # initial values are None
-    assert schedule.cached_ical_file_primary is None
-    assert schedule.cached_ical_file_overrides is None
-
-    # accessing the properties will trigger a refresh of the ical files (both empty)
-    assert schedule._ical_file_primary == ""
-    assert schedule._ical_file_overrides == ""
-
-    # after the refresh, cached values are updated
-    # (not None means no need to refresh cached value)
-    assert schedule.cached_ical_file_primary == ""
-    assert schedule.cached_ical_file_overrides == ""
-
-    # same for Terraform/API schedules
-    schedule = make_schedule(organization, schedule_class=OnCallScheduleCalendar)
-
-    # initial values is None
-    assert schedule.cached_ical_file_primary is None
-
-    # accessing the property will trigger a refresh of the ical file (empty)
-    assert schedule._ical_file_primary == ""
-
-    # after the refresh, cached value is updated
-    # (not None means no need to refresh cached value)
-    assert schedule.cached_ical_file_primary == ""


### PR DESCRIPTION
Reverts grafana/oncall#1312

This change seems to have introduced some unexpected behavior with slack user groups. Reverting to reproduce locally and push an improved update.