### PR TITLE
Restore original lint backend drone step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,13 +61,15 @@ steps:
       ref:
         - refs/tags/v*.*.*
 
-  - name: Lint Everything
+  - name: Lint Backend
     image: python:3.11.3
     environment:
       DJANGO_SETTINGS_MODULE: settings.ci-test
     commands:
       - pip install $(grep "pre-commit" engine/requirements.txt)
-      - pre-commit run --all-files
+      - pre-commit run isort --all-files
+      - pre-commit run black --all-files
+      - pre-commit run flake8 --all-files
 
   - name: Unit Test Backend
     image: python:3.11.3
@@ -112,7 +114,7 @@ steps:
       config:
         from_secret: gcr_admin
     depends_on:
-      - Lint Everything
+      - Lint Backend
       - Unit Test Backend
       - Image Tag
 
@@ -132,7 +134,7 @@ steps:
       username:
         from_secret: docker_username
     depends_on:
-      - Lint Everything
+      - Lint Backend
       - Unit Test Backend
       - Image Tag
     when:
@@ -416,6 +418,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 9eb4e539c2313ae319d12d1f5149ddf93ea017720b1690abe5e1730e2a1489f2
+hmac: a428b546ec4557971dfe3c7eeeac70ddf08faea7336607647ad3f146dd4cb46a
 
 ...


### PR DESCRIPTION
Drone builds are broken because the lint step was changed to run all lint tasks and the plugin is not there when running frontend lint commands. Restore the original step to unblock drone.