### PR TITLE
Fix backend for resolution notes via mobile app

### DIFF
--- a/engine/apps/api/errors.py
+++ b/engine/apps/api/errors.py
@@ -1,0 +1,17 @@
+"""errors contains business-logic error codes for internal api.
+
+It's expected that error codes will use 1000-9999 codes range, where first two digits are for entity:
+11xx - AlertGroup, 12xx - AlertReceiveChannel, etc. 10xx are saved for future.
+"""
+# TODO: this package is WIP. It requires validation of range for codes.
+from enum import Enum, unique
+
+
+@unique
+class AlertGroupAPIError(Enum):
+    """
+    Error codes for alert group.
+    Range is 1100-1199
+    """
+
+    RESOLUTION_NOTE_REQUIRED = 1101

--- a/engine/apps/api/errors.py
+++ b/engine/apps/api/errors.py
@@ -1,9 +1,10 @@
 """errors contains business-logic error codes for internal api.
 
 It's expected that error codes will use 1000-9999 codes range, where first two digits are for entity:
-11xx - AlertGroup, 12xx - AlertReceiveChannel, etc. 10xx are saved for future.
+11xx - AlertGroup, 12xx - AlertReceiveChannel, etc.
+10xx are saved for non-entity related errors.
 """
-# TODO: this package is WIP. It requires validation of range for codes.
+# TODO: this package is WIP. It requires validation of code ranges.
 from enum import Enum, unique
 
 

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -15,6 +15,7 @@ from rest_framework.response import Response
 from apps.alerts.constants import ActionSource
 from apps.alerts.models import Alert, AlertGroup, AlertReceiveChannel, EscalationChain
 from apps.alerts.paging import unpage_user
+from apps.api.errors import AlertGroupAPIError
 from apps.api.permissions import RBACPermission
 from apps.api.serializers.alert_group import AlertGroupListSerializer, AlertGroupSerializer
 from apps.api.serializers.team import TeamSerializer
@@ -458,7 +459,10 @@ class AlertGroupView(
         else:
             if organization.is_resolution_note_required and not alert_group.has_resolution_notes:
                 return Response(
-                    data="Alert group without resolution note cannot be resolved due to organization settings.",
+                    data={
+                        "code": AlertGroupAPIError.RESOLUTION_NOTE_REQUIRED.value,
+                        "detail": "Alert group without resolution note cannot be resolved due to organization settings",
+                    },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             alert_group.resolve_by_user(self.request.user, action_source=ActionSource.WEB)

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -13,8 +13,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from apps.alerts.constants import ActionSource
-from apps.alerts.models import Alert, AlertGroup, AlertReceiveChannel, EscalationChain
+from apps.alerts.models import Alert, AlertGroup, AlertReceiveChannel, EscalationChain, ResolutionNote
 from apps.alerts.paging import unpage_user
+from apps.alerts.tasks import send_update_resolution_note_signal
 from apps.api.errors import AlertGroupAPIError
 from apps.api.permissions import RBACPermission
 from apps.api.serializers.alert_group import AlertGroupListSerializer, AlertGroupSerializer
@@ -457,14 +458,30 @@ class AlertGroupView(
         if alert_group.is_maintenance_incident:
             alert_group.stop_maintenance(self.request.user)
         else:
-            if organization.is_resolution_note_required and not alert_group.has_resolution_notes:
-                return Response(
-                    data={
-                        "code": AlertGroupAPIError.RESOLUTION_NOTE_REQUIRED.value,
-                        "detail": "Alert group without resolution note cannot be resolved due to organization settings",
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
+            resolution_note_text = request.data.get("resolution_note")
+            if resolution_note_text:
+                rn = ResolutionNote.objects.create(
+                    alert_group=alert_group,
+                    author=self.request.user,
+                    source=ResolutionNote.Source.WEB,
+                    text=resolution_note_text[3000:],
                 )
+                send_update_resolution_note_signal.apply_async(
+                    kwargs={
+                        "alert_group_pk": alert_group.pk,
+                        "resolution_note_pk": rn.pk,
+                    }
+                )
+            else:
+                # Check resolution note required setting only if resolution_note_text was not provided.
+                if organization.is_resolution_note_required and not alert_group.has_resolution_notes:
+                    return Response(
+                        data={
+                            "code": AlertGroupAPIError.RESOLUTION_NOTE_REQUIRED.value,
+                            "detail": "Alert group without resolution note cannot be resolved due to organization settings",
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
             alert_group.resolve_by_user(self.request.user, action_source=ActionSource.WEB)
         return Response(AlertGroupSerializer(alert_group, context={"request": self.request}).data)
 


### PR DESCRIPTION
# What this PR does
Add first internal api error code and add "resolution_note" param to resolve endpoint

## Which issue(s) this PR fixes
It fixes resolving alert groups via mobile app when resolution note is required

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
