### PR TITLE
Update apns payload with corrected `interruption-level` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Addressed bug with iOS mobile push notifications always being set to critical by @imtoori and @joeyorlando ([#1646](https://github.com/grafana/oncall/pull/1646))
+
 ## v1.2.2 (2023-03-27)
 
 ### Changed

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -208,7 +208,9 @@ def _get_fcm_message(alert_group, user, registration_id, critical):
                     alert=ApsAlert(title=alert_title, subtitle=alert_subtitle, body=alert_body),
                     sound=CriticalSound(
                         # The notification shouldn't be critical if the user has disabled "override DND" setting
-                        critical=1 if (critical and mobile_app_user_settings.important_notification_override_dnd) else 0,
+                        critical=1
+                        if (critical and mobile_app_user_settings.important_notification_override_dnd)
+                        else 0,
                         name=apns_sound_name,
                         volume=apns_volume,
                     ),

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -208,7 +208,7 @@ def _get_fcm_message(alert_group, user, registration_id, critical):
                     alert=ApsAlert(title=alert_title, subtitle=alert_subtitle, body=alert_body),
                     sound=CriticalSound(
                         # The notification shouldn't be critical if the user has disabled "override DND" setting
-                        critical=(critical and mobile_app_user_settings.important_notification_override_dnd),
+                        critical=1 if (critical and mobile_app_user_settings.important_notification_override_dnd) else 0,
                         name=apns_sound_name,
                         volume=apns_volume,
                     ),

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -141,6 +141,10 @@ def _get_fcm_message(alert_group, user, registration_id, critical):
 
     mobile_app_user_settings, _ = MobileAppUserSettings.objects.get_or_create(user=user)
 
+    # critical defines the type of notification.
+    # we use overrideDND to establish if the notification should sound even if DND is on
+    overrideDND = critical and mobile_app_user_settings.important_notification_override_dnd
+
     # APNS only allows to specify volume for critical notifications
     apns_volume = mobile_app_user_settings.important_notification_volume if critical else None
     apns_sound_name = (
@@ -208,14 +212,12 @@ def _get_fcm_message(alert_group, user, registration_id, critical):
                     alert=ApsAlert(title=alert_title, subtitle=alert_subtitle, body=alert_body),
                     sound=CriticalSound(
                         # The notification shouldn't be critical if the user has disabled "override DND" setting
-                        critical=1
-                        if (critical and mobile_app_user_settings.important_notification_override_dnd)
-                        else 0,
+                        critical=overrideDND,
                         name=apns_sound_name,
                         volume=apns_volume,
                     ),
                     custom_data={
-                        "interruption-level": "critical" if critical else "time-sensitive",
+                        "interruption-level": "critical" if overrideDND else "time-sensitive",
                     },
                 ),
             ),

--- a/engine/apps/mobile_app/tests/test_notify_user.py
+++ b/engine/apps/mobile_app/tests/test_notify_user.py
@@ -270,6 +270,7 @@ def test_fcm_message_user_settings_critical(
     assert apns_sound.critical == 1
     assert apns_sound.name == "default_sound_important.aiff"
     assert apns_sound.volume == 0.8
+    assert message.apns.payload.aps.custom_data["interruption-level"] == "critical"
 
 
 @pytest.mark.django_db
@@ -293,3 +294,4 @@ def test_fcm_message_user_settings_critical_override_dnd_disabled(
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
     assert apns_sound.critical == 0
+    assert message.apns.payload.aps.custom_data["interruption-level"] == "time-sensitive"

--- a/engine/apps/mobile_app/tests/test_notify_user.py
+++ b/engine/apps/mobile_app/tests/test_notify_user.py
@@ -237,7 +237,7 @@ def test_fcm_message_user_settings(
 
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
-    assert apns_sound.critical == 0
+    assert apns_sound.critical is False
     assert apns_sound.name == "default_sound.aiff"
     assert apns_sound.volume is None  # APNS doesn't allow to specify volume for non-critical notifications
 
@@ -267,7 +267,7 @@ def test_fcm_message_user_settings_critical(
 
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
-    assert apns_sound.critical == 1
+    assert apns_sound.critical is True
     assert apns_sound.name == "default_sound_important.aiff"
     assert apns_sound.volume == 0.8
     assert message.apns.payload.aps.custom_data["interruption-level"] == "critical"
@@ -293,5 +293,5 @@ def test_fcm_message_user_settings_critical_override_dnd_disabled(
 
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
-    assert apns_sound.critical == 0
+    assert apns_sound.critical is False
     assert message.apns.payload.aps.custom_data["interruption-level"] == "time-sensitive"

--- a/engine/apps/mobile_app/tests/test_notify_user.py
+++ b/engine/apps/mobile_app/tests/test_notify_user.py
@@ -237,7 +237,7 @@ def test_fcm_message_user_settings(
 
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
-    assert apns_sound.critical is False
+    assert apns_sound.critical == 0
     assert apns_sound.name == "default_sound.aiff"
     assert apns_sound.volume is None  # APNS doesn't allow to specify volume for non-critical notifications
 
@@ -267,7 +267,7 @@ def test_fcm_message_user_settings_critical(
 
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
-    assert apns_sound.critical is True
+    assert apns_sound.critical == 1
     assert apns_sound.name == "default_sound_important.aiff"
     assert apns_sound.volume == 0.8
 
@@ -292,4 +292,4 @@ def test_fcm_message_user_settings_critical_override_dnd_disabled(
 
     # Check APNS notification sound is set correctly
     apns_sound = message.apns.payload.aps.sound
-    assert apns_sound.critical is False
+    assert apns_sound.critical == 0


### PR DESCRIPTION
I just noticed that ios notifications are always critical, even when the switch ("override DND") is set to `false`. I believe this is because `critical` should be either 1 or 0 
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2990112