### PR TITLE
minor bugfix for ios push notifications config

### DIFF
--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -216,11 +216,11 @@ def _get_fcm_message(alert_group, user, registration_id, critical):
                         "interruption-level": "critical" if critical else "time-sensitive",
                     },
                 ),
-                headers={
-                    # From the docs
-                    # https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message
-                    "apns-priority": "10",
-                },
             ),
+            headers={
+                # From the docs
+                # https://firebase.google.com/docs/cloud-messaging/concept-options#setting-the-priority-of-a-message
+                "apns-priority": "10",
+            },
         ),
     )


### PR DESCRIPTION
In the "apns" key of the message sent to FCM, "headers" should not be nested under "payload", it should instead be at the same level. See Firebase docs for the `FirebaseAdmin.Messaging.ApnsConfig` class [here](https://firebase.google.com/docs/reference/admin/dotnet/class/firebase-admin/messaging/apns-config#class_firebase_admin_1_1_messaging_1_1_apns_config_1a7a9858f0b30ef7c437205ca01d6e62f6)