### PR TITLE
don't run changelog/public-docs CI checks on merge_group Github events

### DIFF
--- a/.github/workflows/verify-changelog-updated.yml
+++ b/.github/workflows/verify-changelog-updated.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
       - dev
-  # You can use the merge_group event to trigger your GitHub Actions workflow when
-  # a pull request is added to a merge queue
-  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
-  merge_group:
 
 jobs:
   verfiy-changelog-updated:

--- a/.github/workflows/verify-public-docs-updated.yml
+++ b/.github/workflows/verify-public-docs-updated.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
       - dev
-  # You can use the merge_group event to trigger your GitHub Actions workflow when
-  # a pull request is added to a merge queue
-  # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
-  merge_group:
 
 jobs:
   verify-public-docs-updated:


### PR DESCRIPTION
They don't appear to work properly there:
![Screenshot 2023-02-22 at 16 00 39](https://user-images.githubusercontent.com/9406895/220663834-82b125fa-0a9e-4aff-9399-62563a312842.png)
![Screenshot 2023-02-22 at 16 00 53](https://user-images.githubusercontent.com/9406895/220663841-1af2d0a7-e910-4d84-94a8-0cdec4f0353d.png)
