### PR TITLE
Fix escalation reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed bug in Escalation Chains where reordering an item crashed the list
+
 ## v1.2.23 (2023-05-15)
 
 ### Added

--- a/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
+++ b/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
@@ -36,7 +36,11 @@ import styles from './EscalationPolicy.module.css';
 
 const cx = cn.bind(styles);
 
-export interface EscalationPolicyProps {
+interface ElementSortableProps {
+  index: number;
+}
+
+export interface EscalationPolicyProps extends ElementSortableProps {
   data: EscalationPolicyType;
   waitDelays?: any[];
   isDisabled?: boolean;

--- a/grafana-plugin/src/containers/EscalationChainSteps/EscalationChainSteps.tsx
+++ b/grafana-plugin/src/containers/EscalationChainSteps/EscalationChainSteps.tsx
@@ -76,6 +76,7 @@ const EscalationChainSteps = observer((props: EscalationChainStepsProps) => {
 
           return (
             <EscalationPolicy
+              index={index} // This in here is a MUST for the SortableElement
               key={`item-${escalationPolicy.id}`}
               data={escalationPolicy}
               number={index + offset + 1}


### PR DESCRIPTION
# What this PR does

Fixed bug in Escalation Chains where reordering an item crashed the list

#1936 