### PR TITLE
Docs: Update oncall rbac detail

### DIFF
--- a/docs/sources/mobile-app/alert-groups-feed/index.md
+++ b/docs/sources/mobile-app/alert-groups-feed/index.md
@@ -26,7 +26,7 @@ Additionally, you can take action on the alert group directly from this page. Yo
 
 > **Note:** You need to have sufficient permission to take action on the alert group.
 > To learn more about Grafana OnCall user roles and permission,
-> refer to [this documentation]({{< relref "../user-and-team-management#user-roles-and-permissions" >}}).
+> refer to [this documentation]({{< relref "../../user-and-team-management#user-roles-and-permissions" >}}).
 
 <img src="/static/img/oncall/mobile-app-alertgroups.png" width="300px">
 <img src="/static/img/oncall/mobile-app-alertgroup.png" width="300px">

--- a/docs/sources/mobile-app/alert-groups-feed/index.md
+++ b/docs/sources/mobile-app/alert-groups-feed/index.md
@@ -17,9 +17,16 @@ On the **Feed** page, you can view Alert groups, under two tabs:
 - **Mine** shows Alert Groups that involve you in one way or another. E.g. because a notification went to you about it, or you resolved it.
 - **All** shows all Alert Groups, including ones that may not be relevant to you.
 
-You can filter by status via the **filter** button on the top right.  We are working on an expansion for this filter, to filter by team, integration name, and more.
+You can filter by status via the **filter** button on the top right. We are working on an expansion for this filter, to filter by team, integration name, and more.
 
-Tap on any Alert Group to go to the detailed view.  This page also provides links for opening in slack and sharing the link to this alert group.
+Tap on any Alert Group to go to the detailed view.
+From this page, you have various options available to you.
+You can open the alert group in Slack for further discussion and collaboration, as well as share the link to this specific alert group with others.
+Additionally, you can take action on the alert group directly from this page. You have the ability to acknowledge, resolve, and silence the alert group.
+
+> **Note:** You need to have sufficient permission to take action on the alert group.
+> To learn more about Grafana OnCall user roles and permission,
+> refer to [this documentation]({{< relref "../user-and-team-management#user-roles-and-permissions" >}}).
 
 <img src="/static/img/oncall/mobile-app-alertgroups.png" width="300px">
 <img src="/static/img/oncall/mobile-app-alertgroup.png" width="300px">

--- a/docs/sources/user-and-team-management/_index.md
+++ b/docs/sources/user-and-team-management/_index.md
@@ -53,6 +53,7 @@ To learn more about RBAC for Grafana OnCall, refer to the following documentatio
 
 - [Manage RBAC roles](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/manage-rbac-roles/#update-basic-role-permissions)
 - [RBAC permissions, actions, and scopes](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/custom-role-actions-scopes/)
+- [RBAC role definitions](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/#grafana-oncall-roles-beta)
 
 #### Available Grafana OnCall RBAC roles + granted actions
 


### PR DESCRIPTION
# What this PR does
- Update docs to callout permission requirement in mobile app doc for responding to alert group.
- Update link to RBAC fixed role doc for mapping between OnCall RBAC fixed role and Grafana basic role.
