### PR TITLE
Jira inbound integration docs

### DIFF
--- a/docs/sources/integrations/available-integrations/configure-jira/index.md
+++ b/docs/sources/integrations/available-integrations/configure-jira/index.md
@@ -1,0 +1,37 @@
+---
+aliases:
+  - add-jira/
+  - /docs/oncall/latest/integrations/available-integrations/configure-jira/
+canonical: https://grafana.com/docs/oncall/latest/integrations/available-integrations/configure-jira/
+keywords:
+  - Grafana Cloud
+  - Alerts
+  - Notifications
+  - on-call
+  - Jira
+title: Jira integration for Grafana OnCall
+weight: 500
+---
+
+# Jira integration for Grafana OnCall
+
+The Jira integration for Grafana OnCall handles issue events sent from Jira webhooks.
+The integration provides grouping, auto-acknowledge and auto-resolve logic via customizable alert templates.
+
+## Configure Jira integration for Grafana OnCall
+
+You must have an Admin role to create integrations in Grafana OnCall.
+
+1. In the **Integrations** tab, click **+ New integration to receive alerts**.
+2. Select **Jira** from the list of available integrations.
+3. Follow the instructions in the **How to connect** window to get your unique integration URL and review next steps.
+
+## Grouping, auto-acknowledge and auto-resolve
+
+Grafana OnCall provides grouping, auto-acknowledge and auto-resolve logic for the Jira integration:
+
+- Alerts created from issue events are grouped by issue key
+- Alert groups are auto-acknowledged when the issue status is set to "work in progress"
+- Alerts are auto-resolved when the issue is closed or deleted
+
+To customize this behaviour, consider modifying alert templates in integration settings.

--- a/engine/apps/integrations/templates/html/integration_jira.html
+++ b/engine/apps/integrations/templates/html/integration_jira.html
@@ -1,0 +1,17 @@
+<h4>How to start sending alerts to Grafana OnCall from Jira</h4>
+
+<p>Create a new webhook connection in Jira to send events to Grafana OnCall using the integration URL above.</p>
+<p>Refer to Jira documentation for more information on how to create and manage webhooks:
+    <a href="https://developer.atlassian.com/server/jira/platform/webhooks/" target="_blank">
+        https://developer.atlassian.com/server/jira/platform/webhooks/
+    </a>
+</p>
+
+<p>When creating a webhook in Jira, select the following events to be sent to Grafana OnCall:</p>
+<p>
+    <ol>
+        <li>1. Issue - created</li>
+        <li>2. Issue - updated</li>
+        <li>3. Issue - deleted</li>
+    </ol>
+</p>

--- a/grafana-plugin/src/components/IntegrationLogo/IntegrationLogo.config.ts
+++ b/grafana-plugin/src/components/IntegrationLogo/IntegrationLogo.config.ts
@@ -19,4 +19,5 @@ export const logoCoors: { [key: string]: { x: number; y: number } } = {
   uptimerobot: { x: 14, y: 8 },
   zabbix: { x: 7, y: 14 },
   prtg: { x: 12, y: 5 },
+  jira: { x: 8, y: 9 },
 };


### PR DESCRIPTION
# What this PR does
Add docs & logo for Jira integration. Main PR in private repo: https://github.com/grafana/oncall-private/pull/1769

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/1620

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] No changelog (Jira integration will be only available in cloud)
