### PR TITLE
Fix a bug #1617 with permissions for telegram user settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix a bug with permissions for telegram user settings by @alexintech ([#2075](https://github.com/grafana/oncall/pull/2075))
+
 ## v1.2.34 (2023-05-31)
 
 ### Added

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/TelegramInfo/TelegramInfo.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/TelegramInfo/TelegramInfo.tsx
@@ -40,7 +40,7 @@ const TelegramInfo = observer((_props: TelegramInfoProps) => {
 
   return (
     <WithPermissionControlDisplay
-      userAction={UserActions.OtherSettingsWrite}
+      userAction={UserActions.UserSettingsWrite}
       message="You do not have permission to perform this action. Ask an admin to upgrade your permissions."
     >
       {telegramConfigured || !store.hasFeature(AppFeature.LiveSettings) ? (


### PR DESCRIPTION
# What this PR does

Changes a required role for telegram user settings from Admin to Editor.

## Which issue(s) this PR fixes

closes https://github.com/grafana/oncall/issues/1617

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
