### PR TITLE
Update shift week_start when translating to UTC

### DIFF
--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -46,6 +46,7 @@ def test_create_on_call_shift_rotation(on_call_shift_internal_api_setup, make_us
             CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
             CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.FRIDAY],
         ],
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
         "rolling_users": [[user1.public_primary_key], [user2.public_primary_key]],
     }
 
@@ -86,6 +87,7 @@ def test_create_on_call_shift_override(on_call_shift_internal_api_setup, make_us
         "id": response.data["id"],
         "updated_shift": None,
         "rolling_users": returned_rolling_users,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
     }
 
     assert response.status_code == status.HTTP_201_CREATED
@@ -130,6 +132,7 @@ def test_get_on_call_shift(
         "frequency": None,
         "interval": None,
         "by_day": None,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.SUNDAY],
         "rolling_users": [[user1.public_primary_key], [user2.public_primary_key]],
         "updated_shift": None,
     }
@@ -180,6 +183,7 @@ def test_list_on_call_shift(
                 "frequency": None,
                 "interval": None,
                 "by_day": None,
+                "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.SUNDAY],
                 "rolling_users": [[user1.public_primary_key], [user2.public_primary_key]],
                 "updated_shift": None,
             }
@@ -237,6 +241,7 @@ def test_list_on_call_shift_filter_schedule_id(
                 "frequency": None,
                 "interval": None,
                 "by_day": None,
+                "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.SUNDAY],
                 "rolling_users": [[user1.public_primary_key], [user2.public_primary_key]],
                 "updated_shift": None,
             }
@@ -318,6 +323,7 @@ def test_update_future_on_call_shift(
         "frequency": None,
         "interval": None,
         "by_day": None,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
         "rolling_users": [[user1.public_primary_key]],
         "updated_shift": None,
     }
@@ -385,6 +391,7 @@ def test_update_started_on_call_shift(
         "frequency": None,
         "interval": None,
         "by_day": None,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
         "rolling_users": [[user1.public_primary_key]],
         "updated_shift": None,
     }
@@ -434,6 +441,7 @@ def test_update_started_on_call_shift_force_update(
         "frequency": None,
         "interval": None,
         "by_day": None,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.SUNDAY],
         "rolling_users": [[user1.public_primary_key]],
     }
 
@@ -525,6 +533,7 @@ def test_update_old_on_call_shift_with_future_version(
         "type": CustomOnCallShift.TYPE_ROLLING_USERS_EVENT,
         "schedule": schedule.public_primary_key,
         "updated_shift": None,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -579,6 +588,7 @@ def test_update_started_on_call_shift_title(
         "frequency": None,
         "interval": None,
         "by_day": None,
+        "week_start": "MO",
         "rolling_users": [[user1.public_primary_key]],
     }
 
@@ -593,6 +603,7 @@ def test_update_started_on_call_shift_title(
         "type": CustomOnCallShift.TYPE_ROLLING_USERS_EVENT,
         "schedule": schedule.public_primary_key,
         "updated_shift": None,
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
     }
 
     assert response.status_code == status.HTTP_200_OK

--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -25,7 +25,13 @@ import { Schedule, Shift } from 'models/schedule/schedule.types';
 import { getTzOffsetString } from 'models/timezone/timezone.helpers';
 import { Timezone } from 'models/timezone/timezone.types';
 import { User } from 'models/user/user.types';
-import { getDateTime, getStartOfWeek, getUTCByDay, getUTCString } from 'pages/schedule/Schedule.helpers';
+import {
+  getDateTime,
+  getStartOfWeek,
+  getUTCByDay,
+  getUTCString,
+  getUTCWeekStart,
+} from 'pages/schedule/Schedule.helpers';
 import { SelectOption } from 'state/types';
 import { useStore } from 'state/useStore';
 import { getCoords, waitForElement } from 'utils/DOM';
@@ -164,6 +170,7 @@ const RotationForm: FC<RotationFormProps> = observer((props) => {
       interval: repeatEveryValue,
       frequency: repeatEveryPeriod,
       by_day: getUTCByDay(store.scheduleStore.byDayOptions, selectedDays, shiftStart),
+      week_start: getUTCWeekStart(store.scheduleStore.byDayOptions, shiftStart),
       priority_level: shiftId === 'new' ? layerPriority : shift?.priority_level,
     }),
     [

--- a/grafana-plugin/src/models/schedule/schedule.types.ts
+++ b/grafana-plugin/src/models/schedule/schedule.types.ts
@@ -58,6 +58,7 @@ export interface CreateScheduleExportTokenResponse {
 
 export interface Shift {
   by_day: string[];
+  week_start: string;
   frequency: number | null;
   id: string;
   interval: number;

--- a/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
+++ b/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
@@ -52,6 +52,26 @@ export const getUTCByDay = (dayOptions: SelectOption[], by_day: string[], moment
   return by_day;
 };
 
+export const getUTCWeekStart = (dayOptions: SelectOption[], moment: dayjs.Dayjs) => {
+  let week_start_index = 0;
+  let byDayOptions = [];
+  dayOptions.forEach(({ value }) => byDayOptions.push(value));
+  if (moment.day() !== moment.utc().day()) {
+    // when converting to UTC, shift starts on a different day,
+    // so we may need to change when week starts based on the UTC start time
+    // depending on the UTC side, move one day before or after
+    let offset = moment.utcOffset();
+    if (offset < 0) {
+      // move one day after
+      week_start_index = (week_start_index + 1) % 7;
+    } else {
+      // move one day before
+      week_start_index = (((week_start_index - 1) % 7) + 7) % 7;
+    }
+  }
+  return byDayOptions[week_start_index];
+};
+
 export const getColorSchemeMappingForUsers = (
   store: RootStore,
   scheduleId: string,


### PR DESCRIPTION
This fixes scenario described [here](https://github.com/grafana/oncall/issues/2118#issuecomment-1580499754).

When a rotation is setup in UTC+1, and the shift starts at 00:00 with Monday as active day and a weekly frequency, the values are translated to UTC when submitting to the backend, so the shift data becomes something like: shift starting at 23:00 on Sunday, but since week_start is on Monday, the "first event" in the week belongs to the "previous week". This can be addressed by moving the week_start, so a weekly shift that was starting on a Monday but in UTC tz starts on Sunday, "translates" to a UTC week_start on Sunday:

![rotation-example](https://github.com/grafana/oncall/assets/260710/5222d3ce-52b7-41d5-8ecb-d01c7a0139cb)


(this is with the proposed changes; otherwise you get the same issue linked above where the first event in the week is assigned to the other user group).

About selected week days changed when editing a rotation, see inline comment (related to [this](https://github.com/grafana/oncall/issues/1322#issuecomment-1521787786))