### PR TITLE
Fix alerts order in public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Change alerts order for `/alert` public api endpoint [#1031](https://github.com/grafana/oncall/issues/1031)
+
 ## v1.3.2 (2023-06-29)
 
 ### Added

--- a/docs/sources/oncall-api-reference/alerts.md
+++ b/docs/sources/oncall-api-reference/alerts.md
@@ -24,7 +24,7 @@ The above command returns JSON structured in the following way:
     {
       "id": "AA74DN7T4JQB6",
       "alert_group_id": "I68T24C13IFW1",
-      "created_at": "2020-05-11T20:07:43Z",
+      "created_at": "2020-05-11T20:08:43Z",
       "payload": {
         "state": "alerting",
         "title": "[Alerting] Test notification",
@@ -74,7 +74,7 @@ The above command returns JSON structured in the following way:
     {
       "id": "AWJQSGEYYUFGH",
       "alert_group_id": "I68T24C13IFW1",
-      "created_at": "2020-05-11T20:07:58Z",
+      "created_at": "2020-05-11T20:06:58Z",
       "payload": {
         "state": "alerting",
         "title": "[Alerting] Test notification",

--- a/engine/apps/public_api/tests/test_alerts.py
+++ b/engine/apps/public_api/tests/test_alerts.py
@@ -40,7 +40,8 @@ def test_get_list_alerts(
     # https://api-docs.amixr.io/#list-alerts
     organization, alert_receive_channel, default_channel_filter = alert_public_api_setup
     alert_group = make_alert_group(alert_receive_channel)
-    alert = make_alert(alert_group, alert_raw_request_data)
+    alert_1 = make_alert(alert_group, alert_raw_request_data)
+    alert_2 = make_alert(alert_group, alert_raw_request_data)
     admin = make_user_for_organization(organization)
     _, token = make_public_api_token(admin, organization)
 
@@ -50,14 +51,14 @@ def test_get_list_alerts(
     response = client.get(url, HTTP_AUTHORIZATION=f"{token}")
 
     expected_response = {
-        "count": 1,
+        "count": 2,
         "next": None,
         "previous": None,
         "results": [
             {
-                "id": alert.public_primary_key,
+                "id": alert_2.public_primary_key,
                 "alert_group_id": alert_group.public_primary_key,
-                "created_at": alert.created_at.isoformat().replace("+00:00", "Z"),
+                "created_at": alert_2.created_at.isoformat().replace("+00:00", "Z"),
                 "payload": {
                     "state": "alerting",
                     "title": "[Alerting] Test notification",
@@ -70,7 +71,24 @@ def test_get_list_alerts(
                         {"tags": None, "value": 200, "metric": "Higher Value"},
                     ],
                 },
-            }
+            },
+            {
+                "id": alert_1.public_primary_key,
+                "alert_group_id": alert_group.public_primary_key,
+                "created_at": alert_1.created_at.isoformat().replace("+00:00", "Z"),
+                "payload": {
+                    "state": "alerting",
+                    "title": "[Alerting] Test notification",
+                    "ruleId": 0,
+                    "message": "Someone is testing the alert notification within grafana.",
+                    "ruleUrl": "http://localhost:3000/",
+                    "ruleName": "Test notification",
+                    "evalMatches": [
+                        {"tags": None, "value": 100, "metric": "High value"},
+                        {"tags": None, "value": 200, "metric": "Higher Value"},
+                    ],
+                },
+            },
         ],
     }
     assert response.status_code == status.HTTP_200_OK

--- a/engine/apps/public_api/views/alerts.py
+++ b/engine/apps/public_api/views/alerts.py
@@ -46,4 +46,4 @@ class AlertView(RateLimitHeadersMixin, mixins.ListModelMixin, GenericViewSet):
 
         queryset = self.serializer_class.setup_eager_loading(queryset)
 
-        return queryset.order_by("id")
+        return queryset.order_by("-id")


### PR DESCRIPTION
# What this PR does
Change alerts order in `/alert` public api endpoint

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/1031

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
