### PR TITLE
Make viewset actions more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow mobile app to consume "internal" schedules API endpoints by @joeyorlando ([#2109](https://github.com/grafana/oncall/pull/2109))
 - Add inbound email address in integration API by @vadimkerr ([#2113](https://github.com/grafana/oncall/pull/2113))
 
+### Changed
+
+- Make viewset actions more consistent by @vadimkerr ([#2120](https://github.com/grafana/oncall/pull/2120))
+
 ### Fixed
 
 - Fix + revert [#2057](https://github.com/grafana/oncall/pull/2057) which reverted a change which properly handles

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -802,9 +802,7 @@ def test_alert_receive_channel_send_demo_alert_not_enabled(
     make_alert_receive_channel,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
-    alert_receive_channel = make_alert_receive_channel(
-        organization, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING
-    )
+    alert_receive_channel = make_alert_receive_channel(organization, integration=AlertReceiveChannel.INTEGRATION_MANUAL)
     client = APIClient()
 
     url = reverse(

--- a/engine/apps/api/tests/test_channel_filter.py
+++ b/engine/apps/api/tests/test_channel_filter.py
@@ -315,6 +315,57 @@ def test_channel_filter_create_without_order(
 
 
 @pytest.mark.django_db
+def test_move_to_position(
+    make_organization_and_user_with_plugin_token,
+    make_alert_receive_channel,
+    make_channel_filter,
+    make_user_auth_headers,
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    # create default channel filter
+    make_channel_filter(alert_receive_channel, is_default=True, order=0)
+    first_channel_filter = make_channel_filter(alert_receive_channel, filtering_term="a", is_default=False, order=1)
+    second_channel_filter = make_channel_filter(alert_receive_channel, filtering_term="b", is_default=False, order=2)
+
+    client = APIClient()
+    url = reverse(
+        "api-internal:channel_filter-move-to-position", kwargs={"pk": first_channel_filter.public_primary_key}
+    )
+    url += f"?position=2"
+    response = client.put(url, **make_user_auth_headers(user, token))
+
+    assert response.status_code == status.HTTP_200_OK
+    first_channel_filter.refresh_from_db()
+    second_channel_filter.refresh_from_db()
+    assert first_channel_filter.order == 2
+    assert second_channel_filter.order == 1
+
+
+@pytest.mark.django_db
+def test_move_to_position_cant_move_default(
+    make_organization_and_user_with_plugin_token,
+    make_alert_receive_channel,
+    make_channel_filter,
+    make_user_auth_headers,
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    # create default channel filter
+    default_channel_filter = make_channel_filter(alert_receive_channel, is_default=True, order=0)
+    make_channel_filter(alert_receive_channel, filtering_term="b", is_default=False, order=1)
+
+    client = APIClient()
+    url = reverse(
+        "api-internal:channel_filter-move-to-position", kwargs={"pk": default_channel_filter.public_primary_key}
+    )
+    url += f"?position=1"
+    response = client.put(url, **make_user_auth_headers(user, token))
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
 def test_channel_filter_update_with_order(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -207,14 +207,14 @@ class AlertReceiveChannelView(
 
     @action(detail=True, methods=["put"])
     def change_team(self, request, pk):
+        instance = self.get_object()
+
         if "team_id" not in request.query_params:
             raise BadRequest(detail="team_id must be specified")
 
         team_id = request.query_params["team_id"]
         if team_id == "null":
             team_id = None
-
-        instance = self.get_object()
 
         try:
             instance.change_team(team_id=team_id, user=self.request.user)
@@ -247,14 +247,16 @@ class AlertReceiveChannelView(
 
     # This method is required for PreviewTemplateMixin
     def get_alert_to_template(self, payload=None):
+        channel = self.get_object()
+
         try:
             if payload is None:
-                return self.get_object().alert_groups.last().alerts.first()
+                return channel.alert_groups.last().alerts.first()
             else:
                 if type(payload) != dict:
                     raise PreviewTemplateException("Payload must be a valid json object")
                 # Build Alert and AlertGroup objects to pass to templater without saving them to db
-                alert_group_to_template = AlertGroup(channel=self.get_object())
+                alert_group_to_template = AlertGroup(channel=channel)
                 return Alert(raw_request_data=payload, group=alert_group_to_template)
         except AttributeError:
             return None

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -171,14 +171,14 @@ class AlertReceiveChannelView(
 
     @action(detail=True, methods=["post"], throttle_classes=[DemoAlertThrottler])
     def send_demo_alert(self, request, pk):
-        alert_receive_channel = AlertReceiveChannel.objects.get(public_primary_key=pk)
+        instance = self.get_object()
         payload = request.data.get("demo_alert_payload", None)
 
         if payload is not None and not isinstance(payload, dict):
             raise BadRequest(detail="Payload for demo alert must be a valid json object")
 
         try:
-            alert_receive_channel.send_demo_alert(payload=payload)
+            instance.send_demo_alert(payload=payload)
         except UnableToSendDemoAlert as e:
             raise BadRequest(detail=str(e))
 
@@ -282,7 +282,7 @@ class AlertReceiveChannelView(
 
     @action(detail=True, methods=["post"])
     def start_maintenance(self, request, pk):
-        instance = self.get_queryset(eager=False).get(public_primary_key=pk)
+        instance = self.get_object()
 
         mode = request.data.get("mode", None)
         duration = request.data.get("duration", None)
@@ -312,7 +312,7 @@ class AlertReceiveChannelView(
 
     @action(detail=True, methods=["post"])
     def stop_maintenance(self, request, pk):
-        instance = self.get_queryset(eager=False).get(public_primary_key=pk)
+        instance = self.get_object()
         user = request.user
         instance.force_disable_maintenance(user)
         return Response(status=status.HTTP_200_OK)

--- a/engine/apps/api/views/channel_filter.py
+++ b/engine/apps/api/views/channel_filter.py
@@ -148,7 +148,7 @@ class ChannelFilterView(
 
     @action(detail=True, methods=["post"])
     def convert_from_regex_to_jinja2(self, request, pk):
-        instance = self.get_queryset().get(public_primary_key=pk)
+        instance = self.get_object()
         if not instance.filtering_term_type == ChannelFilter.FILTERING_TERM_TYPE_REGEX:
             raise BadRequest(detail="Only regex filtering term type is supported")
 

--- a/engine/apps/api/views/channel_filter.py
+++ b/engine/apps/api/views/channel_filter.py
@@ -134,7 +134,7 @@ class ChannelFilterView(
     @action(detail=True, methods=["post"], throttle_classes=[DemoAlertThrottler])
     def send_demo_alert(self, request, pk):
         """Deprecated action. May be used in the older version of the plugin."""
-        instance = ChannelFilter.objects.get(public_primary_key=pk)
+        instance = self.get_object()
         try:
             instance.send_demo_alert()
         except UnableToSendDemoAlert as e:

--- a/engine/apps/api/views/channel_filter.py
+++ b/engine/apps/api/views/channel_filter.py
@@ -22,6 +22,7 @@ from common.api_helpers.mixins import (
     TeamFilteringMixin,
     UpdateSerializerMixin,
 )
+from common.api_helpers.serializers import get_move_to_position_param
 from common.exceptions import UnableToSendDemoAlert
 from common.insight_log import EntityEvent, write_resource_insight_log
 
@@ -110,31 +111,25 @@ class ChannelFilterView(
 
     @action(detail=True, methods=["put"])
     def move_to_position(self, request, pk):
-        position = request.query_params.get("position", None)
-        if position is not None:
-            try:
-                instance = ChannelFilter.objects.get(public_primary_key=pk)
-            except ChannelFilter.DoesNotExist:
-                raise BadRequest(detail="Channel filter does not exist")
-            try:
-                if instance.is_default:
-                    raise BadRequest(detail="Unable to change position for default filter")
-                prev_state = instance.insight_logs_serialized
-                instance.to(int(position))
-                new_state = instance.insight_logs_serialized
+        instance = self.get_object()
+        position = get_move_to_position_param(request)
 
-                write_resource_insight_log(
-                    instance=instance,
-                    author=self.request.user,
-                    event=EntityEvent.UPDATED,
-                    prev_state=prev_state,
-                    new_state=new_state,
-                )
-                return Response(status=status.HTTP_200_OK)
-            except ValueError as e:
-                raise BadRequest(detail=f"{e}")
-        else:
-            raise BadRequest(detail="Position was not provided")
+        if instance.is_default:
+            raise BadRequest(detail="Unable to change position for default filter")
+
+        prev_state = instance.insight_logs_serialized
+        instance.to(position)
+        new_state = instance.insight_logs_serialized
+
+        write_resource_insight_log(
+            instance=instance,
+            author=self.request.user,
+            event=EntityEvent.UPDATED,
+            prev_state=prev_state,
+            new_state=new_state,
+        )
+
+        return Response(status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["post"], throttle_classes=[DemoAlertThrottler])
     def send_demo_alert(self, request, pk):

--- a/engine/apps/api/views/escalation_chain.py
+++ b/engine/apps/api/views/escalation_chain.py
@@ -120,6 +120,8 @@ class EscalationChainViewSet(
 
     @action(methods=["post"], detail=True)
     def copy(self, request, pk):
+        obj = self.get_object()
+
         name = request.data.get("name")
         team_id = request.data.get("team")
         if team_id == "null":
@@ -131,7 +133,6 @@ class EscalationChainViewSet(
             if EscalationChain.objects.filter(organization=request.auth.organization, name=name).exists():
                 raise BadRequest(detail={"name": ["Escalation chain with this name already exists."]})
 
-        obj = self.get_object()
         try:
             team = request.user.available_teams.get(public_primary_key=team_id) if team_id else None
         except Team.DoesNotExist:

--- a/engine/apps/api/views/escalation_policy.py
+++ b/engine/apps/api/views/escalation_policy.py
@@ -15,13 +15,13 @@ from apps.api.serializers.escalation_policy import (
 )
 from apps.auth_token.auth import PluginAuthentication
 from apps.webhooks.utils import is_webhooks_enabled_for_organization
-from common.api_helpers.exceptions import BadRequest
 from common.api_helpers.mixins import (
     CreateSerializerMixin,
     PublicPrimaryKeyMixin,
     TeamFilteringMixin,
     UpdateSerializerMixin,
 )
+from common.api_helpers.serializers import get_move_to_position_param
 from common.insight_log import EntityEvent, write_resource_insight_log
 
 
@@ -111,31 +111,22 @@ class EscalationPolicyView(
 
     @action(detail=True, methods=["put"])
     def move_to_position(self, request, pk):
-        position = request.query_params.get("position", None)
-        if position is not None:
-            try:
-                instance = EscalationPolicy.objects.get(public_primary_key=pk)
-            except EscalationPolicy.DoesNotExist:
-                raise BadRequest(detail="Step does not exist")
-            try:
-                prev_state = instance.insight_logs_serialized
-                position = int(position)
-                instance.to(position)
-                new_state = instance.insight_logs_serialized
+        instance = self.get_object()
+        position = get_move_to_position_param(request)
 
-                write_resource_insight_log(
-                    instance=instance,
-                    author=self.request.user,
-                    event=EntityEvent.UPDATED,
-                    prev_state=prev_state,
-                    new_state=new_state,
-                )
-                return Response(status=status.HTTP_200_OK)
-            except ValueError as e:
-                raise BadRequest(detail=f"{e}")
+        prev_state = instance.insight_logs_serialized
+        instance.to(position)
+        new_state = instance.insight_logs_serialized
 
-        else:
-            raise BadRequest(detail="Position was not provided")
+        write_resource_insight_log(
+            instance=instance,
+            author=self.request.user,
+            event=EntityEvent.UPDATED,
+            prev_state=prev_state,
+            new_state=new_state,
+        )
+
+        return Response(status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["get"])
     def escalation_options(self, request):

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -479,12 +479,13 @@ class UserView(
 
     @action(detail=True, methods=["get"])
     def get_backend_verification_code(self, request, pk):
+        user = self.get_object()
+
         backend_id = request.query_params.get("backend")
         backend = get_messaging_backend_from_id(backend_id)
         if backend is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        user = self.get_object()
         code = backend.generate_user_verification_code(user)
         return Response(code)
 
@@ -547,12 +548,13 @@ class UserView(
     @action(detail=True, methods=["post"])
     def unlink_backend(self, request, pk):
         # TODO: insight logs support
+        user = self.get_object()
+
         backend_id = request.query_params.get("backend")
         backend = get_messaging_backend_from_id(backend_id)
         if backend is None:
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
-        user = self.get_object()
         try:
             backend.unlink_user(user)
             write_chatops_insight_log(

--- a/engine/apps/api/views/user_notification_policy.py
+++ b/engine/apps/api/views/user_notification_policy.py
@@ -19,6 +19,7 @@ from apps.mobile_app.auth import MobileAppAuthTokenAuthentication
 from apps.user_management.models import User
 from common.api_helpers.exceptions import BadRequest
 from common.api_helpers.mixins import UpdateSerializerMixin
+from common.api_helpers.serializers import get_move_to_position_param
 from common.exceptions import UserNotificationPolicyCouldNotBeDeleted
 from common.insight_log import EntityEvent, write_resource_insight_log
 
@@ -139,16 +140,10 @@ class UserNotificationPolicyView(UpdateSerializerMixin, ModelViewSet):
 
     @action(detail=True, methods=["put"])
     def move_to_position(self, request, pk):
-        position = request.query_params.get("position", None)
-        if position is not None:
-            step = self.get_object()
-            try:
-                step.to(int(position))
-                return Response(status=status.HTTP_200_OK)
-            except ValueError as e:
-                raise BadRequest(detail=f"{e}")
-        else:
-            raise BadRequest(detail="Position was not provided")
+        instance = self.get_object()
+        position = get_move_to_position_param(request)
+        instance.to(position)
+        return Response(status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["get"])
     def delay_options(self, request):

--- a/engine/apps/public_api/views/maintaiable_object_mixin.py
+++ b/engine/apps/public_api/views/maintaiable_object_mixin.py
@@ -15,6 +15,8 @@ class MaintainableObjectMixin(viewsets.ViewSet):
 
     @action(detail=True, methods=["post"])
     def maintenance_start(self, request, pk) -> Response:
+        instance = self.get_object()
+
         mode = str(request.data.get("mode", None)).lower()
         duration = request.data.get("duration", None)
 
@@ -31,7 +33,6 @@ class MaintainableObjectMixin(viewsets.ViewSet):
         except (ValueError, TypeError):
             raise BadRequest(detail={"duration": ["Invalid duration"]})
 
-        instance = self.get_object()
         try:
             instance.start_maintenance(mode, duration, request.user)
         except MaintenanceCouldNotBeStartedError as e:

--- a/engine/apps/public_api/views/schedules.py
+++ b/engine/apps/public_api/views/schedules.py
@@ -41,6 +41,9 @@ class OnCallScheduleChannelView(RateLimitHeadersMixin, UpdateSerializerMixin, Mo
     filter_backends = (filters.DjangoFilterBackend,)
     filterset_class = ByTeamFilter
 
+    # self.get_object() is not used in export action because ScheduleExportAuthentication is used
+    extra_actions_ignore_no_get_object = ["export"]
+
     def get_queryset(self):
         name = self.request.query_params.get("name", None)
 

--- a/engine/apps/public_api/views/users.py
+++ b/engine/apps/public_api/views/users.py
@@ -48,6 +48,9 @@ class UserView(RateLimitHeadersMixin, ShortSerializerMixin, ReadOnlyModelViewSet
 
     throttle_classes = [UserThrottle]
 
+    # self.get_object() is not used in export action because UserScheduleExportAuthentication is used
+    extra_actions_ignore_no_get_object = ["schedule_export"]
+
     def get_queryset(self):
         if is_request_from_terraform(self.request):
             sync_users_on_tf_request(self.request.auth.organization)

--- a/engine/common/api_helpers/mixins.py
+++ b/engine/common/api_helpers/mixins.py
@@ -300,6 +300,13 @@ class PreviewTemplateMixin:
         template_name = request.data.get("template_name", None)
         payload = request.data.get("payload", None)
 
+        try:
+            alert_to_template = self.get_alert_to_template(payload=payload)
+            if alert_to_template is None:
+                raise BadRequest(detail="Alert to preview does not exist")
+        except PreviewTemplateException as e:
+            raise BadRequest(detail=str(e))
+
         if template_body is None or template_name is None:
             response = {"preview": None}
             return Response(response, status=status.HTTP_200_OK)
@@ -314,13 +321,6 @@ class PreviewTemplateMixin:
                 raise BadRequest(detail={"notification_channel": "notification_channel is required"})
             if notification_channel not in NOTIFICATION_CHANNEL_OPTIONS:
                 raise BadRequest(detail={"notification_channel": "Unknown notification_channel"})
-
-        try:
-            alert_to_template = self.get_alert_to_template(payload=payload)
-            if alert_to_template is None:
-                raise BadRequest(detail="Alert to preview does not exist")
-        except PreviewTemplateException as e:
-            raise BadRequest(detail=str(e))
 
         if attr_name in APPEARANCE_TEMPLATE_NAMES:
 

--- a/engine/common/api_helpers/serializers.py
+++ b/engine/common/api_helpers/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+from rest_framework.request import Request
+
+
+def get_move_to_position_param(request: Request):
+    """
+    Get "position" parameter from query params + validate it.
+    Used by actions on ordered models (e.g. move_to_position).
+    """
+
+    class MoveToPositionQueryParamsSerializer(serializers.Serializer):
+        position = serializers.IntegerField()
+
+    serializer = MoveToPositionQueryParamsSerializer(data=request.query_params)
+    serializer.is_valid(raise_exception=True)
+
+    return serializer.validated_data["position"]

--- a/engine/common/tests/test_viewset_actions.py
+++ b/engine/common/tests/test_viewset_actions.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.test import APIClient
+
+from apps.api.urls import router as internal_api_router
+from apps.public_api.urls import router as public_api_router
+
+
+@pytest.mark.parametrize(
+    "basename,viewset_class,action",
+    [
+        # Collect all detail actions from all viewsets registered in internal API router
+        (basename, viewset_class, action)
+        for _, viewset_class, basename in internal_api_router.registry
+        for action in viewset_class.get_extra_actions()
+        if action.detail
+    ],
+)
+@pytest.mark.django_db
+def test_internal_api_detail_actions_get_object(
+    make_organization_and_user_with_plugin_token, make_user_auth_headers, basename, viewset_class, action
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    client = APIClient()
+
+    url = reverse(f"api-internal:{basename}-{action.url_name}", kwargs={"pk": "NONEXISTENT"})
+
+    with patch.object(viewset_class, "get_object", side_effect=NotFound) as mock_get_object:
+        response = client.generic(
+            path=url, method=list(action.mapping.keys())[0], **make_user_auth_headers(user, token)
+        )
+
+    """
+    If you see this errors in tests, make sure to call self.get_object() in action method that's added / changed.
+    Call to self.get_object() must come before any additional checks. For example, call to self.get_object() must come
+    before checking for request data that may result in 400 Bad Request (i.e. check for 404 must come before check for 400).
+    This is required to ensure all detail actions are safe, consistent with each other and easily testable.
+    """
+    assert response.status_code == status.HTTP_404_NOT_FOUND, "check for 404 must come before any additional checks"
+    assert (
+        mock_get_object.call_count == 1
+    ), f"self.get_object() must be called in {viewset_class.__class__.__name__}.{action.__name__}"
+
+
+@pytest.mark.parametrize(
+    "basename,viewset_class,action",
+    [
+        # Collect all detail actions from all viewsets registered in public API router
+        (basename, viewset_class, action)
+        for _, viewset_class, basename in public_api_router.registry
+        for action in viewset_class.get_extra_actions()
+        if action.detail and action.url_path not in getattr(viewset_class, "extra_actions_ignore_no_get_object", [])
+    ],
+)
+@pytest.mark.django_db
+def test_public_api_detail_actions_get_object(make_organization_and_user_with_token, basename, viewset_class, action):
+    organization, user, token = make_organization_and_user_with_token()
+    client = APIClient()
+
+    url = reverse(f"api-public:{basename}-{action.url_name}", kwargs={"pk": "NONEXISTENT"})
+
+    with patch.object(viewset_class, "get_object", side_effect=NotFound) as mock_get_object:
+        response = client.generic(path=url, method=list(action.mapping.keys())[0], HTTP_AUTHORIZATION=token)
+
+    """
+    If you see this errors in tests, make sure to call self.get_object() in action method that's added / changed.
+    Call to self.get_object() must come before any additional checks. For example, call to self.get_object() must come
+    before checking for request data that may result in 400 Bad Request (i.e. check for 404 must come before check for 400).
+    This is required to ensure all detail actions are safe, consistent with each other and easily testable.
+    In rare cases when self.get_object() is not needed (e.g. because object is identified by authentication class),
+    pass "extra_actions_ignore_no_get_object" to viewset class. Actions listed in extra_actions_ignore_no_get_object
+    will be ignored by this test.
+    """
+    assert response.status_code == status.HTTP_404_NOT_FOUND, "check for 404 must come before any additional checks"
+    assert (
+        mock_get_object.call_count == 1
+    ), f"self.get_object() must be called in {viewset_class.__class__.__name__}.{action.__name__}"

--- a/engine/common/tests/test_viewset_actions.py
+++ b/engine/common/tests/test_viewset_actions.py
@@ -30,9 +30,8 @@ def test_internal_api_detail_actions_get_object(
     url = reverse(f"api-internal:{basename}-{action.url_name}", kwargs={"pk": "NONEXISTENT"})
 
     with patch.object(viewset_class, "get_object", side_effect=NotFound) as mock_get_object:
-        response = client.generic(
-            path=url, method=list(action.mapping.keys())[0], **make_user_auth_headers(user, token)
-        )
+        method = list(action.mapping.keys())[0]  # get the first allowed method
+        response = client.generic(path=url, method=method, **make_user_auth_headers(user, token))
 
     """
     If you see this errors in tests, make sure to call self.get_object() in action method that's added / changed.
@@ -64,7 +63,8 @@ def test_public_api_detail_actions_get_object(make_organization_and_user_with_to
     url = reverse(f"api-public:{basename}-{action.url_name}", kwargs={"pk": "NONEXISTENT"})
 
     with patch.object(viewset_class, "get_object", side_effect=NotFound) as mock_get_object:
-        response = client.generic(path=url, method=list(action.mapping.keys())[0], HTTP_AUTHORIZATION=token)
+        method = list(action.mapping.keys())[0]  # get the first allowed method
+        response = client.generic(path=url, method=method, HTTP_AUTHORIZATION=token)
 
     """
     If you see this errors in tests, make sure to call self.get_object() in action method that's added / changed.


### PR DESCRIPTION
# What this PR does

Makes sure that all viewset actions with `detail=True` use `self.get_object()` to retrieve an instance that's being acted upon.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
