### PR TITLE
1387 source link redesign

### DIFF
--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -755,7 +755,7 @@ function AttachedIncidentsList({
       headerWithBackground
       className={cx('collapse')}
       isOpen
-      label={<HorizontalGroup wrap>{incident.dependent_alert_groups.length} Attached Incidents</HorizontalGroup>}
+      label={<HorizontalGroup wrap>{incident.dependent_alert_groups.length} Attached Alert Groups</HorizontalGroup>}
       contentClassName={cx('incidents-content')}
     >
       {alerts.map((incident) => {

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -296,33 +296,37 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
           <div className={cx('info-row')}>
             <HorizontalGroup>
               <div className={cx('status-tag-container')}>{getIncidentStatusTag(incident)}</div>
-              <PluginLink
-                disabled={incident.alert_receive_channel.deleted}
-                query={{ page: 'integrations', id: incident.alert_receive_channel.id }}
-              >
-                <Button
-                  disabled={incident.alert_receive_channel.deleted}
-                  variant="secondary"
-                  fill="outline"
-                  size="sm"
-                  className={cx('label-button')}
-                  icon="plug"
-                >
-                  <Tooltip
-                    placement="top"
-                    content={
-                      incident.alert_receive_channel.verbal_name.length > INTEGRATION_NAME_LENGTH_LIMIT
-                        ? integrationNameWithEmojies
-                        : 'Go to Integration'
-                    }
-                  >
-                    <div className={cx('label-button-text')}>{integrationNameWithEmojies}</div>
-                  </Tooltip>
-                </Button>
-              </PluginLink>
-
               {integration && (
                 <>
+                  <PluginLink
+                    disabled={incident.alert_receive_channel.deleted}
+                    query={{ page: 'integrations', id: incident.alert_receive_channel.id }}
+                  >
+                    <Button
+                      disabled={incident.alert_receive_channel.deleted}
+                      variant="secondary"
+                      fill="outline"
+                      size="sm"
+                      className={cx('label-button')}
+                    >
+                      <Tooltip
+                        placement="top"
+                        content={
+                          incident.alert_receive_channel.verbal_name.length > INTEGRATION_NAME_LENGTH_LIMIT
+                            ? integrationNameWithEmojies
+                            : 'Go to Integration'
+                        }
+                      >
+                        <div className={cx('label-button-text', 'source-name')}>
+                          <div className={cx('integration-logo')}>
+                            <IntegrationLogo integration={integration} scale={0.08} />
+                          </div>
+                          <div className={cx('label-button-text')}>{integrationNameWithEmojies}</div>
+                        </div>
+                      </Tooltip>
+                    </Button>
+                  </PluginLink>
+
                   <Tooltip
                     placement="top"
                     content={
@@ -338,13 +342,9 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                         size="sm"
                         disabled={incident.render_for_web.source_link === null}
                         className={cx('label-button')}
+                        icon="external-link-alt"
                       >
-                        <div className={cx('label-button-text', 'source-name')}>
-                          <div className={cx('integration-logo')}>
-                            <IntegrationLogo integration={integration} scale={0.08} />
-                          </div>
-                          {integration.display_name}
-                        </div>
+                        Source
                       </Button>
                     </a>
                   </Tooltip>

--- a/grafana-plugin/src/pages/incidents/Incidents.tsx
+++ b/grafana-plugin/src/pages/incidents/Incidents.tsx
@@ -431,7 +431,7 @@ class Incidents extends React.Component<IncidentsPageProps, IncidentsPageState> 
               <span>{record.render_for_web.title}</span>
             </Tooltip>
           </PluginLink>
-          {Boolean(record.dependent_alert_groups.length) && `+ ${record.dependent_alert_groups.length} attached`}
+          {Boolean(record.dependent_alert_groups.length) && ` + ${record.dependent_alert_groups.length} attached`}
         </div>
       </VerticalGroup>
     );


### PR DESCRIPTION
# What this PR does
Source link is not related with Integration, so it is just a label now
Icon of integration moved to Integration label-link
Incident word was removed from "1 attached Incidents"

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/1387

