### PR TITLE
bump celery version to a version which supports Python 3.11

### DIFF
--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -5,7 +5,7 @@ whitenoise==5.3.0
 twilio~=6.37.0
 phonenumbers==8.10.0
 django-ordered-model==3.1.1
-celery[amqp,redis]==5.2.7
+celery[amqp,redis]==5.3.1
 redis==3.4.1
 humanize==0.5.1
 uwsgi==2.0.21

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -6,7 +6,7 @@ twilio~=6.37.0
 phonenumbers==8.10.0
 django-ordered-model==3.1.1
 celery[amqp,redis]==5.3.1
-redis==3.4.1
+redis==4.6.0
 humanize==0.5.1
 uwsgi==2.0.21
 django-cors-headers==3.7.0
@@ -14,7 +14,12 @@ django-debug-toolbar==4.1
 django-sns-view==0.1.2
 python-telegram-bot==13.13
 django-silk==5.0.3
-django-redis-cache==3.0.0
+# we need to use our own fork of django-redis-cache
+# reason being is that the "regular" repo (https://github.com/sebleier/django-redis-cache/)
+# has `redis` pinned @ <4.0
+# celery==5.3.1 complains about this
+# celery[amqp,redis] 5.3.1 depends on redis!=4.5.5 and >=4.5.2; extra == "redis"
+git+https://github.com/grafana/django-redis-cache.git@bump-redis-version-to-v4.6
 hiredis==1.0.0
 django-ratelimit==2.0.0
 django-filter==2.4.0


### PR DESCRIPTION
# Which issue(s) this PR fixes

I was seeing some strange logs occasionally pop up from celery:
```bash
[1;33m2023-07-13 10:05:14,772 source=engine:celery worker=MainProcess task_id=??? task_name=??? name=celery.redirected level=WARNING AttributeError: '_Code' object has no attribute 'co_positions'[0m
```

Did a bit of digging on this and [realized](https://github.com/DataDog/dd-trace-py/issues/4149) that `celery==5.2.7` does not support Python 3.11 (the version we use):

![Screenshot 2023-07-13 at 12 14 36](https://github.com/grafana/oncall/assets/9406895/a6ee76ea-12ed-4a3d-b37c-62b4291893e1)

We should immediately upgrade to `celery==5.3.1`. It mentions in this in the changelog for that version:
![Screenshot 2023-07-13 at 12 13 22](https://github.com/grafana/oncall/assets/9406895/5afdc35e-fbda-4350-8dc4-d989ac31fdc6)


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required) (N/A)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required) (N/A)
