### PR TITLE
outgoing webhooks 2 FE bunch of fixes #2

### DIFF
--- a/grafana-plugin/src/components/GForm/GForm.types.ts
+++ b/grafana-plugin/src/components/GForm/GForm.types.ts
@@ -14,7 +14,7 @@ export interface FormItem {
   name: string;
   label?: string;
   type: FormItemType;
-  isReadOnly?: boolean;
+  disabled?: boolean;
   description?: string;
   normalize?: (value: any) => any;
   isVisible?: (data: any) => any;

--- a/grafana-plugin/src/containers/OutgoingWebhook2Form/OutgoingWebhook2Form.config.tsx
+++ b/grafana-plugin/src/containers/OutgoingWebhook2Form/OutgoingWebhook2Form.config.tsx
@@ -152,7 +152,6 @@ export const form: { name: string; fields: FormItem[] } = {
       label: 'Webhook Headers',
       description: 'Request headers should be in JSON format.',
       type: FormItemType.Monaco,
-      isReadOnly: true,
       extra: {
         rows: 3,
       },
@@ -174,7 +173,6 @@ export const form: { name: string; fields: FormItem[] } = {
     {
       name: 'trigger_template',
       type: FormItemType.Monaco,
-      isReadOnly: true,
       description:
         'Trigger template is used to conditionally execute the webhook based on incoming data. The trigger template must be empty or evaluate to true or 1 for the webhook to be sent',
       extra: {
@@ -191,7 +189,6 @@ export const form: { name: string; fields: FormItem[] } = {
       name: 'data',
       getDisabled: (data) => Boolean(data?.forward_all),
       type: FormItemType.Monaco,
-      isReadOnly: true,
       description:
         'Available variables: {{ event }}, {{ user }}, {{ alert_group }}, {{ alert_group_id }}, {{ alert_payload }}, {{ integration }}, {{ notified_users }}, {{ users_to_be_notified }}, {{ responses }}',
       extra: {},

--- a/grafana-plugin/src/containers/OutgoingWebhook2Form/OutgoingWebhook2Form.tsx
+++ b/grafana-plugin/src/containers/OutgoingWebhook2Form/OutgoingWebhook2Form.tsx
@@ -68,12 +68,19 @@ const OutgoingWebhook2Form = observer((props: OutgoingWebhook2FormProps) => {
     };
   };
 
-  const enrchField = (formItem: FormItem, renderedControl: React.ReactElement, values, setFormFieldValue) => {
+  const enrchField = (
+    formItem: FormItem,
+    disabled: boolean,
+    renderedControl: React.ReactElement,
+    values,
+    setFormFieldValue
+  ) => {
     if (formItem.type === FormItemType.Monaco) {
       return (
         <div className={cx('form-row')}>
           <div className={cx('form-field')}>{renderedControl}</div>
           <Button
+            disabled={disabled}
             icon="edit"
             variant="secondary"
             onClick={getTemplateEditClickHandler(formItem, values, setFormFieldValue)}

--- a/grafana-plugin/src/containers/WebhooksTemplateEditor/WebhooksTemplateEditor.tsx
+++ b/grafana-plugin/src/containers/WebhooksTemplateEditor/WebhooksTemplateEditor.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { Button, Drawer, HorizontalGroup, VerticalGroup } from '@grafana/ui';
 import cn from 'classnames/bind';
 import { debounce } from 'lodash-es';
 
 import CheatSheet from 'components/CheatSheet/CheatSheet';
+import { genericTemplateCheatSheet } from 'components/CheatSheet/CheatSheet.config';
 import MonacoEditor from 'components/MonacoEditor/MonacoEditor';
 import Text from 'components/Text/Text';
 import styles from 'containers/IntegrationTemplate/IntegrationTemplate.module.scss';
@@ -32,7 +33,7 @@ interface WebhooksTemplateEditorProps {
 }
 
 const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ template, id, onHide, handleSubmit }) => {
-  const [isCheatSheetVisible] = useState(false);
+  const [isCheatSheetVisible, setIsCheatSheetVisible] = useState<boolean>(false);
   const [changedTemplateBody, setChangedTemplateBody] = useState<string>(template.value);
   const [editorHeight, setEditorHeight] = useState<string>(undefined);
   const [selectedPayload, setSelectedPayload] = useState(undefined);
@@ -70,6 +71,14 @@ const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ templat
       setSelectedPayload(undefined);
     }
   };
+
+  const onShowCheatSheet = useCallback(() => {
+    setIsCheatSheetVisible(true);
+  }, []);
+
+  const onCloseCheatSheet = useCallback(() => {
+    setIsCheatSheetVisible(false);
+  }, []);
 
   return (
     <Drawer
@@ -119,8 +128,8 @@ const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ templat
 
           {isCheatSheetVisible ? (
             <CheatSheet
-              cheatSheetName={template.displayName}
-              cheatSheetData={getCheatSheet(template.name)}
+              cheatSheetName="Generic"
+              cheatSheetData={genericTemplateCheatSheet}
               onClose={onCloseCheatSheet}
             />
           ) : (
@@ -129,10 +138,9 @@ const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ templat
                 <div className={cx('template-editor-block-title')}>
                   <HorizontalGroup justify="space-between" align="center" wrap>
                     <Text>Template editor</Text>
-
-                    {/*  <Button variant="secondary" fill="outline" onClick={onShowCheatSheet} icon="book" size="sm">
+                    <Button variant="secondary" fill="outline" onClick={onShowCheatSheet} icon="book" size="sm">
                       Cheatsheet
-                    </Button> */}
+                    </Button>
                   </HorizontalGroup>
                 </div>
                 <div className={cx('template-editor-block-content')}>
@@ -163,14 +171,6 @@ const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ templat
       </div>
     </Drawer>
   );
-
-  // function onShowCheatSheet() {}
-
-  function onCloseCheatSheet() {}
-
-  function getCheatSheet(_templateName: string) {
-    return undefined;
-  }
 };
 
 export default WebhooksTemplateEditor;

--- a/grafana-plugin/src/pages/outgoing_webhooks_2/OutgoingWebhooks2.module.scss
+++ b/grafana-plugin/src/pages/outgoing_webhooks_2/OutgoingWebhooks2.module.scss
@@ -10,10 +10,6 @@
   align-items: baseline;
 }
 
-.header__desc {
-  margin-bottom: 12px;
-}
-
 .hamburgerMenu {
   display: flex;
   flex-direction: column;

--- a/grafana-plugin/src/pages/outgoing_webhooks_2/OutgoingWebhooks2.tsx
+++ b/grafana-plugin/src/pages/outgoing_webhooks_2/OutgoingWebhooks2.tsx
@@ -177,17 +177,10 @@ class OutgoingWebhooks2 extends React.Component<OutgoingWebhooks2Props, Outgoing
                 title={() => (
                   <div className={cx('header')}>
                     <div className="header__title">
-                      <VerticalGroup spacing="sm">
-                        <LegacyNavHeading>
-                          <Text.Title level={3}>Outgoing Webhooks 2</Text.Title>
-                        </LegacyNavHeading>
-                        <Text type="secondary" className={cx('header__desc')}>
-                          <Icon name="exclamation-triangle"></Icon> Preview Functionality! Things will change and things
-                          will break! Do not use for critical production processes!
-                        </Text>
-                      </VerticalGroup>
+                      <LegacyNavHeading>
+                        <Text.Title level={3}>Outgoing Webhooks 2</Text.Title>
+                      </LegacyNavHeading>
                     </div>
-
                     <div className="u-pull-right">
                       <PluginLink
                         query={{ page: 'outgoing_webhooks_2', id: 'new' }}

--- a/grafana-plugin/src/pages/outgoing_webhooks_2/OutgoingWebhooks2.tsx
+++ b/grafana-plugin/src/pages/outgoing_webhooks_2/OutgoingWebhooks2.tsx
@@ -178,7 +178,7 @@ class OutgoingWebhooks2 extends React.Component<OutgoingWebhooks2Props, Outgoing
                   <div className={cx('header')}>
                     <div className="header__title">
                       <LegacyNavHeading>
-                        <Text.Title level={3}>Outgoing Webhooks 2</Text.Title>
+                        <Text.Title level={3}>Outgoing Webhooks</Text.Title>
                       </LegacyNavHeading>
                     </div>
                     <div className="u-pull-right">


### PR DESCRIPTION
# What this PR does

Fixes some FE related outgoing webhooks 2 issues

## Which issue(s) this PR fixes

- Cheatsheet is missing
- “Preview Functionality!” annotation is still visible.
- “Forward All” toggler doesn’t make the payload input field uneditable (like it was in the old UI)

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
