### PR TITLE
Use existing caching mechanism for cache invalidation

### DIFF
--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -36,16 +36,24 @@ class AlertGroupFieldsCacheSerializerMixin(AlertsFieldCacheBusterMixin):
         cached_field = cache.get(CACHE_KEY, None)
 
         web_templates_modified_at = obj.channel.web_templates_modified_at
+        alert_receive_channel_restricted_at = obj.channel.resricted_at
         last_alert_created_at = last_alert.created_at
 
-        # use cache only if cache exists
-        # and cache was created after the last alert created
-        # and either web templates never modified
-        # or cache was created after templates were modified
+        # use cache
+        # (only if cache exists)
+        # and (cache was created after the last alert created)
+        # and (either web templates never modified
+        # or cache was created after templates were modified)
+        # and (alert receive channel is not restricted
+        # or cache was created after restriction applied)
         if (
             cached_field is not None
             and cached_field.get("cache_created_at") > last_alert_created_at
             and (web_templates_modified_at is None or cached_field.get("cache_created_at") > web_templates_modified_at)
+            and (
+                alert_receive_channel_restricted_at is None
+                or cached_field.get("cache_created_at") > alert_receive_channel_restricted_at
+            )
         ):
             field = cached_field.get(field_name)
         else:

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -36,7 +36,7 @@ class AlertGroupFieldsCacheSerializerMixin(AlertsFieldCacheBusterMixin):
         cached_field = cache.get(CACHE_KEY, None)
 
         web_templates_modified_at = obj.channel.web_templates_modified_at
-        alert_receive_channel_restricted_at = obj.channel.resricted_at
+        alert_receive_channel_restricted_at = obj.channel.restricted_at
         last_alert_created_at = last_alert.created_at
 
         # use cache


### PR DESCRIPTION
# What this PR does
This PR reuse existing caching invalidation mechanism for irm sku. 
TODO: @joeyorlando irm sku caching

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
