### PR TITLE
update rabbitmq docker containers to v3.12.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -144,7 +144,7 @@ steps:
 # Services for Unit Test Backend
 services:
   - name: rabbit_test
-    image: rabbitmq:3.7.19
+    image: rabbitmq:3.12.0
     environment:
       RABBITMQ_DEFAULT_USER: rabbitmq
       RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -418,6 +418,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 59ad498428731001484be9ac6b9d10685b2cd49f30eb3d97ed7dc99f031dca22
+hmac: e4d25ad9f26d0a2444033ec077029da50818d912fd24ba49c0a915947adffbab
 
 ...

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -96,7 +96,7 @@ jobs:
       SLACK_CLIENT_OAUTH_ID: 1
     services:
       rabbit_test:
-        image: rabbitmq:3.7.19
+        image: rabbitmq:3.12.0
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -148,7 +148,7 @@ jobs:
       ONCALL_TESTING_RBAC_ENABLED: ${{ matrix.rbac_enabled }}
     services:
       rabbit_test:
-        image: rabbitmq:3.7.19
+        image: rabbitmq:3.12.0
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq
@@ -192,7 +192,7 @@ jobs:
       ONCALL_TESTING_RBAC_ENABLED: ${{ matrix.rbac_enabled }}
     services:
       rabbit_test:
-        image: rabbitmq:3.7.19
+        image: rabbitmq:3.12.0
         env:
           RABBITMQ_DEFAULT_USER: rabbitmq
           RABBITMQ_DEFAULT_PASS: rabbitmq

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -179,7 +179,7 @@ services:
   rabbitmq:
     container_name: rabbitmq
     labels: *oncall-labels
-    image: "rabbitmq:3.7.15-management"
+    image: "rabbitmq:3.12.0-management"
     restart: always
     environment:
       RABBITMQ_DEFAULT_USER: "rabbitmq"

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -99,7 +99,7 @@ services:
           cpus: "0.1"
 
   rabbitmq:
-    image: "rabbitmq:3.7.15-management"
+    image: "rabbitmq:3.12.0-management"
     restart: always
     hostname: rabbitmq
     volumes:


### PR DESCRIPTION
# What this PR does

Update `rabbitmq` Docker containers used in the `docker-compose` config files, Drone pipelines, and GitHub Actions to use version 3.12.0.

FWIW, we're already using v12.0.0 of the bitnami `rabbitmq` `helm` chart which, by default, uses the `3.12.0-debian-11-r0` tag for the `rabbitmq` image ([chart docs](https://artifacthub.io/packages/helm/bitnami/rabbitmq/12.0.0)).

closes #695 

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required) (N/A)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required) (N/A)
