### PR TITLE
Change Organization Deleted/Moved Precedence

### DIFF
--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -46,10 +46,10 @@ class ApiTokenAuthentication(BaseAuthentication):
         except InvalidToken:
             raise exceptions.AuthenticationFailed("Invalid token.")
 
-        if auth_token.organization.deleted_at:
-            raise OrganizationDeletedException(auth_token.organization)
         if auth_token.organization.is_moved:
             raise OrganizationMovedException(auth_token.organization)
+        if auth_token.organization.deleted_at:
+            raise OrganizationDeletedException(auth_token.organization)
 
         return auth_token.user, auth_token
 
@@ -180,10 +180,10 @@ class ScheduleExportAuthentication(BaseAuthentication):
         except InvalidToken:
             raise exceptions.AuthenticationFailed("Invalid token.")
 
-        if auth_token.organization.deleted_at:
-            raise OrganizationDeletedException(auth_token.organization)
         if auth_token.organization.is_moved:
             raise OrganizationMovedException(auth_token.organization)
+        if auth_token.organization.deleted_at:
+            raise OrganizationDeletedException(auth_token.organization)
 
         if auth_token.schedule.public_primary_key != public_primary_key:
             raise exceptions.AuthenticationFailed("Invalid schedule export token for schedule")
@@ -215,10 +215,10 @@ class UserScheduleExportAuthentication(BaseAuthentication):
         except InvalidToken:
             raise exceptions.AuthenticationFailed("Invalid token")
 
-        if auth_token.organization.deleted_at:
-            raise OrganizationDeletedException(auth_token.organization)
         if auth_token.organization.is_moved:
             raise OrganizationMovedException(auth_token.organization)
+        if auth_token.organization.deleted_at:
+            raise OrganizationDeletedException(auth_token.organization)
 
         if auth_token.user.public_primary_key != public_primary_key:
             raise exceptions.AuthenticationFailed("Invalid schedule export token for user")

--- a/engine/apps/integrations/mixins/alert_channel_defining_mixin.py
+++ b/engine/apps/integrations/mixins/alert_channel_defining_mixin.py
@@ -66,12 +66,12 @@ class AlertChannelDefiningMixin(object):
                 logger.info("Cache is empty!")
                 raise
 
+        if alert_receive_channel.organization.is_moved:
+            raise OrganizationMovedException(alert_receive_channel.organization)
         if alert_receive_channel.organization.deleted_at:
             # It's better to raise OrganizarionDeletedException, but in legacy code PermissionDenied is returned when integration key not found.
             # So, keep it consistent.
             raise PermissionDenied("Integration key was not found. Permission denied.")
-        if alert_receive_channel.organization.is_moved:
-            raise OrganizationMovedException(alert_receive_channel.organization)
 
         del kwargs["alert_channel_key"]
         kwargs["alert_receive_channel"] = alert_receive_channel


### PR DESCRIPTION
# What this PR does
When an organization is migrated to a different cluster it has it's `migration_destination_slug` set for redirection purposes but it also needs to be deleted so scheduled tasks for it do not run in the old cluster.  By changing the order so moved has precedence over deleted API calls will be correctly redirected for moved organizations while the organization is still considered deleted to suppress tasks that are no longer needed in the old cluster.

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
