### PR TITLE
install requirements-dev.txt dependencies oncall docker image dev target

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -49,6 +49,7 @@ ENV prometheus_multiproc_dir "/tmp/prometheus_django_metrics"
 
 FROM base AS dev
 RUN apt-get install -y sqlite3 default-mysql-client postgresql-client
+RUN pip install -r requirements-dev.txt
 
 FROM dev AS dev-enterprise
 RUN pip install -r requirements-enterprise-docker.txt


### PR DESCRIPTION
# What this PR does

install `requirements-dev.txt` dependencies oncall docker image dev target to allow commands like `make test` to properly work. Otherwise you currently get:
```bash
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "pytest": executable file not found in $PATH: unknown
make: *** [test] Error 1
```

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
