### PR TITLE
Allow passing Firebase credentials via environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Allow passing Firebase credentials via environment variable by @vadimkerr ([#1969](https://github.com/grafana/oncall/pull/1969))
+
 ## v1.2.25 (2023-05-18)
 
 ### Added

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -25,7 +25,6 @@ x-env-vars: &oncall-env-vars
   BROKER_TYPE: ${BROKER_TYPE}
   GRAFANA_API_URL: http://localhost:3000
   GOOGLE_APPLICATION_CREDENTIALS: /etc/app/gcp_service_account.json
-  FCM_PROJECT_ID: oncall-mobile-dev
 
 # basically this is needed because the oncall backend containers have been configured to communicate w/ grafana via
 # http://localhost:3000 (GRAFANA_API_URL). This URL is used in two scenarios:

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -1,8 +1,10 @@
+import base64
+import json
 import os
 from random import randrange
 
 from celery.schedules import crontab
-from firebase_admin import initialize_app
+from firebase_admin import credentials, initialize_app
 
 from common.utils import getenv_boolean, getenv_integer
 
@@ -587,13 +589,18 @@ EXTRA_MESSAGING_BACKENDS = [
     ("apps.mobile_app.backend.MobileAppCriticalBackend", 6),
 ]
 
-FIREBASE_APP = initialize_app(options={"projectId": os.environ.get("FCM_PROJECT_ID", None)})
+# Firebase credentials can be passed as base64 encoded JSON string in GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64 env variable.
+# If it's not passed, firebase_admin will use a file located at GOOGLE_APPLICATION_CREDENTIALS env variable.
+credential = None
+GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64 = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64", None)
+if GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64:
+    credentials_json = json.loads(base64.b64decode(GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64))
+    credential = credentials.Certificate(credentials_json)
 
 FCM_RELAY_ENABLED = getenv_boolean("FCM_RELAY_ENABLED", default=False)
 FCM_DJANGO_SETTINGS = {
     # an instance of firebase_admin.App to be used as default for all fcm-django requests
-    # default: None (the default Firebase app)
-    "DEFAULT_FIREBASE_APP": None,
+    "DEFAULT_FIREBASE_APP": initialize_app(credential=credential),
     "APP_VERBOSE_NAME": "OnCall",
     "ONE_DEVICE_PER_USER": True,
     "DELETE_INACTIVE_DEVICES": False,


### PR DESCRIPTION
# What this PR does
Allow passing Google application credentials (used to send FCM messages using `fcm-django`) as an environment variable `GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64`. If the env variable is not provided, credentials will be taken from file. This change allows uWSGI workers send messages to FCM (currently it's not possible because the uWSGI user doesn't have access to the credentials file) + makes configuration more consistent.

Also removes a redundant `FCM_PROJECT_ID` env variable (Google application credentials already contain the project ID).

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
