### PR TITLE
Fix inbound email bug when attaching files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix inbound email bug when attaching files by @vadimkerr ([#1970](https://github.com/grafana/oncall/pull/1970))
+
 ## v1.2.25 (2023-05-18)
 
 ### Added

--- a/engine/apps/email/inbound.py
+++ b/engine/apps/email/inbound.py
@@ -69,7 +69,7 @@ class InboundEmailWebhookView(AlertChannelDefiningMixin, APIView):
                 alert_receive_channel_pk=alert_receive_channel.pk,
                 image_url=None,
                 link_to_upstream_details=None,
-                integration_unique_data=request.data,
+                integration_unique_data=None,
                 raw_request_data=payload,
             )
 


### PR DESCRIPTION
# What this PR does
Fix inbound email endpoint bug when attaching files to email leads to HTTP 500.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
