### PR TITLE
update wording in some Slack messages which mention 'incident' instead of 'alert group'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Updated wording in some Slack messages to use 'Alert Group' instead of 'Incident' ([1565](https://github.com/grafana/oncall/pull/1565))
+
+### Fixed
+
+- Fix resolution note rendering in Slack message threads where the Slack username was not
+  being properly rendered ([1561](https://github.com/grafana/oncall/pull/1561))
+
 ## v1.1.40 (2023-03-16)
 
 ### Fixed
 
 - Check for duplicated positions in terraform escalation policies create/update
-- Fix resolution note rendering in Slack message threads where the Slack username was not
-  being properly rendered ([1561](https://github.com/grafana/oncall/pull/1561))
 
 ### Added
 

--- a/engine/apps/slack/models/slack_message.py
+++ b/engine/apps/slack/models/slack_message.py
@@ -116,7 +116,7 @@ class SlackMessage(models.Model):
 
         slack_user_identity = user.slack_user_identity
         if slack_user_identity is None:
-            text = "{}\nTried to invite {} to look at incident. Unfortunately {} is not in slack.".format(
+            text = "{}\nTried to invite {} to look at the alert group. Unfortunately {} is not in slack.".format(
                 alert_group.long_verbose_name, user_verbal, user_verbal
             )
 
@@ -131,7 +131,7 @@ class SlackMessage(models.Model):
                 notification_error_code=UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_IN_SLACK_USER_NOT_IN_SLACK,
             ).save()
         else:
-            text = "{}\nInviting {} to look at incident.".format(alert_group.long_verbose_name, user_verbal)
+            text = "{}\nInviting {} to look at the alert group.".format(alert_group.long_verbose_name, user_verbal)
 
         blocks = [
             {

--- a/engine/apps/slack/scenarios/escalation_delivery.py
+++ b/engine/apps/slack/scenarios/escalation_delivery.py
@@ -33,4 +33,4 @@ class EscalationDeliveryStep(scenario_step.ScenarioStep):
             # Don't mention if asked to notify somehow else but drop a note for colleagues
             user_mention_as = user_verbal
             notify_by = " by {}".format(UserNotificationPolicy.NotificationChannel(notification_channel).label)
-        return "Inviting {}{} to look at incident.".format(user_mention_as, notify_by)
+        return "Inviting {}{} to look at the alert group.".format(user_mention_as, notify_by)


### PR DESCRIPTION
# What this PR does

![image](https://user-images.githubusercontent.com/9406895/225678127-4a0bcf96-742e-4335-9958-36fa0be26b9f.png)

## Checklist

- [ ] Tests updated (N/A)
- [ ] Documentation added (N/A)
- [x] `CHANGELOG.md` updated
