### PR TITLE
in the e2e tests, await the grafana instance if it is currently down/unavailable

### DIFF
--- a/grafana-plugin/.gitignore
+++ b/grafana-plugin/.gitignore
@@ -19,4 +19,4 @@ frontend_enterprise
 /test-results/
 /playwright-report/
 /playwright/.cache/
-storageState.json
+/integration-tests/storageState.json

--- a/grafana-plugin/integration-tests/globalSetup.ts
+++ b/grafana-plugin/integration-tests/globalSetup.ts
@@ -16,11 +16,16 @@ const makeGrafanaLoginRequest = async (browserContext: BrowserContext): Promise<
   });
 
 const pollGrafanaInstanceUntilItIsHealthy = async (browserContext: BrowserContext): Promise<boolean> => {
+  console.log('Polling the grafana instance to make sure it is healthy');
+
   const res = await makeGrafanaLoginRequest(browserContext);
 
   if (!res.ok()) {
+    console.log(`Grafana instance is unavailable. Got HTTP ${res.status()}. Will wait 5 seconds and then try again`);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
     return pollGrafanaInstanceUntilItIsHealthy(browserContext);
   }
+  console.log('Grafana instance is available');
   return true;
 };
 

--- a/grafana-plugin/playwright.config.ts
+++ b/grafana-plugin/playwright.config.ts
@@ -12,7 +12,6 @@ require('dotenv').config();
  */
 const config: PlaywrightTestConfig = {
   testDir: './integration-tests',
-  globalSetup: './integration-tests/globalSetup.ts',
   /* Maximum time one test can run for. */
   timeout: 60 * 1000,
   expect: {
@@ -54,22 +53,29 @@ const config: PlaywrightTestConfig = {
   /* Configure projects for major browsers */
   projects: [
     {
+      name: 'setup',
+      testMatch: /globalSetup\.ts/,
+    },
+    {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
       },
+      dependencies: ['setup'],
     },
     {
       name: 'firefox',
       use: {
         ...devices['Desktop Firefox'],
       },
+      dependencies: ['setup'],
     },
     {
       name: 'webkit',
       use: {
         ...devices['Desktop Safari'],
       },
+      dependencies: ['setup'],
     },
 
     /* Test against mobile viewports. */

--- a/grafana-plugin/playwright.config.ts
+++ b/grafana-plugin/playwright.config.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
@@ -6,6 +8,8 @@ import { devices } from '@playwright/test';
  * https://github.com/motdotla/dotenv
  */
 require('dotenv').config();
+
+export const STORAGE_STATE = path.join(__dirname, 'integration-tests/storageState.json');
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -37,8 +41,6 @@ const config: PlaywrightTestConfig = {
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    storageState: './storageState.json',
-
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -60,6 +62,7 @@ const config: PlaywrightTestConfig = {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        storageState: STORAGE_STATE,
       },
       dependencies: ['setup'],
     },
@@ -67,6 +70,7 @@ const config: PlaywrightTestConfig = {
       name: 'firefox',
       use: {
         ...devices['Desktop Firefox'],
+        storageState: STORAGE_STATE,
       },
       dependencies: ['setup'],
     },
@@ -74,6 +78,7 @@ const config: PlaywrightTestConfig = {
       name: 'webkit',
       use: {
         ...devices['Desktop Safari'],
+        storageState: STORAGE_STATE,
       },
       dependencies: ['setup'],
     },


### PR DESCRIPTION
# What this PR does

In the e2e tests, await the grafana instance if it is currently down/unavailable. This is mostly useful for when the tests are run against a hosted grafana instance and it is possible that the instance is paused ([example build](https://drone.grafana.net/grafana/oncall-private/5735/1/4)).

https://www.loom.com/share/35eb49035d454ac6ba306cddfe63f255

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required) (N/A)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required) (N/A)
