### PR TITLE
Allow twilio secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.32 (2023-01-03)
+
+### Added
+
+- Add helm chart support for twilio existing secrets
+
 ## v1.1.31 (2023-03-01)
 
 ### Added

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -117,6 +117,33 @@ MIRAGE_SECRET_KEY
 - name: TWILIO_ACCOUNT_SID
   value: {{ .accountSid | quote }}
 {{- end -}}
+{{- if .existingSecret }}
+- name: TWILIO_AUTH_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ required ".authTokenKey is required if .existingSecret is not empty" .authTokenKey }}
+- name: TWILIO_NUMBER
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ required ".phoneNumberKey is required if .existingSecret is not empty" .phoneNumberKey }}
+- name: TWILIO_VERIFY_SERVICE_SID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ required ".verifySidKey is required if .existingSecret is not empty" .verifySidKey }}
+- name: TWILIO_API_KEY_SID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ required ".apiKeySidKey is required if .existingSecret is not empty" .apiKeySidKey }}
+- name: TWILIO_API_KEY_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .existingSecret }}
+      key: {{ required ".apiKeySecretKey is required if .existingSecret is not empty" .apiKeySecretKey }}
+{{- else }}
 {{- if .authToken }}
 - name: TWILIO_AUTH_TOKEN
   value: {{ .authToken | quote }}
@@ -137,6 +164,7 @@ MIRAGE_SECRET_KEY
 - name: TWILIO_API_KEY_SECRET
   value: {{ .apiKeySecret | quote }}
 {{- end -}}
+{{- end }}
 {{- end -}}
 {{- end -}}
 

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -144,6 +144,19 @@ oncall:
     apiKeySid: ""
     # Twilio API key secret/password to allow OnCall to send SMSes and make phone calls
     apiKeySecret: ""
+    # Use existing secret for authToken, phoneNumber, verifySid, apiKeySid and apiKeySecret.
+    existingSecret: ""
+    # Twilio password to allow OnCall to send SMSes and make calls
+    # the key in the secret containing the auth token
+    authTokenKey: ""
+    # the key in the secret containing the phone number
+    phoneNumberKey: ""
+    # the key in the secret containing verify service sid
+    verifySidKey: ""
+    # the key in the secret containing api key sid
+    apiKeySidKey: ""
+    # the key in the secret containing the api key secret
+    apiKeySecretKey: ""
 
 # Whether to run django database migrations automatically
 migrate:


### PR DESCRIPTION
# What this PR does

Allows functionality of storing twilio credentials in an external secret, in the same way that slack supports

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [x] `CHANGELOG.md` updated
