### PR TITLE
Add final schedule export refresh note

### DIFF
--- a/engine/apps/schedules/ical_utils.py
+++ b/engine/apps/schedules/ical_utils.py
@@ -603,6 +603,8 @@ def create_base_icalendar(name: str) -> Calendar:
     cal.add("x-wr-timezone", "UTC")
     cal.add("version", "2.0")
     cal.add("prodid", "//Grafana Labs//Grafana On-Call//")
+    # suggested minimum interval for polling for changes
+    cal.add("REFRESH-INTERVAL;VALUE=DURATION", "P1H")
 
     return cal
 

--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -312,7 +312,6 @@ class OnCallSchedule(PolymorphicModel):
         return events
 
     def refresh_ical_final_schedule(self):
-        # TODO: check flag?
         tz = "UTC"
         now = timezone.now()
         # window to consider: from now, -15 days + 6 months

--- a/grafana-plugin/src/containers/ScheduleIcalLink/ScheduleIcalLink.tsx
+++ b/grafana-plugin/src/containers/ScheduleIcalLink/ScheduleIcalLink.tsx
@@ -57,7 +57,10 @@ const ScheduleICalSettings: FC<ScheduleICalSettingsProps> = observer((props) => 
       <Label>iCal link:</Label>
       <Text type="secondary">
         Secret iCal export link to export schedule's on call shifts to Google Calendar, iCal, etc. If you forget it,
-        you'll need to revoke this link and create another one
+        you'll need to revoke this link and create another one.
+        <br />
+        NOTE: We do not have control over when a client refreshes an imported calendar (e.g. Google Calendar can take up
+        to 24hs to reflect schedule changes)
       </Text>
       {isICalLinkLoading ? (
         <LoadingPlaceholder text="Loading..." />

--- a/grafana-plugin/src/containers/UserSettings/parts/connectors/ICalConnector.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/connectors/ICalConnector.tsx
@@ -57,7 +57,11 @@ const ICalConnector = (props: ICalConnectorProps) => {
   return (
     <div className={cx('user-item')}>
       <Label>iCal link:</Label>
-      <Text type="secondary">Secret iCal export link to add your assigned on call shifts to your calendar.</Text>
+      <Text type="secondary">
+        Secret iCal export link to add your assigned on call shifts to your calendar.
+        <br />
+        NOTE: We do not have control over when a client refreshes an imported calendar.
+      </Text>
       <div className={cx('iCal-settings')}>
         {iCalLoading ? (
           <LoadingPlaceholder text="Loading..." />


### PR DESCRIPTION
Also include a suggested refresh interval in the generated ical
(Google Calendar will still ignore it, but may be useful for some other clients).