### PR TITLE
Edit critical to be  Important to align with the rest of app convention

### DIFF
--- a/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.tsx
+++ b/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.tsx
@@ -215,7 +215,7 @@ const MobileAppConnection = observer(({ userPk }: Props) => {
                 onClick={() => onSendTestNotification(true)}
                 disabled={isAttemptingTestNotification}
               >
-                Send Critical Test Push notification
+                Send Important Test Push notification
               </Button>
             </HorizontalGroup>
           </div>


### PR DESCRIPTION
# What this PR does
- Edits the send important notification button to be send critical notification button to align with the app conventions
## Which issue(s) this PR fixes
Ref #2043 


