### PR TITLE
Add organization moved exception to mobile app auth

### DIFF
--- a/engine/apps/mobile_app/auth.py
+++ b/engine/apps/mobile_app/auth.py
@@ -4,7 +4,7 @@ from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 
 from apps.auth_token.exceptions import InvalidToken
-from apps.user_management.exceptions import OrganizationMovedException
+from apps.user_management.exceptions import OrganizationDeletedException, OrganizationMovedException
 from apps.user_management.models import User
 
 from .models import MobileAppAuthToken, MobileAppVerificationToken
@@ -45,5 +45,7 @@ class MobileAppAuthTokenAuthentication(BaseAuthentication):
 
         if auth_token.organization.is_moved:
             raise OrganizationMovedException(auth_token.organization)
+        if auth_token.organization.deleted_at:
+            raise OrganizationDeletedException(auth_token.organization)
 
         return auth_token.user, auth_token

--- a/engine/apps/mobile_app/auth.py
+++ b/engine/apps/mobile_app/auth.py
@@ -4,6 +4,7 @@ from rest_framework import exceptions
 from rest_framework.authentication import BaseAuthentication, get_authorization_header
 
 from apps.auth_token.exceptions import InvalidToken
+from apps.user_management.exceptions import OrganizationMovedException
 from apps.user_management.models import User
 
 from .models import MobileAppAuthToken, MobileAppVerificationToken
@@ -41,5 +42,8 @@ class MobileAppAuthTokenAuthentication(BaseAuthentication):
             auth_token = self.model.validate_token_string(token_string)
         except InvalidToken:
             return None, None
+
+        if auth_token.organization.is_moved:
+            raise OrganizationMovedException(auth_token.organization)
 
         return auth_token.user, auth_token

--- a/engine/apps/user_management/middlewares.py
+++ b/engine/apps/user_management/middlewares.py
@@ -46,6 +46,8 @@ class OrganizationMovedMiddleware(MiddlewareMixin):
             return requests.delete(url, headers=headers)
         elif method == "OPTIONS":
             return requests.options(url, headers=headers)
+        elif method == "PATCH":
+            return requests.patch(url, data=body, headers=headers)
 
 
 class OrganizationDeletedMiddleware(MiddlewareMixin):


### PR DESCRIPTION
# What this PR does

Add organization moved exception to mobile app auth to redirect requests to correct region

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
