### PR TITLE
Update alert group view receive channel filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix receive channel filter in alert groups API [#2140](https://github.com/grafana/oncall/pull/2140)
+
 ## v1.2.41 (2023-06-08)
 
 ### Added

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -104,7 +104,7 @@ class AlertGroupFilter(DateRangeFilterMixin, ByTeamModelFieldFilterMixin, ModelF
         method=ModelFieldFilterMixin.filter_model_field.__name__,
     )
     integration = filters.ModelMultipleChoiceFilter(
-        field_name="channel_filter__alert_receive_channel",
+        field_name="channel",
         queryset=None,
         to_field_name="public_primary_key",
         method=ModelFieldFilterMixin.filter_model_field.__name__,


### PR DESCRIPTION
We were noticing some discrepancies in alert groups counts.

From a real example:

```
# queryset is the alert groups initial queryset
>>> qs = queryset.filter(channel_filter__alert_receive_channel=arc)
>>> qs.filter(resolved_at__isnull=False).count()
1318
>>> qs = queryset.filter(channel=arc)
>>> qs.filter(resolved_at__isnull=False).count()
1356
>>> qs.filter(resolved_at__isnull=False, channel_filter__isnull=True).count()
38
```