### PR TITLE
show silence button on alert group page even if alert group is acknowledged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add 2, 3 and 6 hours silence options
 
-## Fixed
+### Changed
+
+- On the individual alert group page, show the "Silence" button if the alert group is firing or acknowledged.
+  Previously the button would only show if the alert group was firing. By @joeyorlando ([#AAAA](https://github.com/grafana/oncall/pull/AAAA))
+
+### Fixed
 
 - Optimize duplicate queries occurring in AlertGroupFilter by @joeyorlando ([1809](https://github.com/grafana/oncall/pull/1809))
 

--- a/grafana-plugin/src/pages/incident/Incident.helpers.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.helpers.tsx
@@ -189,17 +189,6 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
   const buttons = [];
 
   if (incident.alert_receive_channel.integration !== MaintenanceIntegration) {
-    if (incident.status === IncidentStatus.Firing) {
-      buttons.push(
-        <SilenceButtonCascader
-          className={cx('silence-button-inline')}
-          key="silence"
-          disabled={incident.loading || incident.is_restricted}
-          onSelect={onSilence}
-        />
-      );
-    }
-
     if (incident.status === IncidentStatus.Silenced) {
       buttons.push(
         <WithPermissionControlTooltip key="silence" userAction={UserActions.AlertGroupsWrite}>
@@ -207,6 +196,15 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
             Unsilence
           </Button>
         </WithPermissionControlTooltip>
+      );
+    } else if (incident.status !== IncidentStatus.Resolved) {
+      buttons.push(
+        <SilenceButtonCascader
+          className={cx('silence-button-inline')}
+          key="silence"
+          disabled={incident.loading || incident.is_restricted}
+          onSelect={onSilence}
+        />
       );
     }
 


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required) (N/A)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
