### PR TITLE
Fix renamed step in drone deps

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -112,7 +112,7 @@ steps:
       config:
         from_secret: gcr_admin
     depends_on:
-      - Lint Backend
+      - Lint Everything
       - Unit Test Backend
       - Image Tag
 
@@ -132,7 +132,7 @@ steps:
       username:
         from_secret: docker_username
     depends_on:
-      - Lint Backend
+      - Lint Everything
       - Unit Test Backend
       - Image Tag
     when:
@@ -416,6 +416,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: f69f5f11a05ebf62ab021d542e2b453a2614a9326f014b3147346fe2ff0c272b
+hmac: 9eb4e539c2313ae319d12d1f5149ddf93ea017720b1690abe5e1730e2a1489f2
 
 ...


### PR DESCRIPTION
The Lint Backend step was renamed to Lint Everything [here](https://github.com/grafana/oncall/pull/1849/files#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7)