### PR TITLE
Fix pagination issue when searching schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Schedule filters improvements ([941](https://github.com/grafana/oncall/issues/941))
+- Fix pagination issue on schedules page ([1437](https://github.com/grafana/oncall/pull/1437))
 
 ## v1.1.31 (2023-03-01)
 

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -369,6 +369,24 @@ def test_get_list_schedules_by_used(
 
 
 @pytest.mark.django_db
+def test_get_list_schedules_pagination_respects_search(
+    schedule_internal_api_setup,
+    make_escalation_chain,
+    make_escalation_policy,
+    make_user_auth_headers,
+):
+    user, token, _, _, _, _ = schedule_internal_api_setup
+    client = APIClient()
+
+    url = reverse("api-internal:schedule-list") + "?search=ical"
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["count"] == 1
+    assert len(response.json()["results"]) == 1
+
+
+@pytest.mark.django_db
 def test_get_detail_calendar_schedule(schedule_internal_api_setup, make_user_auth_headers):
     user, token, calendar_schedule, _, _, _ = schedule_internal_api_setup
     client = APIClient()

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -121,7 +121,7 @@ class ScheduleView(
         The result of this method is cached and is reused for the whole lifetime of a request,
         since self.get_serializer_context() is called multiple times for every instance in the queryset.
         """
-        current_page_schedules = self.paginate_queryset(self.get_queryset())
+        current_page_schedules = self.paginate_queryset(self.filter_queryset(self.get_queryset()))
         pks = [schedule.pk for schedule in current_page_schedules]
         queryset = OnCallSchedule.objects.filter(pk__in=pks)
         return queryset.get_oncall_users()
@@ -169,6 +169,8 @@ class ScheduleView(
             queryset = queryset.filter().instance_of(SCHEDULE_TYPE_TO_CLASS[filter_by_type])
         if used is not None:
             queryset = queryset.filter(escalation_policies__isnull=not used).distinct()
+
+        queryset = queryset.order_by("pk")
         return queryset
 
     def perform_create(self, serializer):


### PR DESCRIPTION
# What this PR does
Fixes a bug with inconsistent schedule count when searching by name.

Example (2 schedules returned, but count is incorrectly set to 12):
![image](https://user-images.githubusercontent.com/20116910/222198919-2f2124bc-52b2-4e5f-a949-79bbf89a5a26.png)

## Checklist

- [x] Tests updated
- [x] `CHANGELOG.md` updated
