### PR TITLE
Fix relative link to resolve 404 error

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -68,7 +68,7 @@ For more information on Grafana OnCall integrations and further configuration gu
 
 ### Learn Alert Flow
 
-All Alerts in OnCall are grouped to Alert Groups ([read more about Grouping ID]({{< relref "jinja2-templating" >}})). Alert Group could have mutually
+All Alerts in OnCall are grouped to Alert Groups ([read more about Grouping ID]({{< relref "../jinja2-templating" >}})). Alert Group could have mutually
 exclusive states:
 
 - **Firing:** Once Alert Group is registered, Escalation Policy associated with it is getting started. Escalation policy will work while Alert Group is in this status.


### PR DESCRIPTION
Link to the jinja2-templating page was not stepping backwards one level in the directory, therefore linking to a 404.