### PR TITLE
Fix helm hook for migration job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Helm chart: Fix helm hook for db migration job
+
 ## v1.2.13 (2023-04-18)
 
 ### Changed

--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- if .Values.migrate.useHook }}
   name: {{ printf "%s-migrate" (include "oncall.engine.fullname" .) }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
   {{- else }}
   name: {{ printf "%s-migrate-%s" (include "oncall.engine.fullname" .) (now | date "2006-01-02-15-04-05") }}
   {{- end }}


### PR DESCRIPTION
# What this PR does
This PR fixes the migration job when using helm hooks.
## Which issue(s) this PR fixes
Currently when enabling the useHooks option in the helm chart there is a deadlock as the hook is defined as "post-upgrade, post-install". In this case the database migration will only be executed when all other pods are ready. This will not happen as the pods are waiting for the database migration. So we need to use "pre-install, preupgrade" instead of "post-install,post-upgrade"

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
