### PR TITLE
Fix flaky Slack test

### DIFF
--- a/engine/apps/slack/tests/factories.py
+++ b/engine/apps/slack/tests/factories.py
@@ -32,7 +32,7 @@ class SlackUserIdentityFactory(factory.DjangoModelFactory):
 class SlackUserGroupFactory(factory.DjangoModelFactory):
     slack_id = UniqueFaker("word")
     name = factory.Faker("word")
-    handle = factory.Faker("word")
+    handle = UniqueFaker("word")
 
     class Meta:
         model = SlackUserGroup


### PR DESCRIPTION
# What this PR does
Fix [flaky test](https://github.com/grafana/oncall/actions/runs/4821277510/jobs/8586941639#step:5:706) `test_get_user_groups_filter_by_handle` using `UniqueFaker` on `SlackUserGroupFactory.handle` to make handles always unique.

Before:

```shell
>>> len(set([SlackUserGroupFactory().handle for _ in range(100)]))
93
```

After:

```shell
>>> len(set([SlackUserGroupFactory().handle for _ in range(100)]))
100
```


## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
