### PR TITLE
Pin requests and urllib3

### DIFF
--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -53,3 +53,5 @@ django-ipware==4.0.2
 django-anymail==8.6
 django-deprecate-fields==0.1.1
 pymdown-extensions==9.11
+requests==2.29.0
+urllib3==1.26.15


### PR DESCRIPTION
[v1.2.18](https://github.com/grafana/oncall/releases/tag/v1.2.18) has some issues with parsing responses from Slack due to using `requests==2.30.0`, so pinning `requests` and `urllib3` to latest stable versions from [v1.2.17](https://github.com/grafana/oncall/releases/tag/v1.2.17).