### PR TITLE
fix resolution note Slack rendering bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Check for duplicated positions in terraform escalation policies create/update
+- Fix resolution note rendering in Slack message threads where the Slack username was not
+  being properly rendered ([1561](https://github.com/grafana/oncall/pull/1561))
 
 ### Added
 

--- a/engine/apps/slack/scenarios/resolution_note.py
+++ b/engine/apps/slack/scenarios/resolution_note.py
@@ -362,9 +362,8 @@ class UpdateResolutionNoteStep(scenario_step.ScenarioStep):
             "type": "context",
             "elements": [
                 {
-                    "type": "plain_text",
+                    "type": "mrkdwn",
                     "text": f"{author_verbal} resolution note from {resolution_note.get_source_display()}.",
-                    "emoji": True,
                 }
             ],
         }


### PR DESCRIPTION
# Which issue(s) this PR fixes
changing the block element type from `plain_text` to `mrkdwn` now allows slack to properly render Slack usernames in the Slack UI.

Also, it seems that the `mrkdwn` context block type does not support the `emoji` key, hence getting rid of it. From the Slack [docs](https://api.slack.com/reference/block-kit/composition-objects#text):
![Screenshot 2023-03-16 at 16 19 25](https://user-images.githubusercontent.com/9406895/225663614-b0dbbaf1-4b39-48a4-9064-a3aa43fa4f43.png)


## Before
![Screenshot 2023-03-16 at 16 12 33](https://user-images.githubusercontent.com/9406895/225663322-7e84f7a9-dc6b-4827-b01c-1643bd27b766.png)

## After
![Screenshot 2023-03-16 at 16 12 27](https://user-images.githubusercontent.com/9406895/225663343-eff3fd27-d44b-4c2a-a06d-23e0936fcd37.png)



## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated
