### PR TITLE
use docker buildx native multiarch image support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -224,10 +224,8 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: OSS engine release (amd64)
-platform:
-  os: linux
-  arch: amd64
+name: OSS engine release
+
 steps:
   - name: set engine version
     image: alpine
@@ -244,7 +242,8 @@ steps:
       DOCKER_BUILDKIT: 1
     settings:
       repo: grafana/oncall
-      tags: ${DRONE_TAG}-amd64-linux
+      tags: ${DRONE_TAG}
+      platform: linux/arm64/v8,linux/amd64
       dockerfile: engine/Dockerfile
       target: prod
       context: engine/
@@ -254,90 +253,6 @@ steps:
         from_secret: docker_username
     depends_on:
       - set engine version
-
-trigger:
-  event:
-    - promote
-  target:
-    - oss
-  ref:
-    - refs/tags/v*.*.*
-
----
-kind: pipeline
-type: docker
-name: OSS engine release (arm64)
-platform:
-  os: linux
-  arch: arm64
-steps:
-  - name: set engine version
-    image: alpine
-    commands:
-      - apk add --no-cache bash sed
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else sed "0,/VERSION.*/ s/VERSION.*/VERSION = \"${DRONE_TAG}\"/g" engine/settings/base.py > engine/settings/base.temp && mv engine/settings/base.temp engine/settings/base.py; fi
-      - cat engine/settings/base.py | grep VERSION | head -1
-
-  - name: build and push docker image
-    image: plugins/docker
-    environment:
-      # force docker to use buildkit feature, this will skip build stages that aren't required in the final image (ie. dev & dev-enterprise)
-      # https://github.com/docker/cli/issues/1134#issuecomment-406449342
-      DOCKER_BUILDKIT: 1
-    settings:
-      repo: grafana/oncall
-      tags: ${DRONE_TAG}-arm64-linux
-      dockerfile: engine/Dockerfile
-      target: prod
-      context: engine/
-      password:
-        from_secret: docker_password
-      username:
-        from_secret: docker_username
-    depends_on:
-      - set engine version
-
-trigger:
-  event:
-    - promote
-  target:
-    - oss
-  ref:
-    - refs/tags/v*.*.*
-
----
-depends_on:
-  - OSS engine release (amd64)
-  - OSS engine release (arm64)
-kind: pipeline
-type: docker
-name: manifest
-steps:
-  - name: manifest tag
-    image: plugins/manifest
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "grafana/oncall:${DRONE_TAG}"
-      template: "grafana/oncall:${DRONE_TAG}-ARCH-OS"
-      platforms:
-        - linux/amd64
-        - linux/arm64
-
-  - name: manifest latest
-    image: plugins/manifest
-    settings:
-      username:
-        from_secret: docker_username
-      password:
-        from_secret: docker_password
-      target: "grafana/oncall:latest"
-      template: "grafana/oncall:${DRONE_TAG}-ARCH-OS"
-      platforms:
-        - linux/amd64
-        - linux/arm64
 
 trigger:
   event:
@@ -418,6 +333,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: e4d25ad9f26d0a2444033ec077029da50818d912fd24ba49c0a915947adffbab
+hmac: 610fb051f4361baa2621f6aa41c18b3afee5160492b30f5a5f23fcecf86f1b0c
 
 ...


### PR DESCRIPTION
# What this PR does

`docker buildx` natively supports multiarch builds. This means we no longer need to have duplicate `docker build` Drone steps + there is no longer a need for the manual "manifesting" step. This [blog post](https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/) from Docker perfectly summarizes the difference between what we do now vs. what this PR would do.

This would also get rid of pushing `vX.Y.Z-{architecture}` tagged images. These are redundant because modern `docker` clients can pull the appropriate image for the host OS, from a multiarch image:
<img width="618" alt="Screenshot 2023-06-28 at 12 54 09" src="https://github.com/grafana/oncall/assets/9406895/ce4cd0ef-b92e-4273-877d-a73818d9cc54">


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required) (N/A)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required) (N/A)
