### PR TITLE
Do not retry start_sync_organization

### DIFF
--- a/engine/apps/grafana_plugin/tasks/sync.py
+++ b/engine/apps/grafana_plugin/tasks/sync.py
@@ -21,7 +21,7 @@ SYNC_PERIOD = timezone.timedelta(minutes=25)
 INACTIVE_PERIOD = timezone.timedelta(minutes=55)
 
 
-@shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True, max_retries=5)
+@shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True, max_retries=0)
 def start_sync_organizations():
     sync_threshold = timezone.now() - SYNC_PERIOD
 


### PR DESCRIPTION
start_sync_organization is scheduled to run every 30 mins.  Countdown is not specified so the default countdown with exponential backoff will result in retries happening after the next 30 min trigger.  If it is in a state where it is retrying for a long period of time (>30 mins) it will stack up too many redundant sync_organization_async tasks when it finally does succeed.