### PR TITLE
fix for topnav changes with old version of grafana

### DIFF
--- a/grafana-plugin/src/plugin/GrafanaPluginRootPage.helpers.tsx
+++ b/grafana-plugin/src/plugin/GrafanaPluginRootPage.helpers.tsx
@@ -1,7 +1,7 @@
 import { config } from '@grafana/runtime';
 
 export function isTopNavbar(): boolean {
-  return !!config.featureToggles.topnav;
+  return Number(config.buildInfo.version.charAt(0)) >= 9 && !!config.featureToggles.topnav;
 }
 
 export function getQueryParams(): any {


### PR DESCRIPTION
# What this PR does
Fix frontend while using topnav flag with older version of grafana
https://raintank-corp.slack.com/archives/C04JCU51NF8/p1681273331570749