### PR TITLE
Bring back FCM_PROJECT_ID env variable

### DIFF
--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -25,6 +25,7 @@ x-env-vars: &oncall-env-vars
   BROKER_TYPE: ${BROKER_TYPE}
   GRAFANA_API_URL: http://localhost:3000
   GOOGLE_APPLICATION_CREDENTIALS: /etc/app/gcp_service_account.json
+  FCM_PROJECT_ID: oncall-mobile-dev
 
 # basically this is needed because the oncall backend containers have been configured to communicate w/ grafana via
 # http://localhost:3000 (GRAFANA_API_URL). This URL is used in two scenarios:

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -597,10 +597,13 @@ if GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64:
     credentials_json = json.loads(base64.b64decode(GOOGLE_APPLICATION_CREDENTIALS_JSON_BASE64))
     credential = credentials.Certificate(credentials_json)
 
+# FCM_PROJECT_ID can be different from the project ID in the credentials file.
+FCM_PROJECT_ID = os.environ.get("FCM_PROJECT_ID", None)
+
 FCM_RELAY_ENABLED = getenv_boolean("FCM_RELAY_ENABLED", default=False)
 FCM_DJANGO_SETTINGS = {
     # an instance of firebase_admin.App to be used as default for all fcm-django requests
-    "DEFAULT_FIREBASE_APP": initialize_app(credential=credential),
+    "DEFAULT_FIREBASE_APP": initialize_app(credential=credential, options={"projectId": FCM_PROJECT_ID}),
     "APP_VERBOSE_NAME": "OnCall",
     "ONE_DEVICE_PER_USER": True,
     "DELETE_INACTIVE_DEVICES": False,


### PR DESCRIPTION
Bring back `FCM_PROJECT_ID` env variable that was removed in https://github.com/grafana/oncall/pull/1969.
I made an incorrect assumption that project ID is already specified in the credentials file, but in fact project ID can be different from the one in credentials file.