### PR TITLE
Rewrite texts for ~Connectivity~ Notification Warning

### DIFF
--- a/grafana-plugin/src/containers/Alerts/Alerts.tsx
+++ b/grafana-plugin/src/containers/Alerts/Alerts.tsx
@@ -125,17 +125,21 @@ export default function Alerts() {
           onRemove={getRemoveAlertHandler(AlertID.CONNECTIVITY_WARNING)}
           className={cx('alert')}
           severity="warning"
-          title="Connectivity Warning"
+          title="Notification Warning"
         >
           {
             <>
               {!isChatOpsConnected && (
-                <>Communication channels are not connected. Configure at least one channel to receive notifications.</>
+                <>
+                  No messenger connected. Possible notification miss. Connect messenger(s) in{' '}
+                  <PluginLink query={{ page: 'users', id: 'me' }}>User profile settings</PluginLink> to receive all
+                  notifications.
+                </>
               )}
               {!isPhoneVerified && (
                 <>
                   Your phone number is not verified. You can change your configuration in{' '}
-                  <PluginLink query={{ page: 'users', id: 'me' }}>User settings</PluginLink>
+                  <PluginLink query={{ page: 'users', id: 'me' }}>User profile settings</PluginLink>
                 </>
               )}
             </>


### PR DESCRIPTION
# What this PR does

This PR rewrites the misleading warning:
<img width="979" alt="Screenshot 2023-05-04 at 9 50 45 AM" src="https://user-images.githubusercontent.com/2262529/236093917-10f20e6e-f24c-43b6-ab62-44aa3fdd1b86.png">



## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
