### PR TITLE
Changed web schedule updates to sync refresh ical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change .Values.externalRabbitmq.passwordKey from `password` to `""` (default value `rabbitmq-password`) ([#864](https://github.com/grafana/oncall/pull/864))
 - Remove deprecated `permissions` string array from the internal API user serializer by @joeyorlando ([#2269](https://github.com/grafana/oncall/pull/2269))
+- Make web schedule updates to trigger sync refresh of its ical representation ([#2279](https://github.com/grafana/oncall/pull/2279))
 
 ### Added
 

--- a/engine/apps/api/serializers/on_call_shifts.py
+++ b/engine/apps/api/serializers/on_call_shifts.py
@@ -202,7 +202,9 @@ class OnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         self._require_users(validated_data)
         instance = super().create(validated_data)
 
-        instance.start_drop_ical_and_check_schedule_tasks(instance.schedule)
+        # refresh related schedule ical files
+        instance.refresh_schedule()
+
         return instance
 
 
@@ -240,5 +242,7 @@ class OnCallShiftUpdateSerializer(OnCallShiftSerializer):
         else:
             result = super().update(instance, validated_data)
 
-        instance.start_drop_ical_and_check_schedule_tasks(instance.schedule)
+        # refresh related schedule ical files
+        instance.refresh_schedule()
+
         return result


### PR DESCRIPTION
Updating a schedule using the web UI sometimes you don't get the change immediately available (since the ical refresh is async). 
Related to https://github.com/grafana/oncall/issues/1968