### PR TITLE
update engine log format + log out device type when sending push notifications

### DIFF
--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -119,6 +119,7 @@ def _construct_fcm_message(
             **data,
             "type": message_type,
             "thread_id": thread_id,
+            "device_type": device_to_notify.type,
         },
         android=AndroidConfig(
             # from the docs

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -62,7 +62,7 @@ def send_push_notification_to_fcm_relay(message: Message) -> requests.Response:
 def _send_push_notification(
     device_to_notify: FCMDevice, message: Message, error_cb: typing.Optional[typing.Callable[..., None]] = None
 ) -> None:
-    logger.debug(f"Sending push notification with message: {message}")
+    logger.debug(f"Sending push notification to device type {device_to_notify.type} with message: {message}")
 
     def _error_cb():
         if error_cb:
@@ -119,7 +119,6 @@ def _construct_fcm_message(
             **data,
             "type": message_type,
             "thread_id": thread_id,
-            "device_type": device_to_notify.type,
         },
         android=AndroidConfig(
             # from the docs

--- a/engine/engine/middlewares.py
+++ b/engine/engine/middlewares.py
@@ -23,20 +23,18 @@ class RequestTimeLoggingMiddleware(MiddlewareMixin):
             seconds = (dt - request._logging_start_dt).total_seconds()
             status_code = 0 if response is None else response.status_code
             content_length = request.headers.get("content-length", default=0)
+            user_agent = request.META["HTTP_USER_AGENT"]
             message = (
                 "inbound "
                 f"latency={str(seconds)} status={status_code} method={request.method} path={request.path} "
-                f"content-length={content_length} slow={int(seconds > settings.SLOW_THRESHOLD_SECONDS)} "
+                f"user_agent={user_agent} content-length={content_length} "
+                f"slow={int(seconds > settings.SLOW_THRESHOLD_SECONDS)} "
             )
-            if (
-                hasattr(request, "user")
-                and request.user
-                and request.user.id
-                and hasattr(request.user, "organization_id")
-            ):
+            if hasattr(request, "user") and request.user and request.user.id and hasattr(request.user, "organization"):
                 user_id = request.user.id
-                org_id = request.user.organization_id
-                message += f"user_id={user_id} org_id={org_id} "
+                org_id = request.user.organization.id
+                org_slug = request.user.organization.org_slug
+                message += f"user_id={user_id} org_id={org_id} org_slug={org_slug} "
             if request.path.startswith("/integrations/v1"):
                 split_path = request.path.split("/")
                 integration_type = split_path[3]

--- a/engine/engine/middlewares.py
+++ b/engine/engine/middlewares.py
@@ -23,7 +23,7 @@ class RequestTimeLoggingMiddleware(MiddlewareMixin):
             seconds = (dt - request._logging_start_dt).total_seconds()
             status_code = 0 if response is None else response.status_code
             content_length = request.headers.get("content-length", default=0)
-            user_agent = request.META["HTTP_USER_AGENT"]
+            user_agent = request.META.get("HTTP_USER_AGENT", "unknown")
             message = (
                 "inbound "
                 f"latency={str(seconds)} status={status_code} method={request.method} path={request.path} "


### PR DESCRIPTION
# What this PR does

- update engine log format to include `org_slug` + `user_agent`
```bash
2023-05-25 11:28:22 source=engine:app google_trace_id=none logger=root inbound latency=0.33164 status=200 method=GET path=/api/internal/v1/alertgroups/stats user_agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 content-length=0 slow=0 user_id=1 org_id=1 org_slug=self_hosted_org
2023-05-25 11:28:23 source=engine:app google_trace_id=none logger=root inbound latency=0.402866 status=200 method=GET path=/api/internal/v1/alertgroups user_agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36 content-length=0 slow=0 user_id=1 org_id=1 org_slug=self_hosted_org
```
- log out device type when sending push notifications ([possible values are `web`, `ios`, or `android`](https://github.com/xtrinch/fcm-django/blob/master/fcm_django/models.py#L264-L266))

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required) (N/A)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required) (N/A)
