### PR TITLE
Remove absolute aliases as it can cause unexpected redirects in future versions

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/
 canonical: https://grafana.com/docs/oncall/latest/
 keywords:
   - Grafana Cloud

--- a/docs/sources/alert-behavior/_index.md
+++ b/docs/sources/alert-behavior/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/alert-behavior/
 canonical: https://grafana.com/docs/oncall/latest/alert-behavior/
 title: Configure alert behavior for Grafana OnCall
 weight: 900

--- a/docs/sources/alert-behavior/alert-templates/index.md
+++ b/docs/sources/alert-behavior/alert-templates/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../integrations/create-custom-templates/
-  - /docs/oncall/latest/alert-behavior/alert-templates/
 canonical: https://grafana.com/docs/oncall/latest/alert-behavior/alert-templates/
 keywords:
   - Grafana Cloud

--- a/docs/sources/alert-behavior/outgoing-webhooks/index.md
+++ b/docs/sources/alert-behavior/outgoing-webhooks/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../integrations/configure-outgoing-webhooks/
-  - /docs/oncall/latest/alert-behavior/outgoing-webhooks/
 canonical: https://grafana.com/docs/oncall/latest/alert-behavior/outgoing-webhooks/
 keywords:
   - Grafana Cloud

--- a/docs/sources/calendar-schedules/_index.md
+++ b/docs/sources/calendar-schedules/_index.md
@@ -1,14 +1,12 @@
 ---
-title: On-call schedules
-aliases:
-  - /docs/oncall/latest/calendar-schedules/
 canonical: https://grafana.com/docs/oncall/latest/calendar-schedules/
-description: "Learn more about on-call schedules"
+description: Learn more about on-call schedules
 keywords:
   - Grafana
   - oncall
   - schedule
   - calendar
+title: On-call schedules
 weight: 1100
 ---
 

--- a/docs/sources/calendar-schedules/ical-schedules/index.md
+++ b/docs/sources/calendar-schedules/ical-schedules/index.md
@@ -1,14 +1,12 @@
 ---
-title: Import on-call schedules
-aliases:
-  - /docs/oncall/latest/calendar-schedules/ical-schedules/
 canonical: https://grafana.com/docs/oncall/latest/calendar-schedules/ical-schedules/
-description: "Learn how to manage on-call schedules with iCal import"
+description: Learn how to manage on-call schedules with iCal import
 keywords:
   - Grafana
   - oncall
   - on-call
-  - calendar 
+  - calendar
+title: Import on-call schedules
 weight: 300
 ---
 

--- a/docs/sources/calendar-schedules/web-schedule/_index.md
+++ b/docs/sources/calendar-schedules/web-schedule/_index.md
@@ -1,14 +1,12 @@
 ---
-title: Web-based schedules
-aliases:
-  - /docs/oncall/latest/calendar-schedules/web-schedule/
 canonical: https://grafana.com/docs/oncall/latest/calendar-schedules/web-schedule/
-description: "Learn more about Grafana OnCalls built in schedule tool"
+description: Learn more about Grafana OnCalls built in schedule tool
 keywords:
   - Grafana
   - oncall
   - schedule
   - calendar
+title: Web-based schedules
 weight: 100
 ---
 

--- a/docs/sources/calendar-schedules/web-schedule/calendar-export/index.md
+++ b/docs/sources/calendar-schedules/web-schedule/calendar-export/index.md
@@ -1,16 +1,14 @@
 ---
-title: Export on-call schedules
-aliases:
-  - /docs/oncall/latest/calendar-schedules/web-schedule/calendar-export/
 canonical: https://grafana.com/docs/oncall/latest/calendar-schedules/web-schedule/calendar-export/
-description: "Learn how to export an on-call schedule from Grafana OnCall"
+description: Learn how to export an on-call schedule from Grafana OnCall
 keywords:
   - Grafana
   - oncall
   - on-call
   - calendar
-  - iCal export 
-weight: 500 
+  - iCal export
+title: Export on-call schedules
+weight: 500
 ---
 
 # Export on-call schedules

--- a/docs/sources/calendar-schedules/web-schedule/create-schedule/index.md
+++ b/docs/sources/calendar-schedules/web-schedule/create-schedule/index.md
@@ -1,15 +1,13 @@
 ---
-title: Create on-call schedules
-aliases:
-  - /docs/oncall/latest/calendar-schedules/web-schedule/create-schedule/
 canonical: https://grafana.com/docs/oncall/latest/calendar-schedules/web-schedule/create-schedule/
-description: "Create on-call schedules with Grafana OnCall"
+description: Create on-call schedules with Grafana OnCall
 keywords:
   - Grafana
   - oncall
   - on-call
   - schedule
   - calendar
