### PR TITLE
Snyk monitor workflow change

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -29,6 +29,6 @@ jobs:
           yarn --network-timeout 500000
       - name: Run Snyk
         continue-on-error: true
-        run: snyk test --all-projects --severity-threshold=high
+        run: snyk monitor --all-projects --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
# What this PR does
Replaces `snyk test` with `snyk monitor` so results get pushed to out Snyk platform and the [Snyk Dashboards](https://ops.grafana-ops.net/d/H0w7l5NVk/snyk-overview?orgId=1) gets updated. 

## Which issue(s) this PR fixes

## Checklist

- [ ] Tests updated
- [ ] Documentation added
- [ ] `CHANGELOG.md` updated
