### PR TITLE
Fix phone call & SMS relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix phone call & SMS relay by @vadimkerr ([#2345](https://github.com/grafana/oncall/pull/2345))
+
 ## v1.3.0 (2023-06-26)
 
 ### Added

--- a/engine/apps/phone_notifications/phone_backend.py
+++ b/engine/apps/phone_notifications/phone_backend.py
@@ -268,7 +268,7 @@ class PhoneBackend:
         # additional cleaning, since message come from api call and wasn't cleaned by our renderer
         message = clean_markup(message).replace('"', "")
 
-        self.phone_provider.make_call(message, user.verified_phone_number)
+        self.phone_provider.make_call(user.verified_phone_number, message)
         # create PhoneCallRecord to track limits for calls from oss instances
         PhoneCallRecord.objects.create(
             receiver=user,
@@ -298,7 +298,7 @@ class PhoneBackend:
         elif sms_left < 3:
             message = self._add_sms_limit_warning(sms_left, message)
 
-        self.phone_provider.send_sms(message, user.verified_phone_number)
+        self.phone_provider.send_sms(user.verified_phone_number, message)
         SMSRecord.objects.create(
             receiver=user,
             exceeded_limit=False,

--- a/engine/apps/phone_notifications/tests/test_phone_backend_oss_relay.py
+++ b/engine/apps/phone_notifications/tests/test_phone_backend_oss_relay.py
@@ -28,7 +28,7 @@ def test_relay_oss_call(
     _, user = make_organization_and_user()
     phone_backend = PhoneBackend()
     phone_backend.relay_oss_call(user, "relayed_call")
-    assert mock_make_call.called
+    mock_make_call.assert_called_once_with(user.verified_phone_number, "relayed_call")
 
 
 @pytest.mark.django_db
@@ -66,7 +66,7 @@ def test_relay_oss_call_limit_exceed(
 @pytest.mark.django_db
 @mock.patch("apps.phone_notifications.phone_backend.PhoneBackend._validate_user_number", return_value=True)
 @mock.patch("apps.phone_notifications.phone_backend.PhoneBackend._validate_sms_left", return_value=10)
-@mock.patch("apps.phone_notifications.tests.mock_phone_provider.MockPhoneProvider.make_call")
+@mock.patch("apps.phone_notifications.tests.mock_phone_provider.MockPhoneProvider.send_sms")
 def test_relay_oss_sms(
     mock_send_sms,
     mock_validate_user_number,
@@ -75,8 +75,8 @@ def test_relay_oss_sms(
 ):
     _, user = make_organization_and_user()
     phone_backend = PhoneBackend()
-    phone_backend.relay_oss_call(user, "relayed_call")
-    assert mock_send_sms.called
+    phone_backend.relay_oss_sms(user, "relayed_sms")
+    mock_send_sms.assert_called_once_with(user.verified_phone_number, "relayed_sms")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# What this PR does

Fix incorrect order of arguments for phone provider method invocations when relaying phone calls and SMS from OSS instances.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
