### PR TITLE
Add Slack Api error "message_limit_exceeded" to SlackAPIRateLimitException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.2.9 (2023-04-11)
+
+### Fixed
+
+- Catch the new Slack error - "message_limit_exceeded"
+
 ## v1.2.8 (2023-04-06)
 
 ### Changed

--- a/engine/apps/slack/slack_client/slack_client.py
+++ b/engine/apps/slack/slack_client/slack_client.py
@@ -77,7 +77,12 @@ class SlackClientWithErrorHandling(SlackClient):
             if response["error"] == "is_archived":
                 raise SlackAPIChannelArchivedException(exception_text, response=response)
 
-            if response["error"] == "rate_limited" or response["error"] == "ratelimited":
+            if (
+                response["error"] == "rate_limited"
+                or response["error"] == "ratelimited"
+                or response["error"] == "message_limit_exceeded"
+                # "message_limit_exceeded" is related to the limit on post messages for free Slack workspace
+            ):
                 if "headers" in response and response["headers"].get("Retry-After") is not None:
                     delay = int(response["headers"]["Retry-After"])
                 else:


### PR DESCRIPTION
Catch the new Slack error code "message_limit_exceeded" as a rate limit error
