### PR TITLE
Enable selecting active days for every shift freq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add models and framework to use different services (Phone, SMS, Verify) in Twilio depending on
 the destination country code by @mderynck ([#1976](https://github.com/grafana/oncall/pull/1976))
 - Prometheus exporter backend for alert groups related metrics
+- Enable by-day selection when defining monthly and hourly rotations ([2037](https://github.com/grafana/oncall/pull/2037))
 
 ### Fixed
 

--- a/engine/apps/api/serializers/on_call_shifts.py
+++ b/engine/apps/api/serializers/on_call_shifts.py
@@ -118,8 +118,6 @@ class OnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {"frequency": ["Cannot set 'frequency' for shifts with type 'override'"]}
                 )
-            if frequency not in (CustomOnCallShift.FREQUENCY_WEEKLY, CustomOnCallShift.FREQUENCY_DAILY) and by_day:
-                raise serializers.ValidationError({"by_day": ["Cannot set days value for this frequency type"]})
             if interval is None:
                 raise serializers.ValidationError(
                     {"interval": ["If frequency is set, interval must be a positive integer"]}

--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -778,27 +778,6 @@ def test_create_on_call_shift_invalid_data_by_day(on_call_shift_internal_api_set
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["by_day"][0] == "Cannot set days value for non-recurrent shifts"
 
-    # by_day with non-weekly/non-daily frequency
-    data = {
-        "title": "Test Shift 2",
-        "type": CustomOnCallShift.TYPE_ROLLING_USERS_EVENT,
-        "schedule": schedule.public_primary_key,
-        "priority_level": 0,
-        "shift_start": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "shift_end": (start_date + timezone.timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "rotation_start": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "until": None,
-        "frequency": CustomOnCallShift.FREQUENCY_MONTHLY,
-        "interval": None,
-        "by_day": [CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY]],
-        "rolling_users": [[user1.public_primary_key]],
-    }
-
-    response = client.post(url, data, format="json", **make_user_auth_headers(user1, token))
-
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.data["by_day"][0] == "Cannot set days value for this frequency type"
-
 
 @pytest.mark.django_db
 def test_create_on_call_shift_invalid_data_interval(on_call_shift_internal_api_setup, make_user_auth_headers):

--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -163,10 +163,7 @@ const RotationForm: FC<RotationFormProps> = observer((props) => {
       rolling_users: userGroups,
       interval: repeatEveryValue,
       frequency: repeatEveryPeriod,
-      by_day:
-        repeatEveryPeriod === 0 || repeatEveryPeriod === 1
-          ? getUTCByDay(store.scheduleStore.byDayOptions, selectedDays, shiftStart)
-          : null,
+      by_day: getUTCByDay(store.scheduleStore.byDayOptions, selectedDays, shiftStart),
       priority_level: shiftId === 'new' ? layerPriority : shift?.priority_level,
     }),
     [
@@ -362,15 +359,13 @@ const RotationForm: FC<RotationFormProps> = observer((props) => {
                   />
                 </Field>
               </HorizontalGroup>
-              {(repeatEveryPeriod === 0 || repeatEveryPeriod === 1) && (
-                <Field label="Select days to repeat">
-                  <DaysSelector
-                    options={store.scheduleStore.byDayOptions}
-                    value={selectedDays}
-                    onChange={(value) => setSelectedDays(value)}
-                  />
-                </Field>
-              )}
+              <Field label="Select days to repeat">
+                <DaysSelector
+                  options={store.scheduleStore.byDayOptions}
+                  value={selectedDays}
+                  onChange={(value) => setSelectedDays(value)}
+                />
+              </Field>
               <div className={cx('two-fields')}>
                 <Field
                   className={cx('date-time-picker')}


### PR DESCRIPTION
Make it possible to select "by day" active periods for every shift frequency (ie. enable it for hourly and monthly recurrent rotations).