### PR TITLE
Fix `web_link` property of AlertGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug in GForm's RemoteSelect where the value for Dropdown could not change
+- Fixed the URL attached to an Incident created via the 'Declare Incident' button of a Slack alert by @sd2k ([#1738](https://github.com/grafana/oncall/pull/1738))
 
 ## v1.2.8 (2023-04-06)
 

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -474,7 +474,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
 
     @property
     def web_link(self) -> str:
-        return urljoin(self.channel.organization.web_link, f"?page=incident&id={self.public_primary_key}")
+        return urljoin(self.channel.organization.web_link, f"alert-groups/{self.public_primary_key}")
 
     @property
     def declare_incident_link(self) -> str:


### PR DESCRIPTION
The routing of the OnCall plugin has changed and no longer uses URL params
but instead uses paths. This link is used when declaring an Incident from
the OnCall Slack alert and needs to match the correct pattern in order for
Incident to correctly detect it.
