### PR TITLE
Support notification priority in FCM relay

### DIFF
--- a/engine/apps/mobile_app/tests/test_fcm_relay.py
+++ b/engine/apps/mobile_app/tests/test_fcm_relay.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 import pytest
@@ -7,7 +8,8 @@ from firebase_admin.exceptions import FirebaseError
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from apps.mobile_app.fcm_relay import FCMRelayThrottler, fcm_relay_async
+from apps.mobile_app.fcm_relay import FCMRelayThrottler, _get_message_from_request_data, fcm_relay_async
+from apps.mobile_app.tasks import _get_fcm_message
 
 
 @pytest.mark.django_db
@@ -88,3 +90,41 @@ def test_fcm_relay_async_retry():
     ):
         with pytest.raises(FirebaseError):
             fcm_relay_async(token="test_token", data={}, apns={})
+
+
+def test_get_message_from_request_data():
+    token = "test_token"
+    data = {"test_data_key": "test_data_value"}
+    apns = {"headers": {"apns-priority": "10"}, "payload": {"aps": {"thread-id": "test_thread_id"}}}
+    android = {"priority": "high"}
+    message = _get_message_from_request_data(token, data, apns, android)
+
+    assert message.token == "test_token"
+    assert message.data == {"test_data_key": "test_data_value"}
+    assert message.apns.headers == {"apns-priority": "10"}
+    assert message.apns.payload.aps.thread_id == "test_thread_id"
+    assert message.android.priority == "high"
+
+
+@pytest.mark.django_db
+def test_fcm_relay_serialize_deserialize(
+    make_organization_and_user, make_alert_receive_channel, make_alert_group, make_alert
+):
+    organization, user = make_organization_and_user()
+    device = FCMDevice.objects.create(user=user, registration_id="test_device_id")
+
+    alert_receive_channel = make_alert_receive_channel(organization=organization)
+    alert_group = make_alert_group(alert_receive_channel)
+    make_alert(alert_group=alert_group, raw_request_data={})
+
+    # Imitate sending a message to the FCM relay endpoint
+    original_message = _get_fcm_message(alert_group, user, device.registration_id, critical=False)
+    request_data = json.loads(str(original_message))
+
+    # Imitate receiving a message from the FCM relay endpoint
+    relayed_message = _get_message_from_request_data(
+        request_data["token"], request_data["data"], request_data["apns"], request_data["android"]
+    )
+
+    # Check that the message is the same after serialization and deserialization
+    assert json.loads(str(original_message)) == json.loads(str(relayed_message))


### PR DESCRIPTION
# What this PR does
Adds support for notification priority in FCM relay + add some tests on FCM relay

## Which issue(s) this PR fixes
Related to https://github.com/grafana/oncall/issues/1550 and https://github.com/grafana/oncall/pull/1612

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
