### PR TITLE
Add force option to delete web schedule shifts

### DIFF
--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -591,6 +591,45 @@ def test_delete_started_on_call_shift(
 
 
 @pytest.mark.django_db
+def test_force_delete_started_on_call_shift(
+    on_call_shift_internal_api_setup,
+    make_on_call_shift,
+    make_user_auth_headers,
+):
+    """Test deleting the shift that has started (rotation_start < now)"""
+
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
+
+    client = APIClient()
+    start_date = (timezone.now() - timezone.timedelta(hours=1)).replace(microsecond=0)
+
+    title = "Test Shift Rotation"
+
+    on_call_shift = make_on_call_shift(
+        schedule.organization,
+        shift_type=CustomOnCallShift.TYPE_ROLLING_USERS_EVENT,
+        schedule=schedule,
+        title=title,
+        start=start_date,
+        duration=timezone.timedelta(hours=1),
+        rotation_start=start_date,
+        rolling_users=[{user1.pk: user1.public_primary_key}],
+    )
+
+    # set force=true to hard delete the shift
+    url = "{}?force=true".format(
+        reverse("api-internal:oncall_shifts-detail", kwargs={"pk": on_call_shift.public_primary_key})
+    )
+
+    response = client.delete(url, **make_user_auth_headers(user1, token))
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    with pytest.raises(CustomOnCallShift.DoesNotExist):
+        on_call_shift.refresh_from_db()
+
+
+@pytest.mark.django_db
 def test_delete_future_on_call_shift(
     on_call_shift_internal_api_setup,
     make_on_call_shift,

--- a/engine/apps/api/views/on_call_shifts.py
+++ b/engine/apps/api/views/on_call_shifts.py
@@ -85,7 +85,8 @@ class OnCallShiftView(PublicPrimaryKeyMixin, UpdateSerializerMixin, ModelViewSet
             author=self.request.user,
             event=EntityEvent.DELETED,
         )
-        instance.delete()
+        force = self.request.query_params.get("force", "") == "true"
+        instance.delete(force=force)
 
     @action(detail=False, methods=["post"])
     def preview(self, request):

--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -220,8 +220,9 @@ class CustomOnCallShift(models.Model):
         if self.schedule:
             schedules_to_update.append(self.schedule)
 
+        force = kwargs.pop("force", False)
         # do soft delete for started shifts that were created for web schedule
-        if self.schedule and self.event_is_started:
+        if self.schedule and self.event_is_started and not force:
             self.until = timezone.now().replace(microsecond=0)
             self.save(update_fields=["until"])
         else:


### PR DESCRIPTION
Related to #1505
Add force param to shift delete endpoint in plugin internal API.