### PR TITLE
fix mypy return errors

### DIFF
--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -393,7 +393,7 @@ def should_we_send_going_oncall_push_notification(
 
     if not user_wants_to_receive_info_notifications:
         logger.info("not sending going oncall push notification because info_notifications_enabled is false")
-        return
+        return None
 
     # 14 minute window where the notification could be sent (7 mins before or 7 mins after)
     timing_window_lower = user_notification_timing_preference - NOTIFICATION_TIMING_BUFFER
@@ -421,6 +421,7 @@ def should_we_send_going_oncall_push_notification(
         logger.info(f"timing is right to send going oncall push notification\n{timing_logging_msg}")
         return seconds_until_shift_starts
     logger.info(f"timing is not right to send going oncall push notification\n{timing_logging_msg}")
+    return None
 
 
 def _generate_going_oncall_push_notification_cache_key(user_pk: str, schedule_event: ScheduleEvent) -> str:

--- a/engine/apps/slack/scenarios/step_mixins.py
+++ b/engine/apps/slack/scenarios/step_mixins.py
@@ -135,6 +135,7 @@ class AlertGroupActionsMixin:
                 continue
 
             return AlertGroup.all_objects.get(pk=alert_group_pk)
+        return None
 
     def _get_alert_group_from_slack_message_in_db(
         self, slack_team_identity: SlackTeamIdentity, payload: dict

--- a/engine/apps/telegram/updates/update_handlers/button_press.py
+++ b/engine/apps/telegram/updates/update_handlers/button_press.py
@@ -50,8 +50,7 @@ class ButtonPressHandler(UpdateHandler):
             telegram_chat_id=self.update.effective_user.id,
             user__organization=action_context.alert_group.channel.organization,
         ).last()
-        if connector is not None:
-            return connector.user
+        return connector.user if connector is not None else None
 
     @staticmethod
     def _check_permission(user: Optional[User], alert_group: AlertGroup) -> bool:

--- a/engine/apps/telegram/updates/update_manager.py
+++ b/engine/apps/telegram/updates/update_manager.py
@@ -39,6 +39,7 @@ class UpdateManager:
             handler = handler_class(update)
             if handler.matches():
                 return handler
+        return None
 
     @classmethod
     def process_request(cls, request: Request) -> None:

--- a/engine/apps/twilioapp/phone_provider.py
+++ b/engine/apps/twilioapp/phone_provider.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 class TwilioPhoneProvider(PhoneProvider):
-    def make_notification_call(self, number: str, message: str) -> TwilioPhoneCall:
+    def make_notification_call(self, number: str, message: str) -> TwilioPhoneCall | None:
         message = self._escape_call_message(message)
 
         twiml_query = self._message_to_twiml(message, with_gather=True)
@@ -57,8 +57,9 @@ class TwilioPhoneProvider(PhoneProvider):
                 status=TwilioCallStatuses.DETERMINANT.get(response.status, None),
                 sid=response.sid,
             )
+        return None
 
-    def send_notification_sms(self, number: str, message: str) -> TwilioSMS:
+    def send_notification_sms(self, number: str, message: str) -> TwilioSMS | None:
         try_without_callback = False
         response = None
 
@@ -86,6 +87,7 @@ class TwilioPhoneProvider(PhoneProvider):
                 status=TwilioCallStatuses.DETERMINANT.get(response.status, None),
                 sid=response.sid,
             )
+        return None
 
     def send_verification_sms(self, number: str):
         self._send_verification_code(number, via="sms")

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -38,7 +38,6 @@ disable_error_code = [
     "name-defined",
     "no-redef",
     "operator",
-    "return",
     "return-value",
     "typeddict-item",
     "union-attr",


### PR DESCRIPTION
# What this PR does

Fix the following `return` `mypy` errors (related to #2392):

```bash
❯ mypy .
apps/telegram/updates/update_manager.py:36: error: Missing return statement  [return]
apps/slack/scenarios/step_mixins.py:109: error: Missing return statement  [return]
apps/mobile_app/tasks.py:368: error: Missing return statement  [return]
apps/telegram/updates/update_handlers/button_press.py:48: error: Missing return statement  [return]
apps/twilioapp/phone_provider.py:28: error: Missing return statement  [return]
apps/twilioapp/phone_provider.py:61: error: Missing return statement  [return]
Found 6 errors in 5 files (checked 595 source files)
```

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
