### PR TITLE
Update find contact point name, receiver could be missing key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helm chart: fix bugs in helm chart with external postgresql configuration by @alexintech ([#2036](https://github.com/grafana/oncall/pull/2036))
 - Properly address `Organization.DoesNotExist` exceptions thrown which result in HTTP 500 for the Slack `interactive_api_endpoint`
   endpoint by @joeyorlando ([#2040](https://github.com/grafana/oncall/pull/2040))
+- Fix issue when trying to sync Grafana contact point and config receivers miss a key ([#2046](https://github.com/grafana/oncall/pull/2046))
 
 ### Changed
 

--- a/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
+++ b/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
@@ -540,7 +540,7 @@ class GrafanaAlertingSyncManager:
         name_in_alerting = None
         # find name of contact point in alerting config by contact point uid
         for receiver in receivers:
-            receiver_configs = receiver["grafana_managed_receiver_configs"]
+            receiver_configs = receiver.get("grafana_managed_receiver_configs", [])
             for receiver_config in receiver_configs:
                 if receiver_config["uid"] == contact_point_uid:
                     name_in_alerting = receiver_config["name"]

--- a/engine/apps/alerts/tests/test_grafana_alerting_sync.py
+++ b/engine/apps/alerts/tests/test_grafana_alerting_sync.py
@@ -1,0 +1,28 @@
+import pytest
+
+from apps.alerts.grafana_alerting_sync_manager.grafana_alerting_sync import GrafanaAlertingSyncManager
+
+
+@pytest.mark.django_db
+def test_find_name_of_contact_point_grafana_datasource(make_organization, make_alert_receive_channel):
+    organization = make_organization()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    sync_manager = GrafanaAlertingSyncManager(alert_receive_channel)
+
+    receivers = [
+        {
+            "name": "autogen-contact-point-default"
+        },
+        {
+            "name": "testing",
+            "grafana_managed_receiver_configs": [
+                {
+                    "uid": "some-uid",
+                    "name": "testing",
+                }
+            ]
+        },
+    ]
+
+    name = sync_manager.find_name_of_contact_point("some-uid", True, receivers)
+    assert name == "testing"

--- a/engine/apps/alerts/tests/test_grafana_alerting_sync.py
+++ b/engine/apps/alerts/tests/test_grafana_alerting_sync.py
@@ -10,9 +10,7 @@ def test_find_name_of_contact_point_grafana_datasource(make_organization, make_a
     sync_manager = GrafanaAlertingSyncManager(alert_receive_channel)
 
     receivers = [
-        {
-            "name": "autogen-contact-point-default"
-        },
+        {"name": "autogen-contact-point-default"},
         {
             "name": "testing",
             "grafana_managed_receiver_configs": [
@@ -20,7 +18,7 @@ def test_find_name_of_contact_point_grafana_datasource(make_organization, make_a
                     "uid": "some-uid",
                     "name": "testing",
                 }
-            ]
+            ],
         },
     ]
 


### PR DESCRIPTION
Fixes issue when syncing contact points and there are receiver configs with no `grafana_managed_receiver_configs` key.
(eg. `{"name": "autogen-contact-point-default"}`)