### PR TITLE
Fix Telegram ratelimit on live setting change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Do not hide not secret settings in the web plugin UI by @alexintech ([#1964](https://github.com/grafana/oncall/pull/1964))
+- Fix Telegram ratelimit on live setting change by @vadimkerr and @alexintech ([#2100](https://github.com/grafana/oncall/pull/2100))
 
 ## v1.2.36 (2023-06-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix + revert [#2057](https://github.com/grafana/oncall/pull/2057) which reverted a change which properly handles
   `Organization.DoesNotExist` exceptions for Slack events by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+- Fix Telegram ratelimit on live setting change by @vadimkerr and @alexintech ([#2100](https://github.com/grafana/oncall/pull/2100))
 
 ## v1.2.39 (2023-06-06)
 
 ### Changed
 
 - Do not hide not secret settings in the web plugin UI by @alexintech ([#1964](https://github.com/grafana/oncall/pull/1964))
-- Fix Telegram ratelimit on live setting change by @vadimkerr and @alexintech ([#2100](https://github.com/grafana/oncall/pull/2100))
 
 ## v1.2.36 (2023-06-02)
 

--- a/engine/apps/api/views/live_setting.py
+++ b/engine/apps/api/views/live_setting.py
@@ -70,9 +70,6 @@ class LiveSettingViewSet(PublicPrimaryKeyMixin, viewsets.ModelViewSet):
             self._reset_telegram_integration(old_token=old_value)
             register_telegram_webhook.delay()
 
-        if name == "TELEGRAM_WEBHOOK_HOST":
-            register_telegram_webhook.delay()
-
         if name in ["SLACK_CLIENT_OAUTH_ID", "SLACK_CLIENT_OAUTH_SECRET"]:
             organization = self.request.auth.organization
             slack_team_identity = organization.slack_team_identity

--- a/engine/apps/base/models/live_setting.py
+++ b/engine/apps/base/models/live_setting.py
@@ -212,6 +212,7 @@ class LiveSetting(models.Model):
     def validate_settings(cls):
         settings_to_validate = cls.objects.all()
         for setting in settings_to_validate:
+            setting.error = LiveSettingValidator(live_setting=setting).get_error()
             setting.save(update_fields=["error"])
 
     @staticmethod
@@ -220,13 +221,11 @@ class LiveSetting(models.Model):
 
     def save(self, *args, **kwargs):
         """
-        Save validates LiveSettings values and save them in database
+        Save checks that setting name is in list of available names, then saves it.
         """
         if self.name not in self.AVAILABLE_NAMES:
             raise ValueError(
                 f"Setting with name '{self.name}' is not in list of available names {self.AVAILABLE_NAMES}"
             )
-
-        self.error = LiveSettingValidator(live_setting=self).get_error()
 
         super().save(*args, **kwargs)

--- a/engine/apps/base/models/live_setting.py
+++ b/engine/apps/base/models/live_setting.py
@@ -220,9 +220,6 @@ class LiveSetting(models.Model):
         return getattr(settings, setting_name)
 
     def save(self, *args, **kwargs):
-        """
-        Save checks that setting name is in list of available names, then saves it.
-        """
         if self.name not in self.AVAILABLE_NAMES:
             raise ValueError(
                 f"Setting with name '{self.name}' is not in list of available names {self.AVAILABLE_NAMES}"

--- a/engine/apps/base/utils.py
+++ b/engine/apps/base/utils.py
@@ -45,7 +45,7 @@ class LiveSettingValidator:
     def get_error(self):
         check_fn_name = f"_check_{self.live_setting.name.lower()}"
 
-        if self.live_setting.value is None and self.live_setting.name not in self.EMPTY_VALID_NAMES:
+        if self.live_setting.value in (None, "") and self.live_setting.name not in self.EMPTY_VALID_NAMES:
             return "Empty"
 
         # skip validation if there's no handler for it
@@ -138,9 +138,11 @@ class LiveSettingValidator:
     @classmethod
     def _check_telegram_webhook_host(cls, telegram_webhook_host):
         try:
+            # avoid circular import
+            from apps.telegram.client import TelegramClient
+
             url = create_engine_url("/telegram/", override_base=telegram_webhook_host)
-            bot = Bot(token=live_settings.TELEGRAM_TOKEN)
-            bot.set_webhook(url)
+            TelegramClient().register_webhook(url)
         except Exception as e:
             return f"Telegram error: {str(e)}"
 

--- a/engine/apps/telegram/client.py
+++ b/engine/apps/telegram/client.py
@@ -39,6 +39,7 @@ class TelegramClient:
     def register_webhook(self, webhook_url: Optional[str] = None) -> None:
         webhook_url = webhook_url or create_engine_url("/telegram/", override_base=live_settings.TELEGRAM_WEBHOOK_HOST)
 
+        # avoid unnecessary set_webhook calls to make sure Telegram rate limits are not exceeded
         webhook_info = self.api_client.get_webhook_info()
         if webhook_info.url == webhook_url:
             return


### PR DESCRIPTION
# What this PR does

Fixes https://github.com/grafana/oncall/issues/1103, inspired by https://github.com/grafana/oncall/pull/1934.

Makes sure that:
1. `LiveSettings.validate_settings` is only called once per update request and not called for any individual LiveSetting instance save.
2. `telegram.Bot.set_webhook` is only called once per request when changing `TELEGRAM_WEBHOOK_HOST`.


## Which issue(s) this PR fixes

https://github.com/grafana/oncall/issues/1103

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
