### PR TITLE
Helm chart: added configuration of uwsgi using environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add models and framework to use different services (Phone, SMS, Verify) in Twilio depending on
 the destination country code by @mderynck ([#1976](https://github.com/grafana/oncall/pull/1976))
 - Prometheus exporter backend for alert groups related metrics
+- Helm chart: configuration of `uwsgi` using environment variables by @alexintech ([#2045](https://github.com/grafana/oncall/pull/2045))
 
 ### Fixed
 
 - Fix error when updating closed modal window in Slack by @vadimkerr ([#2019](https://github.com/grafana/oncall/pull/2019))
 - Fix final schedule export failing to update when ical imported events set start/end as date ([#2025](https://github.com/grafana/oncall/pull/2025))
+- Helm chart: fix bugs in helm chart with external postgresql configuration by @alexintech ([#2036](https://github.com/grafana/oncall/pull/2036))
 
 ### Changed
 

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -19,8 +19,7 @@
   value: "admin"
 - name: OSS
   value: "True"
-- name: UWSGI_LISTEN
-  value: "1024"
+{{- template "snippet.oncall.uwsgi" . }}
 - name: BROKER_TYPE
   value: {{ .Values.broker.type | default "rabbitmq" }}
 - name: GRAFANA_API_URL
@@ -48,6 +47,15 @@ SECRET_KEY
 {{ required "oncall.secrets.mirageSecretKey is required if oncall.secret.existingSecret is not empty" .Values.oncall.secrets.mirageSecretKey }}
 {{- else -}}
 MIRAGE_SECRET_KEY
+{{- end -}}
+{{- end -}}
+
+{{- define "snippet.oncall.uwsgi" -}}
+{{- if .Values.uwsgi -}}
+  {{- range $key, $value := .Values.uwsgi }}
+- name: UWSGI_{{ $key | upper | replace "-" "_" }}
+  value: {{ $value | quote }}
+  {{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/oncall/templates/_helpers.tpl
+++ b/helm/oncall/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Create the name of the service account to use
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   command: ['sh', '-c', "until (python manage.py migrate --check); do echo Waiting for database migrations; sleep 2; done"]
   securityContext:
-  {{ toYaml .Values.init.securityContext| nindent 4}}
+  {{ toYaml .Values.init.securityContext | nindent 4 }}
   env:
     {{- include "snippet.oncall.env" . | nindent 4 }}
     {{- include "snippet.mysql.env" . | nindent 4 }}
@@ -116,13 +116,13 @@ Create the name of the service account to use
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   command: ['sh', '-c', "until (python manage.py migrate --check); do echo Waiting for database migrations; sleep 2; done"]
   securityContext:
-  {{ toYaml .Values.init.securityContext| nindent 4}}
+  {{ toYaml .Values.init.securityContext | nindent 4 }}
   env:
-    {{- include "snippet.oncall.env" . | nindent 12 }}
-    {{- include "snippet.postgresql.env" . | nindent 12 }}
-    {{- include "snippet.rabbitmq.env" . | nindent 12 }}
-    {{- include "snippet.redis.env" . | nindent 12 }}
+    {{- include "snippet.oncall.env" . | nindent 4 }}
+    {{- include "snippet.postgresql.env" . | nindent 4 }}
+    {{- include "snippet.rabbitmq.env" . | nindent 4 }}
+    {{- include "snippet.redis.env" . | nindent 4 }}
     {{- if .Values.env }}
-      {{- toYaml .Values.env | nindent 12 }}
+      {{- toYaml .Values.env | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/helm/oncall/tests/uwsgi_env_test.yaml
+++ b/helm/oncall/tests/uwsgi_env_test.yaml
@@ -1,0 +1,49 @@
+suite: test uwsgi environment variables
+templates:
+  - engine/deployment.yaml
+  - engine/job-migrate.yaml
+  - celery/deployment-celery.yaml
+release:
+  name: oncall
+tests:
+  - it: uwsgi.listen should overwrite UWSGI_LISTEN env
+    set:
+      uwsgi.listen: 128
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UWSGI_LISTEN
+            value: "128"
+  - it: uwsgi.envs should set multiple UWSGI_* envs
+    set:
+      uwsgi:
+        processes: 3
+        max-requests: 1000
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UWSGI_LISTEN
+            value: "1024"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UWSGI_PROCESSES
+            value: "3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UWSGI_MAX_REQUESTS
+            value: "1000"
+  - it: uwsgi.null should not set any UWSGI_* variable
+    set:
+      uwsgi: null
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: UWSGI_LISTEN
+
+
+

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -166,6 +166,12 @@ migrate:
   # use a helm hook to manage the migration job
   useHook: false
 
+# Sets environment variables with name capitalized and prefixed with UWSGI_, and dashes are substituted with underscores.
+# see more: https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#environment-variables
+# Set null to disable all UWSGI environment variables
+uwsgi:
+  listen: 1024
+
 # Additional env variables to add to deployments
 env: {}
 


### PR DESCRIPTION
# What this PR does

Adds `uwsgi` configuration to helm chart.
Sets environment variables with name capitalized and prefixed with `UWSGI_`, and dashes are substituted with underscores like described [here](https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#environment-variables)

Sets `UWSGI_LISTEN=1024` by default, but can be overwritten or completely removed by `uwsgi: null`

Or is it better to not specify default value (it's not backward compatible)?

Also, small indentation fixes for postgresql configuration.

## Which issue(s) this PR fixes

closes https://github.com/grafana/oncall/issues/562

Also, [this PR](https://github.com/grafana/oncall/pull/856) has been closed because of this PR

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
