### PR TITLE
Add full avatar URL for on-call users in schedule internal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add full avatar URL for on-call users in schedule internal API by @vadimkerr ([#2414](https://github.com/grafana/oncall/pull/2414))
+
 ## v1.3.3 (2023-06-29)
 
 ### Added

--- a/engine/apps/user_management/models/user.py
+++ b/engine/apps/user_management/models/user.py
@@ -270,7 +270,12 @@ class User(models.Model):
         self._timezone = value
 
     def short(self):
-        return {"username": self.username, "pk": self.public_primary_key, "avatar": self.avatar_url}
+        return {
+            "username": self.username,
+            "pk": self.public_primary_key,
+            "avatar": self.avatar_url,
+            "avatar_full": self.avatar_full_url,
+        }
 
     # Insight logs
     @property


### PR DESCRIPTION
# What this PR does

Adds full avatar URL for on-call users in schedule internal API (`avatar_full`).

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
