### PR TITLE
Fix for Filters discarding the query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed bug on Filters where team param from URL was discarded [#6237](https://github.com/grafana/support-escalations/issues/6237)
 - Fix receive channel filter in alert groups API [#2140](https://github.com/grafana/oncall/pull/2140)
 - Helm chart: Fix usage of `env` settings as map;
   Fix usage of `mariadb.auth.database` and `mariadb.auth.username` for MYSQL env variables by @alexintech [#2146](https://github.com/grafana/oncall/pull/2146)

--- a/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.helpers.ts
+++ b/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.helpers.ts
@@ -10,12 +10,18 @@ const normalize = (value: any) => {
   return value;
 };
 
-export function parseFilters(query: { [key: string]: any }, filterOptions: FilterOption[]) {
-  const filters = filterOptions.filter((filterOption: FilterOption) => filterOption.name in query);
+export function parseFilters(data: { [key: string]: any }, filterOptions: FilterOption[], query: { [key: string]: any}) {
+  const filters = filterOptions.filter((filterOption: FilterOption) => filterOption.name in data);
+
+  console.log({ filterOptions, filters })
 
   const values = filters.reduce((memo: any, filterOption: FilterOption) => {
-    const rawValue = query[filterOption.name];
+    const rawValue = query[filterOption.name] || data[filterOption.name]; // query takes priority over localstorage
+
+    console.log({ rawValue, name: filterOption.name })
+
     let value: any = rawValue;
+    
     if (filterOption.type === 'options' || filterOption.type === 'team_select') {
       if (!Array.isArray(rawValue)) {
         value = [rawValue];

--- a/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.helpers.ts
+++ b/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.helpers.ts
@@ -13,12 +13,8 @@ const normalize = (value: any) => {
 export function parseFilters(data: { [key: string]: any }, filterOptions: FilterOption[], query: { [key: string]: any}) {
   const filters = filterOptions.filter((filterOption: FilterOption) => filterOption.name in data);
 
-  console.log({ filterOptions, filters })
-
   const values = filters.reduce((memo: any, filterOption: FilterOption) => {
-    const rawValue = query[filterOption.name] || data[filterOption.name]; // query takes priority over localstorage
-
-    console.log({ rawValue, name: filterOption.name })
+    const rawValue = query[filterOption.name] || data[filterOption.name]; // query takes priority over local storage
 
     let value: any = rawValue;
     

--- a/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.tsx
+++ b/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.tsx
@@ -75,8 +75,6 @@ class RemoteFilters extends Component<RemoteFiltersProps, RemoteFiltersState> {
       ({ filters, values } = parseFilters(defaultFilters || { team: [] }, filterOptions, query));
     }
 
-    console.log('Called already parseFilters')
-
     this.setState({ filterOptions, filters, values }, () => this.onChange(true));
   }
 


### PR DESCRIPTION
# What this PR does

Original escalation: https://github.com/grafana/support-escalations/issues/6237

Now instead of always reading the values from local storage, we first check for query params instead and then for local storage. On the first render we skip re-updating the local storage, therefore if you visit alert groups with `team 1` and `team 2`, while local storage had `team 3`, this will not be overwritten but it **WILL** be once the teams value change in the dropdown.