### PR TITLE
Better handle "Verification delivery attempt blocked" and "Geo Permission configuration is not permitting call" exceptions from Twilio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Better handle "Verification delivery attempt blocked" exceptions from Twilio by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+- Better handle "Verification delivery attempt blocked" and "Geo Permission configuration is not permitting call"
+  exceptions from Twilio by @joeyorlando ([#2065](https://github.com/grafana/oncall/pull/2065))
 
 ## v1.2.33 (2023-05-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Better handle "Verification delivery attempt blocked" exceptions from Twilio by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+
 ## v1.2.33 (2023-05-30)
 
 ### Fixed

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -47,6 +47,7 @@ from apps.phone_notifications.exceptions import (
     FailedToMakeCall,
     FailedToStartVerification,
     NumberAlreadyVerified,
+    NumberBlocked,
     NumberNotVerified,
     ProviderNotSupports,
 )
@@ -342,6 +343,8 @@ class UserView(
             return Response("Phone number already verified", status=status.HTTP_400_BAD_REQUEST)
         except FailedToStartVerification:
             return Response("Something went wrong while sending code", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except NumberBlocked:
+            return Response("Unauthorized", status=status.HTTP_403_FORBIDDEN)
         except ProviderNotSupports:
             return Response(
                 "Phone provider not supports sms verification", status=status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -43,11 +43,11 @@ from apps.mobile_app.auth import MobileAppAuthTokenAuthentication
 from apps.mobile_app.demo_push import send_test_push
 from apps.mobile_app.exceptions import DeviceNotSet
 from apps.phone_notifications.exceptions import (
+    CallOrSMSNotAllowed,
     FailedToFinishVerification,
     FailedToMakeCall,
     FailedToStartVerification,
     NumberAlreadyVerified,
-    NumberBlocked,
     NumberNotVerified,
     ProviderNotSupports,
 )
@@ -343,8 +343,8 @@ class UserView(
             return Response("Phone number already verified", status=status.HTTP_400_BAD_REQUEST)
         except FailedToStartVerification:
             return Response("Something went wrong while sending code", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        except NumberBlocked:
-            return Response("Unauthorized", status=status.HTTP_403_FORBIDDEN)
+        except CallOrSMSNotAllowed:
+            return Response("Texts to this number are not allowed", status=status.HTTP_403_FORBIDDEN)
         except ProviderNotSupports:
             return Response(
                 "Phone provider not supports sms verification", status=status.HTTP_500_INTERNAL_SERVER_ERROR
@@ -439,6 +439,8 @@ class UserView(
             return Response(
                 "Something went wrong while making a test call", status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
+        except CallOrSMSNotAllowed:
+            return Response("Calls to this number are not allowed", status=status.HTTP_403_FORBIDDEN)
         except ProviderNotSupports:
             return Response("Phone provider not supports phone calls", status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 

--- a/engine/apps/phone_notifications/exceptions.py
+++ b/engine/apps/phone_notifications/exceptions.py
@@ -34,5 +34,5 @@ class SMSLimitExceeded(Exception):
     pass
 
 
-class NumberBlocked(Exception):
+class CallOrSMSNotAllowed(Exception):
     pass

--- a/engine/apps/phone_notifications/exceptions.py
+++ b/engine/apps/phone_notifications/exceptions.py
@@ -32,3 +32,7 @@ class CallsLimitExceeded(Exception):
 
 class SMSLimitExceeded(Exception):
     pass
+
+
+class NumberBlocked(Exception):
+    pass

--- a/engine/apps/twilioapp/tests/test_twilio_provider.py
+++ b/engine/apps/twilioapp/tests/test_twilio_provider.py
@@ -1,13 +1,20 @@
 from unittest import mock
 
 import pytest
+from twilio.base.exceptions import TwilioRestException as BaseTwilioRestException
 
+from apps.phone_notifications.exceptions import CallOrSMSNotAllowed, FailedToMakeCall, FailedToStartVerification
 from apps.twilioapp.phone_provider import TwilioPhoneProvider
 
 
 class MockTwilioCallInstance:
     status = "mock_status"
     sid = "mock_sid"
+
+
+class TwilioRestException(BaseTwilioRestException):
+    def __init__(self, code):
+        super().__init__(status=403, uri="http://example.com", msg="asdf", code=code, method="GET")
 
 
 @pytest.mark.django_db
@@ -34,6 +41,49 @@ def test_make_call(mock_twiml, mock_call_create):
     provider_call = provider.make_call(number, message)
     assert provider_call is None  # test that provider_call is not returned from make_call
     mock_call_create.assert_called_once_with("mocked_twiml", number, with_callback=False)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "twilio_code,expected_exception",
+    [
+        (21215, CallOrSMSNotAllowed),
+        (None, FailedToMakeCall),
+    ],
+)
+@mock.patch("apps.twilioapp.phone_provider.TwilioPhoneProvider._call_create", return_value=MockTwilioCallInstance())
+@mock.patch("apps.twilioapp.phone_provider.TwilioPhoneProvider._message_to_twiml", return_value="mocked_twiml")
+def test_make_call_exceptions(mock_twiml, mock_call_create, twilio_code, expected_exception):
+    number = "+1234567890"
+    message = "Hello"
+    provider = TwilioPhoneProvider()
+
+    mock_call_create.side_effect = TwilioRestException(twilio_code)
+
+    with pytest.raises(expected_exception):
+        provider.make_call(number, message)
+
+    mock_call_create.assert_called_once_with("mocked_twiml", number, with_callback=False)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "twilio_code,expected_exception",
+    [
+        (60410, CallOrSMSNotAllowed),
+        (None, FailedToStartVerification),
+    ],
+)
+@mock.patch("apps.twilioapp.phone_provider.TwilioPhoneProvider._verify_sender", return_value=MockTwilioCallInstance())
+def test_send_verification_sms_exceptions(mock_verify_sender, twilio_code, expected_exception):
+    number = "+1234567890"
+
+    mock_verify_sender.side_effect = TwilioRestException(twilio_code)
+
+    with pytest.raises(expected_exception):
+        TwilioPhoneProvider().send_verification_sms(number)
+
+    mock_verify_sender.assert_called_once_with(number)
 
 
 class MockTwilioSMSInstance:


### PR DESCRIPTION
# What this PR does

When we receive a [code 60410](https://www.twilio.com/docs/api/errors/60410) from Twilio, return HTTP 403, instead of HTTP 500.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
