### PR TITLE
use the official playwright docker image instead of reinstalling all deps manually

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -329,6 +329,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script
+      - name: Install docker binary
+        run: curl -fsSL https://get.docker.com -o get-docker.sh | sh
+
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0
         with:

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -306,6 +306,8 @@ jobs:
     # the oncall backend, and hence, flaky tests. Let's use CI runners w/ more resources to avoid this (plus
     # this will allow us to run more backend containers and parralelize the tests)
     runs-on: ubuntu-latest-8-cores
+    container:
+      image: mcr.microsoft.com/playwright:v1.35.1-jammy
     name: "End to end tests - Grafana: ${{ matrix.grafana-image-tag }}"
     strategy:
       matrix:
@@ -420,34 +422,6 @@ jobs:
             --set-json "grafana.plugins=[]" \
             --set-json 'grafana.extraVolumeMounts=[{"name":"plugins","mountPath":"/var/lib/grafana/plugins/grafana-plugin","hostPath":"/oncall-plugin","readOnly":true}]' \
             ./helm/oncall
-
-      # helpful reference for properly caching the playwright binaries/dependencies
-      # https://playwrightsolutions.com/playwright-github-action-to-cache-the-browser-binaries/
-      - name: Get installed Playwright version
-        id: playwright-version
-        working-directory: grafana-plugin
-        run: echo "PLAYWRIGHT_VERSION=$(cat ./package.json | jq -r '.devDependencies["@playwright/test"]')" >> $GITHUB_ENV
-
-      - name: Cache Playwright binaries/dependencies
-        id: playwright-cache
-        uses: actions/cache@v3
-        with:
-          path: "~/.cache/ms-playwright"
-          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}-chromium-firefox-webkit
-
-      # For the next two steps, use the binary directly from node_modules/.bin as opposed to npx playwright
-      # due to this bug (https://github.com/microsoft/playwright/issues/13188)
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        working-directory: grafana-plugin
-        run: ./node_modules/.bin/playwright install --with-deps chromium firefox webkit
-
-      # use the cached browsers, but we still need to install the necessary system dependencies
-      # (system deps are installed in the cache-miss step above by the --with-deps flag)
-      - name: Install Playwright System Dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        working-directory: grafana-plugin
-        run: ./node_modules/.bin/playwright install-deps chromium firefox webkit
 
       # we could instead use the --wait flag for the helm install command above
       # but there's no reason to block on that step

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -329,13 +329,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Collect Workflow Telemetry
-        uses: runforesight/workflow-telemetry-action@v1
-        with:
-          comment_on_pr: false
-          proc_trace_chart_show: false
-          proc_trace_table_show: false
-
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.3.0
         with:


### PR DESCRIPTION
# What this PR does

it takes a non-zero amount of time to properly install all of the playwright dependencies. Instead, let's use their official Docker image. Their documentation states [here](https://playwright.dev/docs/ci#via-containers) how to do this in GitHub Actions inside a container.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
