### PR TITLE
Fix and tidy alertmanager heartbeat template

### DIFF
--- a/engine/apps/integrations/templates/heartbeat_instructions/alertmanager.html
+++ b/engine/apps/integrations/templates/heartbeat_instructions/alertmanager.html
@@ -1,25 +1,25 @@
-<p>This configuration will send an alert once in a minute and if alertmanager stops working amixr will detect that it
-    doesn't work and notify you about that.</p>
+<p>This configuration will send an alert once in a minute and if alertmanager stops working OnCall will detect
+    it and notify you about that.</p>
 <ol>
-    <li>Add the alert generating script to prometheus.yaml file
-        Within prometheus it is trivial to create an expression that we can build a heartbeat with Amixr
-        expr: vector(1)
-        <p>That expression will always return true. Here is an alert that leverages the previous expression to create a
-            heartbeat alert</p>
+    <li>
+        <p>Add the alert generating script to <code>prometheus.yaml</code> file.
+        Within Prometheus it is trivial to create an expression that we can use as a heartbeat for OnCall,
+        like <code>vector(1)</code>. That expression will always return true.</p>
+        <p>Here is an alert that leverages the previous expression to create a heartbeat alert:</p>
         <pre><code>
             groups:
             - name: meta
-                rules:
-                - alert: heartbeat
-                  expr: vector(1)
-                  labels:
-                    severity: none
-                  annotations:
-                    description: This is heartbeat alert
-                    summary: Alerting Amixr
+              rules:
+              - alert: heartbeat
+                expr: vector(1)
+                labels:
+                  severity: none
+                annotations:
+                  description: This is a heartbeat alert for Grafana OnCall
+                  summary: Heartbeat for Grafana OnCall
         </code></pre>
     </li>
-    <li>Add receiver configuration to prometheus.yaml with the unique url from Amixr global
+    <li><p>Add receiver configuration to <code>prometheus.yaml</code> with the unique url from OnCall global:</p>
         <pre><code>
             ...
             route:
@@ -27,12 +27,12 @@
                 routes:
                 - match:
                     alertname: heartbeat
-                  receiver: 'amixr-heartbeat'
+                  receiver: 'grafana-oncall-heartbeat'
                   group_wait: 0s
                   group_interval: 1m
                   repeat_interval: 50s
             receivers:
-            - name: 'amixr-heartbeat'
+            - name: 'grafana-oncall-heartbeat'
             webhook_configs:
             - url: {{ heartbeat_url }}
                 send_resolved: false

--- a/engine/apps/integrations/templates/heartbeat_instructions/alertmanager.html
+++ b/engine/apps/integrations/templates/heartbeat_instructions/alertmanager.html
@@ -1,4 +1,4 @@
-<p>This configuration will send an alert once in a minute and if alertmanager stops working OnCall will detect
+<p>This configuration will send an alert once a minute, and if alertmanager stops working, OnCall will detect
     it and notify you about that.</p>
 <ol>
     <li>

--- a/grafana-plugin/src/containers/HeartbeatModal/HeartbeatForm.tsx
+++ b/grafana-plugin/src/containers/HeartbeatModal/HeartbeatForm.tsx
@@ -105,9 +105,7 @@ const HeartbeatForm = observer(({ alertReceveChannelId, onUpdate }: HeartBeatMod
       </p>
       {heartbeat && (
         <p>
-          <Text>
-            Use the following unique Grafana link to send GET and POST requests:
-          </Text>
+          <Text>Use the following unique Grafana link to send GET and POST requests:</Text>
           <pre><code>{heartbeat?.link}</code></pre>
         </p>
       )}

--- a/grafana-plugin/src/containers/HeartbeatModal/HeartbeatForm.tsx
+++ b/grafana-plugin/src/containers/HeartbeatModal/HeartbeatForm.tsx
@@ -106,7 +106,9 @@ const HeartbeatForm = observer(({ alertReceveChannelId, onUpdate }: HeartBeatMod
       {heartbeat && (
         <p>
           <Text>Use the following unique Grafana link to send GET and POST requests:</Text>
-          <pre><code>{heartbeat?.link}</code></pre>
+          <pre>
+            <code>{heartbeat?.link}</code>
+          </pre>
         </p>
       )}
       {heartbeat && (

--- a/grafana-plugin/src/containers/HeartbeatModal/HeartbeatForm.tsx
+++ b/grafana-plugin/src/containers/HeartbeatModal/HeartbeatForm.tsx
@@ -106,11 +106,9 @@ const HeartbeatForm = observer(({ alertReceveChannelId, onUpdate }: HeartBeatMod
       {heartbeat && (
         <p>
           <Text>
-            Use the following unique Grafana link to send GET and POST requests:{' '}
-            <a href={heartbeat?.link} target="_blank" rel="noreferrer">
-              {heartbeat?.link}
-            </a>
+            Use the following unique Grafana link to send GET and POST requests:
           </Text>
+          <pre><code>{heartbeat?.link}</code></pre>
         </p>
       )}
       {heartbeat && (


### PR DESCRIPTION
# What this PR does


There was an unnecessary indentation in the `rules:` key which made it invalid YAML.

Also replaced the mentions to Amixr with Grafana OnCall, used some `<code>` tags and reworded some sentences.

Also removed the anchor tag from the webhook link: we don't want people to follow that in their browser, we want them to copy it

## Result screenshot

![image](https://user-images.githubusercontent.com/1511481/236173565-b5201b81-4d69-4d0b-944a-a2106f8fbab3.png)

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
