### PR TITLE
Show 100 latest alerts on alert group page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved reCAPTCHA to backend environment variable for more flexible configuration between different environments.
 - Add pagination to schedule listing
-- Show latest 100 alert on alert group page ([1417](https://github.com/grafana/oncall/pull/1417))
+- Show 100 latest alerts on alert group page ([1417](https://github.com/grafana/oncall/pull/1417))
 
 ## v1.1.29 (2023-02-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Moved reCAPTCHA to backend environment variable for more flexible configuration between different environments.
 - Add pagination to schedule listing
+- Show latest 100 alert on alert group page ([1417](https://github.com/grafana/oncall/pull/1417))
 
 ## v1.1.29 (2023-02-23)
 

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -204,12 +204,7 @@ class AlertGroupSerializer(AlertGroupListSerializer):
         Overriding default alerts because there are alert_groups with thousands of them.
         It's just too slow, we need to cut here.
         """
-        alerts = obj.alerts.all()[:100]
-
-        if len(alerts) > 90:
-            for alert in alerts:
-                alert.title = str(alert.title) + " Only last 100 alerts are shown. Use OnCall API to fetch all of them."
-
+        alerts = obj.alerts.order_by("-pk")[:100]
         return AlertSerializer(alerts, many=True).data
 
     def get_paged_users(self, obj):

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -638,7 +638,7 @@ function GroupedIncidentsList({
     return null;
   }
 
-  const latestAlert = alerts[alerts.length - 1];
+  const latestAlert = alerts[0];
   const latestAlertMoment = moment(latestAlert.created_at);
 
   return (


### PR DESCRIPTION
# What this PR does
Make internal API return 100 latest alerts for alert group.

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/857

## Checklist

- [x] Tests updated
- [x] `CHANGELOG.md` updated
