### PR TITLE
Use correct slack key/display_name in templates

### DIFF
--- a/grafana-plugin/src/components/AlertTemplates/CommonAlertTemplatesForm.config.ts
+++ b/grafana-plugin/src/components/AlertTemplates/CommonAlertTemplatesForm.config.ts
@@ -33,8 +33,8 @@ export const commonTemplateForEdit: { [id: string]: TemplateForEdit } = {
     type: 'html',
   },
   slack_title_template: {
-    name: 'slack_title_template',
-    displayName: TemplateOptions.SlackTitle.key,
+    displayName: 'Slack title',
+    name: TemplateOptions.SlackTitle.key,
     description: '',
     additionalData: {
       chatOpsName: 'slack',
@@ -45,7 +45,7 @@ export const commonTemplateForEdit: { [id: string]: TemplateForEdit } = {
   },
   sms_title_template: {
     name: TemplateOptions.SMS.key,
-    displayName: 'Sms title',
+    displayName: 'SMS title',
     description: '',
     type: 'plain',
   },

--- a/grafana-plugin/src/components/AlertTemplates/CommonAlertTemplatesForm.config.ts
+++ b/grafana-plugin/src/components/AlertTemplates/CommonAlertTemplatesForm.config.ts
@@ -51,7 +51,7 @@ export const commonTemplateForEdit: { [id: string]: TemplateForEdit } = {
   },
   phone_call_title_template: {
     name: TemplateOptions.Phone.key,
-    displayName: 'Phone call title',
+    displayName: 'Phone Call title',
     description: '',
     type: 'plain',
   },

--- a/grafana-plugin/src/containers/IntegrationContainers/IntegrationCommonTemplatesList.config.ts
+++ b/grafana-plugin/src/containers/IntegrationContainers/IntegrationCommonTemplatesList.config.ts
@@ -67,7 +67,7 @@ export const commonTemplatesToRender: TemplateBlock[] = [
     ],
   },
   {
-    name: null,
+    name: 'Phone',
     contents: [
       {
         name: 'phone_call_title_template',


### PR DESCRIPTION
Slack was prior to this using the wrong key to display the name of the template