### PR TITLE
Use X-WR-TIMEZONE as calendar tz when available, fallback to UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix demo alert for inbound email integration by @vadimkerr ([#2081](https://github.com/grafana/oncall/pull/2081))
+- Fix calendar TZ used when comparing current shifts triggering slack shift notifications ([#2091](https://github.com/grafana/oncall/pull/2091))
 
 ## v1.2.35 (2023-06-01)
 

--- a/engine/apps/schedules/ical_utils.py
+++ b/engine/apps/schedules/ical_utils.py
@@ -575,10 +575,7 @@ def calculate_shift_diff(first_shift, second_shift):
 
 
 def get_icalendar_tz_or_utc(icalendar):
-    try:
-        calendar_timezone = icalendar.walk("VTIMEZONE")[0]["TZID"]
-    except (IndexError, KeyError):
-        calendar_timezone = "UTC"
+    calendar_timezone = icalendar.get("X-WR-TIMEZONE", "UTC")
 
     if pytz_timezone := is_valid_timezone(calendar_timezone):
         return pytz_timezone


### PR DESCRIPTION
When checking current shifts to trigger slack notifications, a stable value for timezone should be used (to avoid triggering multiple duplicated notifications; using the first `VTIMEZONE` value available may change on refresh, besides being potentially incorrect).

Also, `VTIMEZONE` shouldn't be used as the calendar timezone, it just describes a [timezone definition](https://icalendar.org/iCalendar-RFC-5545/3-6-5-time-zone-component.html) which can later be [used when specifying a start/end date/datetime](https://icalendar.org/iCalendar-RFC-5545/3-2-19-time-zone-identifier.html) ("The parameter MUST be specified on properties with a DATE-TIME value if the DATE-TIME is not either a UTC or a "floating" time.").

OTOH, Google uses the non-standard[ `X-WR-TIMEZONE` ](https://github.com/collective/icalendar/issues/343)field as fallback TZ for date-times without a `TZID`. Try to use this when available, otherwise fallback to `UTC`.