+title: Create on-call schedules
 weight: 300
 ---
 

--- a/docs/sources/configure-user-settings/_index.md
+++ b/docs/sources/configure-user-settings/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/configure-user-settings/
 canonical: https://grafana.com/docs/oncall/latest/configure-user-setting/
 keywords:
   - Grafana Cloud

--- a/docs/sources/escalation-policies/_index.md
+++ b/docs/sources/escalation-policies/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/escalation-policies/
 canonical: https://grafana.com/docs/oncall/latest/escalation-policies/
 title: Escalation Chains and Routes
 weight: 700

--- a/docs/sources/escalation-policies/configure-escalation-chains/index.md
+++ b/docs/sources/escalation-policies/configure-escalation-chains/index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/escalation-policies/configure-escalation-chains/
 canonical: https://grafana.com/docs/oncall/latest/escalation-policies/configure-escalation-chains/
 keywords:
   - Grafana Cloud

--- a/docs/sources/escalation-policies/configure-routes/index.md
+++ b/docs/sources/escalation-policies/configure-routes/index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/escalation-policies/configure-routes/
 canonical: https://grafana.com/docs/oncall/latest/escalation-policies/configure-routes/
 keywords:
   - Grafana Cloud

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -1,6 +1,5 @@
 ---
 aliases:
-  - /docs/oncall/latest/get-started/
   - /getting-started/
 canonical: https://grafana.com/docs/oncall/latest/get-started/
 keywords:

--- a/docs/sources/integrations/_index.md
+++ b/docs/sources/integrations/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/integrations/
 canonical: https://grafana.com/docs/oncall/latest/integrations/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/available-integrations/_index.md
+++ b/docs/sources/integrations/available-integrations/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/integrations/available-integrations/
 canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/available-integrations/configure-alertmanager/index.md
+++ b/docs/sources/integrations/available-integrations/configure-alertmanager/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - add-alertmanager/
-  - /docs/oncall/latest/integrations/available-integrations/configure-alertmanager/
 canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/configure-alertmanager/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/available-integrations/configure-grafana-alerting/index.md
+++ b/docs/sources/integrations/available-integrations/configure-grafana-alerting/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - add-grafana-alerting/
-  - /docs/oncall/latest/integrations/available-integrations/configure-grafana-alerting/
 canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/configure-grafana-alerting/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/available-integrations/configure-inbound-email/index.md
+++ b/docs/sources/integrations/available-integrations/configure-inbound-email/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - add-inbound-email/
-  - /docs/oncall/latest/integrations/available-integrations/configure-inbound-email/
 canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/configure-inbound-email/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/available-integrations/configure-webhook/index.md
+++ b/docs/sources/integrations/available-integrations/configure-webhook/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../add-webhook-integration/
-  - /docs/oncall/latest/integrations/available-integrations/configure-webhook/
 canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/configure-webhook/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/available-integrations/configure-zabbix/index.md
+++ b/docs/sources/integrations/available-integrations/configure-zabbix/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - add-zabbix/
-  - /docs/oncall/latest/integrations/available-integrations/configure-zabbix/
 canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/configure-zabbix/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/chatops-integrations/_index.md
+++ b/docs/sources/integrations/chatops-integrations/_index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../chat-options/
-  - /docs/oncall/latest/integrations/chatops-integrations/
 canonical: https://grafana.com/docs/oncall/latest/integrations/chatops-integrations/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/chatops-integrations/configure-slack/index.md
+++ b/docs/sources/integrations/chatops-integrations/configure-slack/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../../chat-options/configure-slack/
-  - /docs/oncall/latest/integrations/chatops-integrations/configure-slack/
 canonical: https://grafana.com/docs/oncall/latest/integrations/chatops-integrations/configure-slack/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/chatops-integrations/configure-teams/index.md
+++ b/docs/sources/integrations/chatops-integrations/configure-teams/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../../chat-options/configure-teams/
-  - /docs/oncall/latest/integrations/chatops-integrations/configure-teams/
 canonical: https://grafana.com/docs/oncall/latest/integrations/chatops-integrations/configure-teams/
 keywords:
   - Grafana Cloud

--- a/docs/sources/integrations/chatops-integrations/configure-telegram/index.md
+++ b/docs/sources/integrations/chatops-integrations/configure-telegram/index.md
@@ -1,7 +1,6 @@
 ---
 aliases:
   - ../../chat-options/configure-telegram/
-  - /docs/oncall/latest/integrations/chatops-integrations/configure-telegram/
 canonical: https://grafana.com/docs/oncall/latest/integrations/chatops-integrations/configure-telegram/
 keywords:
   - Grafana Cloud

