### PR TITLE
Fix 404 link for schedule quality

### DIFF
--- a/grafana-plugin/src/components/ScheduleQualityDetails/ScheduleQualityDetails.tsx
+++ b/grafana-plugin/src/components/ScheduleQualityDetails/ScheduleQualityDetails.tsx
@@ -112,7 +112,7 @@ export const ScheduleQualityDetails: FC<ScheduleQualityDetailsProps> = ({ qualit
             <Text type="primary" className={cx('text')}>
               The next 52 weeks (~1 year) are taken into account when generating the quality report. Refer to the{' '}
               <a
-                href={'https://grafana.com/docs/oncall/latest/calendar-schedules/web-schedule/#schedule-quality-report'}
+                href={'https://grafana.com/docs/oncall/latest/on-call-schedules/web-schedule/#schedule-quality-report'}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/grafana-plugin/src/components/ScheduleQualityDetails/ScheduleQualityDetails.tsx
+++ b/grafana-plugin/src/components/ScheduleQualityDetails/ScheduleQualityDetails.tsx
@@ -116,7 +116,7 @@ export const ScheduleQualityDetails: FC<ScheduleQualityDetailsProps> = ({ qualit
                 target="_blank"
                 rel="noreferrer"
               >
-                documentation
+                <Text type="link">documentation</Text>
               </a>{' '}
               for more details.
             </Text>


### PR DESCRIPTION
Fixes https://github.com/grafana/oncall/issues/2357

Old link (404): https://grafana.com/docs/oncall/latest/calendar-schedules/web-schedule/#schedule-quality-report 
New link: https://grafana.com/docs/oncall/latest/on-call-schedules/web-schedule/#schedule-quality-report