### PR TITLE
Add option to use helm hook for migration job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.2.12 (2023-04-14)
+## Unreleased
 
 ### Added
 
-- Helm chart: add the option to use a helm hook for the migration job
+- Helm chart: add the option to use a helm hook for the migration job ([1386](https://github.com/grafana/oncall/pull/1386))
 
 ## v1.2.11 (2023-04-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.12 (2023-04-14)
+
+### Added
+
+- Helm chart: add the option to use a helm hook for the migration job
+
 ## v1.2.11 (2023-04-14)
 
 ### Added

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oncall
 description: Developer-friendly incident response with brilliant Slack integration
 type: application
-version: 1.2.8
-appVersion: v1.2.8
+version: 1.2.9
+appVersion: v1.2.9
 dependencies:
   - name: cert-manager
     version: v1.8.0

--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -2,7 +2,13 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  {{- if .Values.migrate.useHook }}
+  name: {{ printf "%s-migrate" (include "oncall.engine.fullname" .) }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+  {{- else }}
   name: {{ printf "%s-migrate-%s" (include "oncall.engine.fullname" .) (now | date "2006-01-02-15-04-05") }}
+  {{- end }}
   labels:
     {{- include "oncall.engine.labels" . | nindent 4 }}
 spec:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -150,6 +150,8 @@ migrate:
   enabled: true
   # TTL can be unset by setting ttlSecondsAfterFinished: ""
   ttlSecondsAfterFinished: 20
+  # use a helm hook to manage the migration job
+  useHook: false
 
 # Additional env variables to add to deployments
 env: {}


### PR DESCRIPTION
# What this PR does
This PR adds the option to use helm hooks for the database migration.

## Which issue(s) this PR fixes
Currently oncall always shows as out-of-sync in argo-cd because the name changes on each hard refresh. 
When using a helm hook the job is executed on sync but does not show as out-of-sync

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated
