### PR TITLE
Add templates for mobile push notifications

### DIFF
--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -19,7 +19,6 @@ from apps.alerts.grafana_alerting_sync_manager.grafana_alerting_sync import Graf
 from apps.alerts.integration_options_mixin import IntegrationOptionsMixin
 from apps.alerts.models.maintainable_object import MaintainableObject
 from apps.alerts.tasks import disable_maintenance, sync_grafana_alerting_contact_points
-from apps.base.messaging import get_messaging_backend_from_id
 from apps.base.utils import live_settings
 from apps.integrations.metadata import heartbeat
 from apps.integrations.tasks import create_alert, create_alertmanager_alerts
@@ -212,15 +211,6 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
             backend_id = render_for.upper()
             value = self.messaging_backends_templates.get(backend_id, {}).get(attr_name)
         return value
-
-    def get_default_template_attribute(self, render_for, attr_name):
-        defaults = {}
-        backend_id = render_for.upper()
-        # check backend exists
-        if get_messaging_backend_from_id(backend_id):
-            # fallback to web defaults for now
-            defaults = getattr(self, f"INTEGRATION_TO_DEFAULT_WEB_{attr_name.upper()}_TEMPLATE", {})
-        return defaults.get(self.integration)
 
     @classmethod
     def create(cls, **kwargs):

--- a/engine/apps/mobile_app/alert_rendering.py
+++ b/engine/apps/mobile_app/alert_rendering.py
@@ -9,6 +9,15 @@ class AlertMobileAppTemplater(AlertTemplater):
         return "MOBILE_APP"
 
 
+def get_push_notification_title(alert_group):
+    alert = alert_group.alerts.first()
+    templated_alert = AlertMobileAppTemplater(alert).render()
+    alert_title = str_or_backup(templated_alert.title, "Alert Group")
+    print(f"alert_title: {alert_title}")
+    return alert_title
+    # return "New Important Alert" if critical else "New Alert"
+
+
 def get_push_notification_subtitle(alert_group):
     alert = alert_group.alerts.first()
     templated_alert = AlertMobileAppTemplater(alert).render()

--- a/engine/apps/mobile_app/backend.py
+++ b/engine/apps/mobile_app/backend.py
@@ -12,7 +12,7 @@ class MobileAppBackend(BaseMessagingBackend):
     label = "Mobile push"
     short_label = "Mobile push"
     available_for_use = True
-    template_fields = ["title"]
+    template_fields = ["title", "message"]
 
     def generate_user_verification_code(self, user):
         from apps.mobile_app.models import MobileAppVerificationToken
@@ -50,13 +50,6 @@ class MobileAppBackend(BaseMessagingBackend):
             critical=critical,
         )
 
