### PR TITLE
Fix cuddled list Markdown issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Address issue where we were improperly parsing Grafana feature flags that were enabled via the `feature_flags.enabled`
   method by @joeyorlando ([#2477](https://github.com/grafana/oncall/pull/2477))
+- Fix cuddled list Markdown issue by @vadimkerr ([#2488](https://github.com/grafana/oncall/pull/2488))
 
 ## v1.3.7 (2023-07-06)
 

--- a/engine/common/tests/test_markup.py
+++ b/engine/common/tests/test_markup.py
@@ -1,4 +1,4 @@
-from common.utils import clean_markup
+from common.utils import clean_markup, convert_md_to_html
 
 
 def test_clean_code_blocks_name():
@@ -42,3 +42,15 @@ def test_clean_mailto():
     expected = "bob@example.com"
 
     assert clean_markup(original) == expected
+
+
+def test_convert_md_to_html_basic():
+    md = "This is a test, **This is bold**, *This is italic*"
+    expected = "<p>This is a test, <strong>This is bold</strong>, <em>This is italic</em></p>"
+    assert convert_md_to_html(md) == expected
+
+
+def test_convert_md_to_html_bad_cuddled_list():
+    md = "- - "
+    expected = "<p>- - </p>"
+    assert convert_md_to_html(md) == expected

--- a/engine/common/utils.py
+++ b/engine/common/utils.py
@@ -163,23 +163,34 @@ def convert_md_to_html(text):
     # Adding two spaces to any line break to support templates that were built without this in mind.
     # https://daringfireball.net/projects/markdown/syntax#p
     text = text.replace("\n", "  \n")
-    text = markdown2.markdown(
-        text,
-        extras=[
-            "cuddled-lists",
-            "code-friendly",  # Disable _ and __ for em and strong.
-            # This gives us <pre> and <code> tags for ```-fenced blocks
-            "fenced-code-blocks",
-            "pyshell",
-            "nl2br",
-            "target-blank-links",
-            "nofollow",
-            "pymdownx.emoji",
-            "pymdownx.magiclink",
-            "tables",
-        ],
-    ).strip()
-    return text
+
+    extras = {
+        "cuddled-lists",
+        "code-friendly",  # Disable _ and __ for em and strong.
+        # This gives us <pre> and <code> tags for ```-fenced blocks
+        "fenced-code-blocks",
+        "pyshell",
+        "nl2br",
+        "target-blank-links",
+        "nofollow",
+        "pymdownx.emoji",
+        "pymdownx.magiclink",
+        "tables",
+    }
+    try:
+        text = markdown2.markdown(
+            text,
+            extras=extras,
+        )
+    except AssertionError:
+        # markdown2 raises an AssertionError when using the "cuddled-lists" extra and passing strings with "- - " in it.
+        # If the initial attempt fails, try again without the "cuddled-lists" extra.
+        text = markdown2.markdown(
+            text,
+            extras=extras - {"cuddled-lists"},
+        )
+
+    return text.strip()
 
 
 def clean_markup(text):


### PR DESCRIPTION
# What this PR does

Fixes an issue when alert group list page fails to load if any alert group on the page has `- - ` substring in its message.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
