### PR TITLE
Fix 500 on templates when slack or tg integration is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix templates when slack or telegram is disabled ([#2064](https://github.com/grafana/oncall/pull/2064))
+
 ## v1.2.33 (2023-05-30)
 
 ### Fixed

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -325,9 +325,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
         """Update core templates if needed."""
         errors = {}
 
-        core_template_names = self.CORE_TEMPLATE_NAMES
-
-        for field_name in core_template_names:
+        for field_name in self.core_templates_names:
             value = data.get(field_name)
             validator = jinja_template_env.from_string
             if value is not None:
@@ -343,7 +341,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
 
     def to_representation(self, obj):
         ret = super().to_representation(obj)
-        ret = self._get_templates_to_show(ret)
+        # ret = self._get_templates_to_show(ret)
 
         core_templates = self._get_core_templates(obj)
         ret.update(core_templates)
@@ -399,8 +397,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
     def _get_core_templates(self, obj):
         core_templates = {}
 
-        core_template_names = self.CORE_TEMPLATE_NAMES
-        for template_name in core_template_names:
+        for template_name in self.core_templates_names:
             template_value = getattr(obj, template_name)
             defaults = getattr(obj, f"INTEGRATION_TO_DEFAULT_{template_name.upper()}", {})
             default_template_value = defaults.get(obj.integration)
@@ -408,3 +405,36 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
             core_templates[f"{template_name}_is_default"] = not bool(template_value)
 
         return core_templates
+
+    @property
+    def core_templates_names(self):
+        core_templates = [
+            "web_title_template",
+            "web_message_template",
+            "web_image_url_template",
+            "sms_title_template",
+            "phone_call_title_template",
+            "source_link_template",
+            "grouping_id_template",
+            "resolve_condition_template",
+            "acknowledge_condition_template",
+        ]
+
+        slack_integration_required_templates = [
+            "slack_title_template",
+            "slack_message_template",
+            "slack_image_url_template",
+        ]
+        telegram_integration_required_templates = [
+            "telegram_title_template",
+            "telegram_message_template",
+            "telegram_image_url_template",
+        ]
+
+        apppend = []
+
+        if settings.FEATURE_SLACK_INTEGRATION_ENABLED:
+            core_templates += slack_integration_required_templates
+        if settings.FEATURE_TELEGRAM_INTEGRATION_ENABLED:
+            core_templates += telegram_integration_required_templates
+        return apppend + core_templates

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -334,29 +334,6 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
 
         return ret
 
-    def _get_templates_to_show(self, response_data):
-        """
-        For On-prem installations with disabled features it is needed to disable corresponding templates
-        """
-        slack_integration_required_templates = [
-            "slack_title_template",
-            "slack_message_template",
-            "slack_image_url_template",
-        ]
-        telegram_integration_required_templates = [
-            "telegram_title_template",
-            "telegram_message_template",
-            "telegram_image_url_template",
-        ]
-        if not settings.FEATURE_SLACK_INTEGRATION_ENABLED:
-            for st in slack_integration_required_templates:
-                response_data.pop(st)
-        if not settings.FEATURE_TELEGRAM_INTEGRATION_ENABLED:
-            for tt in telegram_integration_required_templates:
-                response_data.pop(tt)
-
-        return response_data
-
     def _get_messaging_backend_templates(self, obj):
         """Return additional messaging backend templates if any."""
         templates = {}
@@ -390,6 +367,10 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
 
     @property
     def core_templates_names(self):
+        """
+        core_templates_names returns names of templates introduced before messaging backends system with respect to
+        enabled integrations.
+        """
         core_templates = [
             "web_title_template",
             "web_message_template",

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -216,23 +216,6 @@ class FilterAlertReceiveChannelSerializer(serializers.ModelSerializer):
 
 class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, source="public_primary_key")
-    CORE_TEMPLATE_NAMES = [
-        "slack_title_template",
-        "slack_message_template",
-        "slack_image_url_template",
-        "web_title_template",
-        "web_message_template",
-        "web_image_url_template",
-        "telegram_title_template",
-        "telegram_message_template",
-        "telegram_image_url_template",
-        "sms_title_template",
-        "phone_call_title_template",
-        "source_link_template",
-        "grouping_id_template",
-        "resolve_condition_template",
-        "acknowledge_condition_template",
-    ]
 
     payload_example = SerializerMethodField()
     is_based_on_alertmanager = SerializerMethodField()
@@ -341,7 +324,6 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
 
     def to_representation(self, obj):
         ret = super().to_representation(obj)
-        # ret = self._get_templates_to_show(ret)
 
         core_templates = self._get_core_templates(obj)
         ret.update(core_templates)

--- a/engine/apps/api/tests/test_alert_receive_channel_template.py
+++ b/engine/apps/api/tests/test_alert_receive_channel_template.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.test.utils import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.response import Response
@@ -381,3 +382,44 @@ def test_update_alert_receive_channel_templates(
             assert updated_templates_data[template_name] is False
         else:
             assert updated_templates_data[template_name] == template_update_func(prev_template_value)
+
+
+@override_settings(FEATURE_TELEGRAM_INTEGRATION_ENABLED=False)
+@override_settings(FEATURE_SLACK_INTEGRATION_ENABLED=False)
+@pytest.mark.django_db
+def test_update_alert_receive_channel_backend_template_hide_disabled_integration_templates(
+    make_organization_and_user_with_plugin_token,
+    make_user_auth_headers,
+    make_alert_receive_channel,
+):
+    slack_integration_required_templates = [
+        "slack_title_template",
+        "slack_message_template",
+        "slack_image_url_template",
+    ]
+    telegram_integration_required_templates = [
+        "telegram_title_template",
+        "telegram_message_template",
+        "telegram_image_url_template",
+    ]
+
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    alert_receive_channel = make_alert_receive_channel(
+        organization,
+        messaging_backends_templates={"TESTONLY": {"title": "the-title", "message": "the-message", "image_url": "url"}},
+    )
+    client = APIClient()
+
+    url = reverse(
+        "api-internal:alert_receive_channel_template-detail", kwargs={"pk": alert_receive_channel.public_primary_key}
+    )
+
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+    templates_data = response.json()
+
+    for st in slack_integration_required_templates:
+        assert st not in templates_data
+
+    for tt in telegram_integration_required_templates:
+        assert tt not in templates_data


### PR DESCRIPTION
# What this PR does
Continue the work, started in https://github.com/grafana/oncall/pull/2061. 
Check if slack or telegram integration is enabled to include related templates in the response
## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/1889

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