-    @property
-    def customizable_templates(self):
-        """
-        Disable customization if templates for mobile app
-        """
-        return False
-
 
 class MobileAppCriticalBackend(MobileAppBackend):
     """
@@ -69,6 +62,13 @@ class MobileAppCriticalBackend(MobileAppBackend):
     label = "Mobile push important"
     short_label = "Mobile push important"
     template_fields = []
+
+    @property
+    def customizable_templates(self):
+        """
+        Disable customization if templates for mobile app
+        """
+        return False
 
     def notify_user(self, user, alert_group, notification_policy, critical=True):
         super().notify_user(user, alert_group, notification_policy, critical)

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -18,7 +18,7 @@ from rest_framework import status
 
 from apps.alerts.models import AlertGroup
 from apps.base.utils import live_settings
-from apps.mobile_app.alert_rendering import get_push_notification_subtitle
+from apps.mobile_app.alert_rendering import get_push_notification_subtitle, get_push_notification_title
 from apps.schedules.models.on_call_schedule import OnCallSchedule, ScheduleEvent
 from apps.user_management.models import User
 from common.api_helpers.utils import create_engine_url
@@ -154,7 +154,8 @@ def _get_alert_group_escalation_fcm_message(
 
     thread_id = f"{alert_group.channel.organization.public_primary_key}:{alert_group.public_primary_key}"
 
-    alert_title = "New Important Alert" if critical else "New Alert"
+    # alert_title = "New Important Alert" if critical else "New Alert"
+    alert_title = get_push_notification_title(alert_group)
     alert_subtitle = get_push_notification_subtitle(alert_group)
 
     mobile_app_user_settings, _ = MobileAppUserSettings.objects.get_or_create(user=user)

--- a/engine/common/api_helpers/mixins.py
+++ b/engine/common/api_helpers/mixins.py
@@ -19,6 +19,7 @@ from apps.alerts.incident_appearance.templaters import (
 )
 from apps.api.permissions import LegacyAccessControlRole
 from apps.base.messaging import get_messaging_backends
+from apps.mobile_app.alert_rendering import AlertMobileAppTemplater
 from common.api_helpers.exceptions import BadRequest
 from common.jinja_templater import apply_jinja_template
 from common.jinja_templater.apply_jinja_template import JinjaTemplateError, JinjaTemplateWarning
@@ -257,8 +258,9 @@ WEB = "web"
 PHONE_CALL = "phone_call"
 SMS = "sms"
 TELEGRAM = "telegram"
+MOBILE_APP = "mobile_app"
 # templates with its own field in db, this concept replaced by messaging_backend_templates field
-NOTIFICATION_CHANNEL_OPTIONS = [SLACK, WEB, PHONE_CALL, SMS, TELEGRAM]
+NOTIFICATION_CHANNEL_OPTIONS = [SLACK, WEB, PHONE_CALL, SMS, TELEGRAM, MOBILE_APP]
 
 TITLE = "title"
 MESSAGE = "message"
@@ -275,6 +277,7 @@ NOTIFICATION_CHANNEL_TO_TEMPLATER_MAP = {
     PHONE_CALL: AlertPhoneCallTemplater,
     SMS: AlertSmsTemplater,
     TELEGRAM: AlertTelegramTemplater,
+    MOBILE_APP: AlertMobileAppTemplater,
 }
 
 # add additionally supported messaging backends

--- a/engine/config_integrations/formatted_webhook.py
+++ b/engine/config_integrations/formatted_webhook.py
@@ -44,6 +44,17 @@ grouping_id = '{{ payload.get("alert_uid", "") }}'
 
 resolve_condition = '{{ payload.get("state", "").upper() == "OK" }}'
 
+# TODO: put normal template here
+mobile_app_title = "Alert!"
+
+mobile_app_message = """\
+{{ grafana_oncall_alert_group_id }}
+via {{ integration_name }}
+{{ grafana_oncall_alert_group_status }}
+Status: {{status_verbose}}
+alerts: {{alerts_count_str}}
+"""
+
 acknowledge_condition = None
 
 example_payload = {

--- a/grafana-plugin/src/components/AlertTemplates/AlertTemplatesForm.config.ts
+++ b/grafana-plugin/src/components/AlertTemplates/AlertTemplatesForm.config.ts
@@ -138,6 +138,16 @@ export const templateForEdit: { [id: string]: TemplateForEdit } = {
     },
     isRoute: true,
   },
+  mobile_app_title_template: {
+    name: 'mobile_app_title_template',
+    displayName: 'Title',
+    description: '',
+  },
+  mobile_app_message_template: {
+    name: 'mobile_app_message_template',
+    displayName: 'Subtitle',
+    description: '',
+  },
 };
 
 export const templatesToRender: Template[] = [

--- a/grafana-plugin/src/containers/IntegrationContainers/IntegrationTemplatesList.config.ts
+++ b/grafana-plugin/src/containers/IntegrationContainers/IntegrationTemplatesList.config.ts
@@ -18,22 +18,22 @@ export const templatesToRender: TemplateBlock[] = [
       {
         name: 'grouping_id_template',
         label: 'Grouping',
-        height: MONACO_INPUT_HEIGHT_TALL,
+        height: MONACO_INPUT_HEIGHT_SMALL,
       },
       {
         name: 'resolve_condition_template',
-        label: 'Auto resolve',
+        label: 'Autoresolve',
         height: MONACO_INPUT_HEIGHT_SMALL,
       },
     ],
   },
   {
-    name: 'Web',
+    name: 'Web & Mobile',
     contents: [
       {
         name: 'web_title_template',
         label: 'Title',
-        height: MONACO_INPUT_HEIGHT_TALL,
+        height: MONACO_INPUT_HEIGHT_SMALL,
       },
       {
         name: 'web_message_template',
@@ -44,6 +44,21 @@ export const templatesToRender: TemplateBlock[] = [
         name: 'web_image_url_template',
         label: 'Image',
         height: MONACO_INPUT_HEIGHT_SMALL,
+      },
+    ],
+  },
+  {
+    name: 'Mobile Push Notification',
+    contents: [
+      {
+        name: 'mobile_app_title_template',
+        label: 'Title',
+        height: MONACO_INPUT_HEIGHT_SMALL,
+      },
+      {
+        name: 'mobile_app_message_template',
+        label: 'Message',
+        height: MONACO_INPUT_HEIGHT_TALL,
       },
     ],
   },


### PR DESCRIPTION
# What this PR does
This PR adds ability to customise push notification content. See this [issue](https://github.com/grafana/oncall/issues/2050) 

<img width="1022" alt="Screenshot 2023-05-31 at 6 18 12 PM" src="https://github.com/grafana/oncall/assets/2262529/0819aa0a-3fea-4e93-a456-476f1a77969d">


## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