--- a/docs/sources/mobile-app/_index.md
+++ b/docs/sources/mobile-app/_index.md
@@ -1,12 +1,10 @@
 ---
-title: Grafana OnCall mobile app
-aliases:
-  - /docs/oncall/latest/mobile-app/
 keywords:
   - Mobile App
   - oncall
   - notification
   - push notification
+title: Grafana OnCall mobile app
 weight: 1200
 ---
 

--- a/docs/sources/oncall-api-reference/_index.md
+++ b/docs/sources/oncall-api-reference/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/
 title: Grafana OnCall HTTP API reference
 weight: 1500

--- a/docs/sources/oncall-api-reference/alertgroups.md
+++ b/docs/sources/oncall-api-reference/alertgroups.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/alertgroups/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/alertgroups/
 title: Alert groups HTTP API
 weight: 400

--- a/docs/sources/oncall-api-reference/alerts.md
+++ b/docs/sources/oncall-api-reference/alerts.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/alerts/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/alerts/
 title: Alerts HTTP API
 weight: 100

--- a/docs/sources/oncall-api-reference/escalation_chains.md
+++ b/docs/sources/oncall-api-reference/escalation_chains.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/escalation_chains/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_chains/
 title: Escalation Chains HTTP API
 weight: 200

--- a/docs/sources/oncall-api-reference/escalation_policies.md
+++ b/docs/sources/oncall-api-reference/escalation_policies.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/escalation_policies/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/escalation_policies/
 title: Escalation Policies HTTP API
 weight: 300

--- a/docs/sources/oncall-api-reference/integrations.md
+++ b/docs/sources/oncall-api-reference/integrations.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/integrations/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/integrations/
 title: Integrations HTTP API
 weight: 500

--- a/docs/sources/oncall-api-reference/on_call_shifts.md
+++ b/docs/sources/oncall-api-reference/on_call_shifts.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/on_call_shifts/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/on_call_shifts/
 title: OnCall shifts HTTP API
 weight: 600

--- a/docs/sources/oncall-api-reference/outgoing_webhooks.md
+++ b/docs/sources/oncall-api-reference/outgoing_webhooks.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/outgoing_webhooks/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/outgoing_webhooks/
 title: Outgoing webhooks HTTP API
 weight: 700

--- a/docs/sources/oncall-api-reference/personal_notification_rules.md
+++ b/docs/sources/oncall-api-reference/personal_notification_rules.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/personal_notification_rules/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/personal_notification_rules/
 title: Personal Notification Rules HTTP API
 weight: 800

--- a/docs/sources/oncall-api-reference/postmortem_messages.md
+++ b/docs/sources/oncall-api-reference/postmortem_messages.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/postmortem_messages/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/postmortem_messages/
 draft: true
 title: Postmortem Messages HTTP API

--- a/docs/sources/oncall-api-reference/postmortems.md
+++ b/docs/sources/oncall-api-reference/postmortems.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/postmortems/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/postmortems/
 draft: true
 title: Postmortem HTTP API

--- a/docs/sources/oncall-api-reference/routes.md
+++ b/docs/sources/oncall-api-reference/routes.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/routes/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/routes/
 title: Routes HTTP API
 weight: 1100

--- a/docs/sources/oncall-api-reference/schedules.md
+++ b/docs/sources/oncall-api-reference/schedules.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/schedules/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/schedules/
 title: Schedule HTTP API
 weight: 1200

--- a/docs/sources/oncall-api-reference/slack_channels.md
+++ b/docs/sources/oncall-api-reference/slack_channels.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/slack_channels/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/slack_channels/
 title: Slack Channels HTTP API
 weight: 1300

--- a/docs/sources/oncall-api-reference/user_groups.md
+++ b/docs/sources/oncall-api-reference/user_groups.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/user_groups/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/user_groups/
 title: OnCall User Groups HTTP API
 weight: 1400

--- a/docs/sources/oncall-api-reference/users.md
+++ b/docs/sources/oncall-api-reference/users.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/oncall-api-reference/users/
 canonical: https://grafana.com/docs/oncall/latest/oncall-api-reference/users/
 title: Grafana OnCall Users HTTP API
 weight: 1500

--- a/docs/sources/open-source/_index.md
+++ b/docs/sources/open-source/_index.md
@@ -1,6 +1,4 @@
 ---
-aliases:
-  - /docs/oncall/latest/open-source/
 keywords:
   - Open Source
 title: Open Source


### PR DESCRIPTION

If a page is removed in a future version, the presence of a "latest" absolute alias in a previous version can redirect that removed page.
