### PR TITLE
Templates tweaks

### DIFF
--- a/grafana-plugin/src/components/Timeline/Timeline.module.css
+++ b/grafana-plugin/src/components/Timeline/Timeline.module.css
@@ -27,3 +27,6 @@
   word-break: break-word;
   flex-grow: 1;
 }
+.content--noMargin {
+  margin: 0;
+}

--- a/grafana-plugin/src/components/Timeline/Timeline.module.css
+++ b/grafana-plugin/src/components/Timeline/Timeline.module.css
@@ -27,6 +27,7 @@
   word-break: break-word;
   flex-grow: 1;
 }
+
 .content--noMargin {
   margin: 0;
 }

--- a/grafana-plugin/src/components/Timeline/TimelineItem.tsx
+++ b/grafana-plugin/src/components/Timeline/TimelineItem.tsx
@@ -33,7 +33,7 @@ const TimelineItem: React.FC<TimelineItemProps> = ({
           {number}
         </div>
       )}
-      <div className={cx('content', contentClassName)}>{children}</div>
+      <div className={cx('content', contentClassName, { 'content--noMargin': isDisabled })}>{children}</div>
     </li>
   );
 };

--- a/grafana-plugin/src/containers/AlertRules/parts/index.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/index.tsx
@@ -12,10 +12,11 @@ import { getVar } from 'utils/DOM';
 
 interface ChatOpsConnectorsProps {
   channelFilterId: ChannelFilter['id'];
+  showLineNumber?: boolean;
 }
 
 export const ChatOpsConnectors = (props: ChatOpsConnectorsProps) => {
-  const { channelFilterId } = props;
+  const { channelFilterId, showLineNumber } = props;
 
   const store = useStore();
   const { telegramChannelStore } = store;
@@ -29,7 +30,7 @@ export const ChatOpsConnectors = (props: ChatOpsConnectorsProps) => {
   }
 
   return (
-    <Timeline.Item number={0} backgroundColor={getVar('--tag-secondary')}>
+    <Timeline.Item number={0} backgroundColor={getVar('--tag-secondary')} isDisabled={!showLineNumber}>
       <VerticalGroup>
         {isSlackInstalled && <SlackConnector channelFilterId={channelFilterId} />}
         {isTelegramInstalled && <TelegramConnector channelFilterId={channelFilterId} />}

--- a/grafana-plugin/src/containers/AlertRules/parts/index.tsx
+++ b/grafana-plugin/src/containers/AlertRules/parts/index.tsx
@@ -16,7 +16,7 @@ interface ChatOpsConnectorsProps {
 }
 
 export const ChatOpsConnectors = (props: ChatOpsConnectorsProps) => {
-  const { channelFilterId, showLineNumber } = props;
+  const { channelFilterId, showLineNumber = true } = props;
 
   const store = useStore();
   const { telegramChannelStore } = store;

--- a/grafana-plugin/src/containers/GSelect/GSelect.tsx
+++ b/grafana-plugin/src/containers/GSelect/GSelect.tsx
@@ -146,7 +146,6 @@ const GSelect = observer((props: GSelectProps) => {
 
   return (
     <div className={cx('root', className)}>
-      {/*@ts-ignore*/}
       <Tag
         autoFocus={autoFocus}
         isSearchable={showSearch}

--- a/grafana-plugin/src/containers/IntegrationContainers/ExpandedIntegrationRouteDisplay/ExpandedIntegrationRouteDisplay.tsx
+++ b/grafana-plugin/src/containers/IntegrationContainers/ExpandedIntegrationRouteDisplay/ExpandedIntegrationRouteDisplay.tsx
@@ -152,7 +152,7 @@ const ExpandedIntegrationRouteDisplay: React.FC<ExpandedIntegrationRouteDisplayP
                 <IntegrationBlockItem>
                   <VerticalGroup spacing="md">
                     <Text type="primary">Publish to ChatOps</Text>
-                    <ChatOpsConnectors channelFilterId={channelFilterId} />
+                    <ChatOpsConnectors channelFilterId={channelFilterId} showLineNumber={false} />
                   </VerticalGroup>
                 </IntegrationBlockItem>
               )}

--- a/grafana-plugin/src/containers/IntegrationContainers/ExpandedIntegrationRouteDisplay/ExpandedIntegrationRouteDisplay.tsx
+++ b/grafana-plugin/src/containers/IntegrationContainers/ExpandedIntegrationRouteDisplay/ExpandedIntegrationRouteDisplay.tsx
@@ -19,12 +19,12 @@ import { WithPermissionControlTooltip } from 'containers/WithPermissionControl/W
 import { AlertReceiveChannel } from 'models/alert_receive_channel/alert_receive_channel.types';
 import { AlertTemplatesDTO } from 'models/alert_templates';
 import { ChannelFilter } from 'models/channel_filter/channel_filter.types';
+import { EscalationChain } from 'models/escalation_chain/escalation_chain.types';
 import { MONACO_INPUT_HEIGHT_SMALL, MONACO_OPTIONS } from 'pages/integration_2/Integration2.config';
 import IntegrationHelper from 'pages/integration_2/Integration2.helper';
 import { AppFeature } from 'state/features';
 import { useStore } from 'state/useStore';
 import { UserActions } from 'utils/authorization';
-import { EscalationChain } from 'models/escalation_chain/escalation_chain.types';
 
 const cx = cn.bind(styles);
 


### PR DESCRIPTION
# What this PR does


- Hide timeline numbering when `isDisabled` is being sent
- Fixed tooltips within expanded route for escalation chains actions
- Replaced GSelect with Select to allow refreshing list manually