### PR TITLE
Fix a regression bug when alertgroup filters cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add 2, 3 and 6 hours silence options
 
+### Fixed
+
+- Fix a regression bug where alertgroup filters cleared when going off the page 
+
 ## v1.2.15 (2023-04-24)
 
 ### Fixed

--- a/grafana-plugin/src/containers/IncidentsFilters/IncidentsFilters.tsx
+++ b/grafana-plugin/src/containers/IncidentsFilters/IncidentsFilters.tsx
@@ -60,15 +60,21 @@ class IncidentsFilters extends Component<IncidentsFiltersProps, IncidentsFilters
   async componentDidMount() {
     const { query, objectStore } = this.props;
 
-    const filterOptions = await makeRequest(objectStore.path + 'filters/', {});
+
+    console.log("objectStore")
+    console.log(objectStore.alertGroupStore.path)
+    const filterOptions = await makeRequest(objectStore.alertGroupStore.path + 'filters/', {});
 
     let { filters, values } = parseFilters(query, filterOptions);
+
+    console.log("VALUES")
+    console.log(values)
 
     if (isEmpty(values)) {
       // TODO fill filters if no filters in query
       let newQuery;
-      if (objectStore.incidentFilters) {
-        newQuery = { ...objectStore.incidentFilters };
+      if (objectStore.alertGroupStore.incidentFilters) {
+        newQuery = { ...objectStore.alertGroupStore.incidentFilters };
       } else {
         newQuery = {
           team: [],
@@ -84,7 +90,10 @@ class IncidentsFilters extends Component<IncidentsFiltersProps, IncidentsFilters
   }
 
   render() {
-    return <div className={cx('root')}>{this.renderFilters()}</div>;
+    return <div className={cx('root')}>
+      {this.renderFilters()}
+      {this.renderCards()}
+    </div>;
   }
 
   renderFilters = () => {


### PR DESCRIPTION
# What this PR does
Fix this bug https://github.com/grafana/oncall/issues/482 that was fixed in https://github.com/grafana/oncall/pull/1311. Looks like a regression. 

I have not tested the UI for this. Just pull what was in https://github.com/grafana/oncall/pull/1311 into the current dev branch

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/482

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
