### PR TITLE
Fix team update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix bug when updating team access settings by @vadimkerr ([#1794](https://github.com/grafana/oncall/pull/1794))
+
 ## v1.2.13 (2023-04-18)
 
 ### Changed

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -151,11 +151,12 @@ def test_update_team(
     client = APIClient()
     url = reverse("api-internal:team-detail", kwargs={"pk": team.public_primary_key})
 
-    data = {"is_sharing_resources_to_all": True}
-    response = client.put(url, data=data, format="json", **make_user_auth_headers(user, token))
+    response = client.put(
+        url, data={"is_sharing_resources_to_all": True}, format="json", **make_user_auth_headers(user, token)
+    )
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == data
+    assert response.json()["is_sharing_resources_to_all"] is True
 
 
 @pytest.mark.django_db

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -134,6 +134,31 @@ def test_list_teams_permissions(
 
 
 @pytest.mark.django_db
+def test_update_team(
+    make_organization,
+    make_team,
+    make_user_for_organization,
+    make_token_for_organization,
+    make_user_auth_headers,
+):
+    organization = make_organization()
+    user = make_user_for_organization(organization)
+    _, token = make_token_for_organization(organization)
+
+    team = make_team(organization)
+    team.users.add(user)
+
+    client = APIClient()
+    url = reverse("api-internal:team-detail", kwargs={"pk": team.public_primary_key})
+
+    data = {"is_sharing_resources_to_all": True}
+    response = client.put(url, data=data, format="json", **make_user_auth_headers(user, token))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == data
+
+
+@pytest.mark.django_db
 def test_team_permissions_wrong_team(
     make_organization,
     make_team,

--- a/engine/apps/api/views/team.py
+++ b/engine/apps/api/views/team.py
@@ -1,6 +1,7 @@
 from rest_framework import mixins, viewsets
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from apps.api.permissions import RBACPermission
 from apps.api.serializers.team import TeamSerializer
@@ -29,9 +30,12 @@ class TeamViewSet(PublicPrimaryKeyMixin, mixins.ListModelMixin, mixins.UpdateMod
     def get_queryset(self):
         return self.request.user.available_teams
 
-    def filter_queryset(self, queryset):
+    def list(self, request, *args, **kwargs):
         """
         Adds general team to the queryset in a way that it always shows up first (even when not searched for).
         """
         general_team = Team(public_primary_key="null", name="No team", email=None, avatar_url=None)
-        return [general_team] + list(super().filter_queryset(queryset))
+        queryset = [general_team] + list(self.filter_queryset(self.get_queryset()))
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
# What this PR does
Fixes team update endpoint for internal API + adds a unit test for this scenario.

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/1774

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
