### PR TITLE
Fix insight_logs exceptions

### DIFF
--- a/engine/apps/api/views/telegram_channels.py
+++ b/engine/apps/api/views/telegram_channels.py
@@ -8,7 +8,7 @@ from apps.api.permissions import RBACPermission
 from apps.api.serializers.telegram import TelegramToOrganizationConnectorSerializer
 from apps.auth_token.auth import PluginAuthentication
 from common.api_helpers.mixins import PublicPrimaryKeyMixin
-from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 
 
 class TelegramChannelViewSet(
@@ -47,7 +47,7 @@ class TelegramChannelViewSet(
         write_chatops_insight_log(
             author=user,
             event_name=ChatOpsEvent.CHANNEL_DISCONNECTED,
-            chatops_type=ChatOpsType.TELEGRAM,
+            chatops_type=ChatOpsTypePlug.TELEGRAM.value,
             channel_name=instance.channel_name,
         )
         instance.delete()

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -49,7 +49,7 @@ from common.api_helpers.paginators import HundredPageSizePaginator
 from common.api_helpers.utils import create_engine_url
 from common.insight_log import (
     ChatOpsEvent,
-    ChatOpsType,
+    ChatOpsTypePlug,
     EntityEvent,
     write_chatops_insight_log,
     write_resource_insight_log,
@@ -417,7 +417,7 @@ class UserView(
         write_chatops_insight_log(
             author=request.user,
             event_name=ChatOpsEvent.USER_UNLINKED,
-            chatops_type=ChatOpsType.SLACK,
+            chatops_type=ChatOpsTypePlug.SLACK.value,
             linked_user=user.username,
             linked_user_id=user.public_primary_key,
         )
@@ -433,7 +433,7 @@ class UserView(
             write_chatops_insight_log(
                 author=request.user,
                 event_name=ChatOpsEvent.USER_UNLINKED,
-                chatops_type=ChatOpsType.TELEGRAM,
+                chatops_type=ChatOpsTypePlug.TELEGRAM.value,
                 linked_user=user.username,
                 linked_user_id=user.public_primary_key,
             )

--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -687,7 +687,7 @@ class OnCallSchedule(PolymorphicModel):
             result["notification_frequency"] = self.get_notify_oncall_shift_freq_display()
             result["current_shift_notification"] = self.mention_oncall_start
             result["next_shift_notification"] = self.mention_oncall_next
-            result["notify_empty_oncall"] = self.get_notify_empty_oncall_display
+            result["notify_empty_oncall"] = self.get_notify_empty_oncall_display()
         return result
 
     @property

--- a/engine/apps/slack/models/slack_team_identity.py
+++ b/engine/apps/slack/models/slack_team_identity.py
@@ -9,7 +9,7 @@ from apps.slack.constants import SLACK_INVALID_AUTH_RESPONSE, SLACK_WRONG_TEAM_N
 from apps.slack.slack_client import SlackClientWithErrorHandling
 from apps.slack.slack_client.exceptions import SlackAPIException, SlackAPITokenException
 from apps.user_management.models.user import User
-from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +65,7 @@ class SlackTeamIdentity(models.Model):
         self.installed_via_granular_permissions = True
         self.save()
         write_chatops_insight_log(
-            author=user, event_name=ChatOpsEvent.WORKSPACE_CONNECTED, chatops_type=ChatOpsType.SLACK
+            author=user, event_name=ChatOpsEvent.WORKSPACE_CONNECTED, chatops_type=ChatOpsTypePlug.SLACK.value
         )
 
     def get_cached_channels(self, search_term=None, slack_id=None):

--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -53,7 +53,7 @@ from apps.slack.scenarios.slack_usergroup import STEPS_ROUTING as SLACK_USERGROU
 from apps.slack.slack_client import SlackClientWithErrorHandling
 from apps.slack.slack_client.exceptions import SlackAPIException, SlackAPITokenException
 from apps.slack.tasks import clean_slack_integration_leftovers, unpopulate_slack_user_identities
-from common.insight_log import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 from common.oncall_gateway import delete_slack_connector
 
 from .models import SlackMessage, SlackTeamIdentity, SlackUserIdentity
@@ -555,7 +555,7 @@ class ResetSlackView(APIView):
                 write_chatops_insight_log(
                     author=request.user,
                     event_name=ChatOpsEvent.WORKSPACE_DISCONNECTED,
-                    chatops_type=ChatOpsType.SLACK,
+                    chatops_type=ChatOpsTypePlug.SLACK.value,
                 )
                 unpopulate_slack_user_identities(organization.pk, True)
                 response = Response(status=200)

--- a/engine/apps/social_auth/pipeline.py
+++ b/engine/apps/social_auth/pipeline.py
@@ -14,7 +14,7 @@ from common.constants.slack_auth import (
     SLACK_AUTH_SLACK_USER_ALREADY_CONNECTED_ERROR,
     SLACK_AUTH_WRONG_WORKSPACE_ERROR,
 )
-from common.insight_log import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 from common.oncall_gateway import check_slack_installation_possible, create_slack_connector
 
 logger = logging.getLogger(__name__)
@@ -74,7 +74,7 @@ def connect_user_to_slack(response, backend, strategy, user, organization, *args
     write_chatops_insight_log(
         author=user,
         event_name=ChatOpsEvent.USER_LINKED,
-        chatops_type=ChatOpsType.SLACK,
+        chatops_type=ChatOpsTypePlug.SLACK.value,
         linked_user=user.username,
         linked_user_id=user.public_primary_key,
     )

--- a/engine/apps/telegram/models/connectors/channel.py
+++ b/engine/apps/telegram/models/connectors/channel.py
@@ -10,7 +10,7 @@ from telegram import error
 from apps.alerts.models import AlertGroup
 from apps.telegram.client import TelegramClient
 from apps.telegram.models import TelegramMessage
-from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
 logger = logging.getLogger(__name__)
@@ -102,7 +102,7 @@ class TelegramToOrganizationConnector(models.Model):
         write_chatops_insight_log(
             author=author,
             event_name=ChatOpsEvent.DEFAULT_CHANNEL_CHANGED,
-            chatops_type=ChatOpsType.TELEGRAM,
+            chatops_type=ChatOpsTypePlug.TELEGRAM.value,
             prev_channel=old_default_channel.channel_name if old_default_channel else None,
             new_channel=self.channel_name,
         )

--- a/engine/apps/telegram/models/verification/channel.py
+++ b/engine/apps/telegram/models/verification/channel.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.utils import timezone
 
 from apps.telegram.models import TelegramToOrganizationConnector
-from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log.chatops_insight_logs import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 
 
 class TelegramChannelVerificationCode(models.Model):
@@ -66,14 +66,14 @@ class TelegramChannelVerificationCode(models.Model):
             write_chatops_insight_log(
                 author=code_instance.author,
                 event_name=ChatOpsEvent.CHANNEL_CONNECTED,
-                chatops_type=ChatOpsType.TELEGRAM,
+                chatops_type=ChatOpsTypePlug.TELEGRAM.value,
                 channel_name=channel_name,
             )
             if not connector_exists:
                 write_chatops_insight_log(
                     author=code_instance.author,
                     event_name=ChatOpsEvent.DEFAULT_CHANNEL_CHANGED,
-                    chatops_type=ChatOpsType.TELEGRAM,
+                    chatops_type=ChatOpsTypePlug.TELEGRAM.value,
                     prev_channel=None,
                     new_channel=channel_name,
                 )

--- a/engine/apps/telegram/models/verification/personal.py
+++ b/engine/apps/telegram/models/verification/personal.py
@@ -6,7 +6,7 @@ from django.db import IntegrityError, models
 from django.utils import timezone
 
 from apps.telegram.models import TelegramToUserConnector
-from common.insight_log import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 
 
 class TelegramVerificationCode(models.Model):
@@ -48,7 +48,7 @@ class TelegramVerificationCode(models.Model):
             write_chatops_insight_log(
                 author=user,
                 event_name=ChatOpsEvent.USER_LINKED,
-                chatops_type=ChatOpsType.TELEGRAM,
+                chatops_type=ChatOpsTypePlug.TELEGRAM.value,
                 linked_user=user.username,
                 linked_user_id=user.public_primary_key,
             )

--- a/engine/apps/user_management/models/organization.py
+++ b/engine/apps/user_management/models/organization.py
@@ -14,7 +14,7 @@ from apps.alerts.models import MaintainableObject
 from apps.alerts.tasks import disable_maintenance
 from apps.slack.utils import post_message_to_channel
 from apps.user_management.subscription_strategy import FreePublicBetaSubscriptionStrategy
-from common.insight_log import ChatOpsEvent, ChatOpsType, write_chatops_insight_log
+from common.insight_log import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log
 from common.oncall_gateway import create_oncall_connector, delete_oncall_connector, delete_slack_connector
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
@@ -302,7 +302,7 @@ class Organization(MaintainableObject):
             write_chatops_insight_log(
                 author=user,
                 event_name=ChatOpsEvent.DEFAULT_CHANNEL_CHANGED,
-                chatops_type=ChatOpsType.SLACK,
+                chatops_type=ChatOpsTypePlug.SLACK.value,
                 prev_channel=old_channel_name,
                 new_channel=channel_name,
             )

--- a/engine/common/insight_log/__init__.py
+++ b/engine/common/insight_log/__init__.py
@@ -1,3 +1,3 @@
-from .chatops_insight_logs import ChatOpsEvent, ChatOpsType, write_chatops_insight_log  # noqa
+from .chatops_insight_logs import ChatOpsEvent, ChatOpsTypePlug, write_chatops_insight_log  # noqa
 from .maintenance_insight_log import MaintenanceEvent, write_maintenance_insight_log  # noqa
 from .resource_insight_logs import EntityEvent, write_resource_insight_log  # noqa

--- a/engine/common/insight_log/chatops_insight_logs.py
+++ b/engine/common/insight_log/chatops_insight_logs.py
@@ -18,17 +18,13 @@ class ChatOpsEvent(enum.Enum):
     DEFAULT_CHANNEL_CHANGED = "default_channel_changed"
 
 
-class ChatOpsType(enum.Enum):
-    # Keep in sync with messaging backends' id.
-    # In perfect world backend_ids should be used intead of this enums
-    # It can be achieved when we move refactor slack and telegram to use the messaging_backend system.
-    SLACK = "SLACK"
-    MSTEAMS = "MSTEAMS"
-    TELEGRAM = "TELEGRAM"
-    MOBILE_APP = "MOBILE_APP"
+class ChatOpsTypePlug(enum.Enum):
+    # ChatOpsTypePlug provides backend_id string for chatops integration not supporting messaging_backends.
+    SLACK = "slack"
+    TELEGRAM = "telegram"
 
 
-def write_chatops_insight_log(author, event_name: ChatOpsEvent, chatops_type: ChatOpsType, **kwargs):
+def write_chatops_insight_log(author, event_name: ChatOpsEvent, chatops_type: str, **kwargs):
     try:
         organization = author.organization
 
@@ -37,7 +33,7 @@ def write_chatops_insight_log(author, event_name: ChatOpsEvent, chatops_type: Ch
             user_id = author.public_primary_key
             username = json.dumps(author.username)
 
-            log_line = f"tenant_id={tenant_id} author_id={user_id} author={username} action_type=chat_ops action_name={event_name.value} chat_ops_type={chatops_type.value}"  # noqa
+            log_line = f"tenant_id={tenant_id} author_id={user_id} author={username} action_type=chat_ops action_name={event_name.value} chat_ops_type={chatops_type.lower()}"  # noqa
             for k, v in kwargs.items():
                 log_line += f" {k}={json.dumps(v)}"
 


### PR DESCRIPTION
Most of the PR is just renaming ChatOpsType to ChatOpsPlug, core changes are linked below: 

- Fix insight_logs error writing unlink_backend error https://github.com/grafana/oncall/pull/1757/files#diff-7ae187be84e55ebac962bad0984f7569186cdc83c896132b2ebcbcbb31bbf5dd
- Fix insight_logs error writing updated schedule with installed slack integration (https://github.com/grafana/oncall/pull/1757/files#diff-4037b7bbef9fc16d9b541beb3ed46f760916d7cd720847c3123adf7afb5ab4b4L690)