### PR TITLE
Refresh final schedule after cached icals are dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Phone provider refactoring [#1713](https://github.com/grafana/oncall/pull/1713)
 
+### Fixed
+
+- Fix issue with sometimes cached final schedule not being refreshed after an update ([#2004](https://github.com/grafana/oncall/pull/2004))
+
 ## v1.2.28 (2023-05-24)
 
 ### Fixed

--- a/engine/apps/schedules/models/custom_on_call_shift.py
+++ b/engine/apps/schedules/models/custom_on_call_shift.py
@@ -21,7 +21,6 @@ from recurring_ical_events import UnfoldableCalendar
 
 from apps.schedules.tasks import (
     drop_cached_ical_task,
-    refresh_ical_final_schedule,
     schedule_notify_about_empty_shifts_in_schedule,
     schedule_notify_about_gaps_in_schedule,
 )
@@ -671,7 +670,6 @@ class CustomOnCallShift(models.Model):
         drop_cached_ical_task.apply_async((schedule.pk,))
         schedule_notify_about_empty_shifts_in_schedule.apply_async((schedule.pk,))
         schedule_notify_about_gaps_in_schedule.apply_async((schedule.pk,))
-        refresh_ical_final_schedule.apply_async((schedule.pk,))
 
     @cached_property
     def last_updated_shift(self):

--- a/engine/apps/schedules/tasks/drop_cached_ical.py
+++ b/engine/apps/schedules/tasks/drop_cached_ical.py
@@ -3,6 +3,8 @@ from django.apps import apps
 
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 
+from .refresh_ical_files import refresh_ical_final_schedule
+
 task_logger = get_task_logger(__name__)
 
 
@@ -16,6 +18,9 @@ def drop_cached_ical_task(schedule_pk):
         schedule.drop_cached_ical()
     except OnCallSchedule.DoesNotExist:
         task_logger.info(f"Tried to drop_cached_ical_task for non-existing schedule {schedule_pk}")
+    else:
+        # queue a refresh for final schedule
+        refresh_ical_final_schedule.apply_async((schedule_pk,))
     task_logger.info(f"Finish drop_cached_ical_task for schedule {schedule_pk}")
 
 

--- a/engine/apps/schedules/tests/test_tasks_drop_cached_ical.py
+++ b/engine/apps/schedules/tests/test_tasks_drop_cached_ical.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.schedules.models import OnCallScheduleWeb
+from apps.schedules.tasks.drop_cached_ical import drop_cached_ical_task
+
+
+@pytest.mark.django_db
+def test_drop_cached_ical_triggers_final_refresh(make_organization, make_schedule):
+    organization = make_organization()
+    schedule = make_schedule(organization, schedule_class=OnCallScheduleWeb)
+
+    with patch("apps.schedules.tasks.drop_cached_ical.refresh_ical_final_schedule") as mock_refresh_final:
+        drop_cached_ical_task(schedule.pk)
+        assert mock_refresh_final.apply_async.called


### PR DESCRIPTION
Make sure the final schedule is refreshed after dropping the cached ical representations (sometimes the refresh final task was completed before the cached ical files were refreshed).