### PR TITLE
adjust frontmatter weight and add menu title

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -9,7 +9,8 @@ keywords:
   - OnCall
   - irm
 title: Grafana OnCall
-weight: 1000
+menuTitle: OnCall
+weight: 500
 ---
 
 # Grafana OnCall documentation


### PR DESCRIPTION
The doc squad is restructuring the Grafana Cloud TOC to align with UI navigation. This PR makes minor changes to the source _index.md file frontmatter in support of these changes.

Changed weight to 500 to manipulate order or doc sets and added menuTitle field to remove "Grafana" from TOC title for consistency.
