### PR TITLE
Slack: use `user_profile_changed` event instead of `user_change`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add a way to set a maintenance mode message and display this in the web plugin UI by @joeyorlando ([#1917](https://github.com/grafana/oncall/pull/#1917))
 
+### Changed
+
+- Use `user_profile_changed` Slack event instead of `user_change` to update Slack user profile by @vadimkerr ([#1938](https://github.com/grafana/oncall/pull/1938))
+
 ## v1.2.22 (2023-05-12)
 
 ### Added

--- a/docs/sources/open-source/_index.md
+++ b/docs/sources/open-source/_index.md
@@ -154,7 +154,7 @@ settings:
       - subteam_created
       - subteam_members_changed
       - subteam_updated
-      - user_change
+      - user_profile_changed
   interactivity:
     is_enabled: true
     request_url: <ONCALL_ENGINE_PUBLIC_URL>/slack/interactive_api_endpoint/

--- a/engine/apps/slack/scenarios/profile_update.py
+++ b/engine/apps/slack/scenarios/profile_update.py
@@ -41,9 +41,16 @@ class ProfileUpdateStep(scenario_step.ScenarioStep):
 
 
 STEPS_ROUTING = [
+    # Slack event "user_change" is deprecated in favor of "user_profile_changed".
+    # Handler for "user_change" is kept for backward compatibility.
     {
         "payload_type": scenario_step.PAYLOAD_TYPE_EVENT_CALLBACK,
         "event_type": scenario_step.EVENT_TYPE_USER_CHANGE,
+        "step": ProfileUpdateStep,
+    },
+    {
+        "payload_type": scenario_step.PAYLOAD_TYPE_EVENT_CALLBACK,
+        "event_type": scenario_step.EVENT_TYPE_USER_PROFILE_CHANGED,
         "step": ProfileUpdateStep,
     },
 ]

--- a/engine/apps/slack/scenarios/scenario_step.py
+++ b/engine/apps/slack/scenarios/scenario_step.py
@@ -17,7 +17,10 @@ PAYLOAD_TYPE_EVENT_CALLBACK = "event_callback"
 EVENT_TYPE_MESSAGE = "message"
 EVENT_TYPE_MESSAGE_CHANNEL = "channel"
 EVENT_TYPE_MESSAGE_IM = "im"
+# Slack event "user_change" is deprecated in favor of "user_profile_changed".
+# Handler for "user_change" is kept for backward compatibility.
 EVENT_TYPE_USER_CHANGE = "user_change"
+EVENT_TYPE_USER_PROFILE_CHANGED = "user_profile_changed"
 EVENT_TYPE_APP_MENTION = "app_mention"
 EVENT_TYPE_MEMBER_JOINED_CHANNEL = "member_joined_channel"
 EVENT_TYPE_IM_OPEN = "im_open"

--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -38,6 +38,7 @@ from apps.slack.scenarios.scenario_step import (
     EVENT_TYPE_SUBTEAM_MEMBERS_CHANGED,
     EVENT_TYPE_SUBTEAM_UPDATED,
     EVENT_TYPE_USER_CHANGE,
+    EVENT_TYPE_USER_PROFILE_CHANGED,
     PAYLOAD_TYPE_BLOCK_ACTIONS,
     PAYLOAD_TYPE_DIALOG_SUBMISSION,
     PAYLOAD_TYPE_EVENT_CALLBACK,
@@ -272,8 +273,12 @@ class SlackEventApiEndpointView(APIView):
                     EVENT_TYPE_SUBTEAM_MEMBERS_CHANGED,
                 ]:
                     logger.info("Slack event without user slack_id.")
-                elif payload["event"]["type"] == EVENT_TYPE_USER_CHANGE:
-                    logger.info("Event user_change. Dropping request because it does not have SlackUserIdentity.")
+                elif payload["event"]["type"] in (EVENT_TYPE_USER_CHANGE, EVENT_TYPE_USER_PROFILE_CHANGED):
+                    logger.info(
+                        "Event {}. Dropping request because it does not have SlackUserIdentity.".format(
+                            payload["event"]["type"]
+                        )
+                    )
                     return Response()
             else:
                 logger.info("Dropping request because it does not have SlackUserIdentity.")


### PR DESCRIPTION
# What this PR does
Adds a handler for [user_profile_changed](https://api.slack.com/events/user_profile_changed) Slack event + updates the Slack app manifest.

This is needed to replace [user_change](https://api.slack.com/events/user_change) event with [user_profile_changed](https://api.slack.com/events/user_profile_changed) event, since using `user_change` can cause a lot of excessive requests from Slack.

## Which issue(s) this PR fixes
Might be related to https://github.com/grafana/oncall-private/issues/1803

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
