### PR TITLE
Fix team search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix team search when filtering resources by @vadimkerr ([#1680](https://github.com/grafana/oncall/pull/1680))
+
 ## v1.2.6 (2023-03-30)
 
 ### Fixed

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -52,8 +52,8 @@ def test_list_teams(
         ("", [GENERAL_TEAM.name, "team 1", "team 2"]),
         ("team", [GENERAL_TEAM.name, "team 1", "team 2"]),
         ("no team", [GENERAL_TEAM.name]),
-        ("team ", ["team 1", "team 2"]),
-        ("team 1", ["team 1"]),
+        ("team ", [GENERAL_TEAM.name, "team 1", "team 2"]),
+        ("team 1", [GENERAL_TEAM.name, "team 1"]),
     ],
 )
 def test_list_teams_search_by_name(

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -46,6 +46,49 @@ def test_list_teams(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "search,team_names",
+    [
+        ("", [GENERAL_TEAM.name, "team 1", "team 2"]),
+        ("team", [GENERAL_TEAM.name, "team 1", "team 2"]),
+        ("no team", [GENERAL_TEAM.name]),
+        ("team ", ["team 1", "team 2"]),
+        ("team 1", ["team 1"]),
+    ],
+)
+def test_list_teams_search_by_name(
+    make_organization,
+    make_team,
+    make_user_for_organization,
+    make_token_for_organization,
+    make_user_auth_headers,
+    search,
+    team_names,
+):
+    organization = make_organization()
+    user = make_user_for_organization(organization)
+    _, token = make_token_for_organization(organization)
+
+    for team_name in team_names:
+        if team_name != GENERAL_TEAM.name:
+            make_team(organization, name=team_name)
+
+    client = APIClient()
+
+    url = reverse("api-internal:team-list") + f"?search={search}"
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+
+    expected_json = [
+        get_payload_from_team(organization.teams.get(name=team_name))
+        if team_name != GENERAL_TEAM.name
+        else get_payload_from_team(GENERAL_TEAM)
+        for team_name in team_names
+    ]
+    assert response.json() == expected_json
+
+
+@pytest.mark.django_db
 def test_list_teams_for_non_member(
     make_organization,
     make_team,

--- a/engine/apps/api/views/team.py
+++ b/engine/apps/api/views/team.py
@@ -31,13 +31,7 @@ class TeamViewSet(PublicPrimaryKeyMixin, mixins.ListModelMixin, mixins.UpdateMod
 
     def filter_queryset(self, queryset):
         """
-        Adds general team to the queryset in a way that it works well with searching by name.
+        Adds general team to the queryset in a way that it always shows up first (even when not searched for).
         """
-        result = list(super().filter_queryset(queryset))
         general_team = Team(public_primary_key="null", name="No team", email=None, avatar_url=None)
-
-        search = self.request.query_params.get(SearchFilter.search_param)
-        if not search or search.lower() in general_team.name.lower():  # check if general team should be added
-            return [general_team] + result
-
-        return result
+        return [general_team] + list(super().filter_queryset(queryset))

--- a/engine/apps/api/views/team.py
+++ b/engine/apps/api/views/team.py
@@ -1,6 +1,6 @@
 from rest_framework import mixins, viewsets
+from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
 
 from apps.api.permissions import RBACPermission
 from apps.api.serializers.team import TeamSerializer
@@ -23,17 +23,21 @@ class TeamViewSet(PublicPrimaryKeyMixin, mixins.ListModelMixin, mixins.UpdateMod
     }
 
     serializer_class = TeamSerializer
+    filter_backends = [SearchFilter]
+    search_fields = ["name"]
 
     def get_queryset(self):
         return self.request.user.available_teams
 
-    def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
+    def filter_queryset(self, queryset):
+        """
+        Adds general team to the queryset in a way that it works well with searching by name.
+        """
+        result = list(super().filter_queryset(queryset))
         general_team = Team(public_primary_key="null", name="No team", email=None, avatar_url=None)
 
-        page = self.paginate_queryset(queryset)
-        if page is not None:
-            serializer = self.get_serializer([general_team] + list(page), many=True)
-            return self.get_paginated_response(serializer.data)
-        serializer = self.get_serializer([general_team] + list(queryset), many=True)
-        return Response(serializer.data)
+        search = self.request.query_params.get(SearchFilter.search_param)
+        if not search or search.lower() in general_team.name.lower():  # check if general team should be added
+            return [general_team] + result
+
+        return result


### PR DESCRIPTION
# What this PR does

Team search doesn't work when filtering by team:

<img width="331" alt="Screenshot 2023-03-30 at 15 48 50" src="https://user-images.githubusercontent.com/20116910/228875971-0f55bdf8-6aa7-4759-9882-cdf7d11bb0c7.png">

This PR fixes it + adds backend unit tests.


## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
