### PR TITLE
add channel__team to internal api serializer select_related

### DIFF
--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -99,6 +99,7 @@ class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerialize
 
     SELECT_RELATED = [
         "channel__organization",
+        "channel__team",
         "root_alert_group",
         "resolved_by_user",
         "acknowledged_by_user",


### PR DESCRIPTION
Locally I reproduced a slow `GET /api/internal/v1/alertgroups` query (took 9s - 10s). After adding this line to the alert group serializer for the internal api it:
- cut the response time in half
- cut the number of executed SQL queries from 52 to 30