### PR TITLE
Add field descriptions for webhooks

### DIFF
--- a/engine/apps/webhooks/tasks/trigger_webhook.py
+++ b/engine/apps/webhooks/tasks/trigger_webhook.py
@@ -106,7 +106,7 @@ def make_request(webhook, alert_group, data):
         "url": None,
         "request_trigger": None,
         "request_headers": None,
-        "request_data": data,
+        "request_data": None,
         "status_code": None,
         "content": None,
         "webhook": webhook,

--- a/grafana-plugin/src/containers/OutgoingWebhook2Form/OutgoingWebhook2Form.config.tsx
+++ b/grafana-plugin/src/containers/OutgoingWebhook2Form/OutgoingWebhook2Form.config.tsx
@@ -35,7 +35,7 @@ export const form: { name: string; fields: FormItem[] } = {
       name: 'team',
       label: 'Assign to Team',
       description:
-        'Assigning to the teams allows you to filter Outgoing Webhooks and configure their visibility. Go to OnCall -> Settings -> Team and Access Settings for more details',
+        'Assigning to the teams allows you to filter Outgoing Webhooks and configure their visibility. Go to OnCall -> Settings -> Team and Access Settings for more details. This setting does not effect execution of the webhook.',
       type: FormItemType.GSelect,
       extra: {
         modelName: 'grafanaTeamStore',
@@ -48,6 +48,7 @@ export const form: { name: string; fields: FormItem[] } = {
     {
       name: 'trigger_type',
       label: 'Trigger Type',
+      description: 'The type of event which will cause this webhook to execute.',
       type: FormItemType.Select,
       extra: {
         options: [
@@ -135,7 +136,7 @@ export const form: { name: string; fields: FormItem[] } = {
       },
       validation: { required: true },
       description:
-        'Integrations that this webhook applies to. If this is empty the webhook will apply to all integrations',
+        'Integrations that this webhook applies to. If this is empty the webhook will execute for all integrations',
     },
     {
       name: 'url',
@@ -146,6 +147,7 @@ export const form: { name: string; fields: FormItem[] } = {
     {
       name: 'headers',
       label: 'Webhook Headers',
+      description: 'Request headers should be in JSON format.',
       type: FormItemType.TextArea,
       extra: {
         rows: 3,
@@ -161,6 +163,8 @@ export const form: { name: string; fields: FormItem[] } = {
     },
     {
       name: 'authorization_header',
+      description:
+        'Value of the Authorization header, do not need to prefix with "Authorization:". For example: Bearer AbCdEf123456',
       type: FormItemType.Password,
     },
     {
@@ -176,13 +180,14 @@ export const form: { name: string; fields: FormItem[] } = {
       name: 'forward_all',
       normalize: (value) => Boolean(value),
       type: FormItemType.Switch,
-      description: "Forwards whole payload of the alert to the webhook's url as POST/PUT data",
+      description: "Forwards whole payload of the alert group and context data to the webhook's url as POST/PUT data",
     },
     {
       name: 'data',
       getDisabled: (data) => Boolean(data?.forward_all),
       type: FormItemType.TextArea,
-      description: 'Available variables: {{ alert_payload }}, {{ alert_group_id }}',
+      description:
+        'Available variables: {{ event }}, {{ user }}, {{ alert_group }}, {{ alert_group_id }}, {{ alert_payload }}, {{ integration }}, {{ notified_users }}, {{ users_to_be_notified }}, {{ responses }}',
       extra: {
         rows: 9,
       },


### PR DESCRIPTION
- Add descriptions for fields
- Change default value of request_data to avoid confusing situation where if there was a error before request data is built, like in the template for the request headers, request_data would be a python dict resulting in hard to read text in the UI status page.