### PR TITLE
Update team name: grafana/docs-oncall is now grafana/docs-gops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 CHANGELOG.md
 
 /grafana-plugin @grafana/grafana-oncall-frontend
-/docs @grafana/docs-oncall
+/docs @grafana/docs-gops


### PR DESCRIPTION
# What this PR does

Fixes the CODEOWNERS file which is marked as invalid because of the team name change.

The team will need to be given write access to the repository by a repository admin.

https://github.com/orgs/grafana/teams/docs-gops is the team.