### PR TITLE
Remove unused prefetch_related in metrics task

### DIFF
--- a/engine/apps/metrics_exporter/tasks.py
+++ b/engine/apps/metrics_exporter/tasks.py
@@ -81,7 +81,6 @@ def calculate_and_cache_metrics(organization_id, force=False):
         AlertReceiveChannel.objects.using(get_random_readonly_database_key_if_present_otherwise_default())
         .filter(~Q(integration=AlertReceiveChannel.INTEGRATION_MAINTENANCE) & Q(organization_id=organization_id))
         .select_related("organization", "team")
-        .prefetch_related("alert_groups")
     )
 
     response_time_period = get_response_time_period()


### PR DESCRIPTION
The `prefecth_related` data here is not being used later (since we are applying filters not getting `.all`) and it is preloading all alert groups for integrations into memory (which can be a lot).