### PR TITLE
Remove user defined time period from "you're going oncall" mobile push 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix SQLite permission issue by @vadimkerr ([#1984](https://github.com/grafana/oncall/pull/1984))
+- Remove user defined time period from "you're going oncall" mobile push ([2001](https://github.com/grafana/oncall/pull/2001))
 
 ## v1.2.26 (2023-05-18)
 

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -383,7 +383,9 @@ def should_we_send_going_oncall_push_notification(
         f"shift_starts_within_fifteen_minutes: {shift_starts_within_fifteen_minutes}"
     )
 
-    if shift_starts_within_users_notification_timing_preference or shift_starts_within_fifteen_minutes:
+    # Temporary remove `shift_starts_within_users_notification_timing_preference` from condition to send notification only 15 minutes before the shift starts
+    # TODO: Return it once mobile app ready and default value is changed (https://github.com/grafana/oncall/issues/1999)
+    if shift_starts_within_fifteen_minutes:
         logger.info(f"timing is right to send going oncall push notification\n{timing_logging_msg}")
         return seconds_until_shift_starts
     logger.info(f"timing is not right to send going oncall push notification\n{timing_logging_msg}")

--- a/engine/apps/mobile_app/tests/test_your_going_oncall_notification.py
+++ b/engine/apps/mobile_app/tests/test_your_going_oncall_notification.py
@@ -64,7 +64,7 @@ def test_shift_starts_within_range(timing_window_lower, timing_window_upper, sec
             timezone.datetime(2022, 5, 2, 12, 5, 0),
             ONE_HOUR_IN_SECONDS,
             timezone.datetime(2022, 5, 2, 13, 12, 0),
-            67 * 60,
+            None,
         ),
         (
             False,
@@ -79,7 +79,7 @@ def test_shift_starts_within_range(timing_window_lower, timing_window_upper, sec
             timezone.datetime(2022, 5, 2, 12, 5, 0),
             ONE_HOUR_IN_SECONDS,
             timezone.datetime(2022, 5, 2, 12, 58, 0),
-            53 * 60,
+            None,
         ),
         (
             False,


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
