### PR TITLE
temporarily disable e2e CI job

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -262,6 +262,8 @@ jobs:
           pytest -x
 
   end-to-end-tests:
+    # TODO: reenable this job once https://github.com/grafana/oncall/issues/1692 is fixed
+    if: ${{ false }}
     runs-on: ubuntu-latest
     name: "End to end tests - Grafana: ${{ matrix.grafana-image-tag }}"
     strategy:


### PR DESCRIPTION
Will re-enable them (and set this job as a required passing build step) once all of the sub-tasks of https://github.com/grafana/oncall/issues/1692 are fixed