### PR TITLE
Handle error when updating closed modal window in Slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix error when updating closed modal window in Slack by @vadimkerr ([#2019](https://github.com/grafana/oncall/pull/2019))
+
 ## v1.2.30 (2023-05-25)
 
 ### Fixed


### PR DESCRIPTION
# What this PR does
Handle HTTP 500 error when attempting to update resolution note modal window that was already closed by user.

## Which issue(s) this PR fixes
Related to https://github.com/grafana/oncall-private/issues/1834

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
