### PR TITLE
add github action to triage stale pull requests

### DIFF
--- a/.github/workflows/triage-stale-pull-requests.yml
+++ b/.github/workflows/triage-stale-pull-requests.yml
@@ -1,0 +1,21 @@
+name: "Triage stale pull requests"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          # docs - https://github.com/actions/stale
+          # don't mark issues as stale, only triage pull requests
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 30
+          days-before-pr-close: 30
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had activity in the last 30 days. It will be closed in 30 days if no further activity occurs. Please feel free to give a status update now, ping for review, or re-open when it's ready. Thank you for your contributions!
+          close-pr-message: >
+            This pull request has been automatically closed because it has not had activity in the last 30 days. Please feel free to give a status update now, ping for review, or re-open when it's ready. Thank you for your contributions!


### PR DESCRIPTION
# What this PR does

Use [this](https://github.com/actions/stale) GitHub Action to run a cron-job every morning to triage stale pull requests. The messages posted to the pull request when stale/closed were borrowed from the `grafana/grafana` repo ([example](https://github.com/grafana/grafana/pull/65754)).

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
