### PR TITLE
set default phone provider

### DIFF
--- a/engine/apps/phone_notifications/phone_provider.py
+++ b/engine/apps/phone_notifications/phone_provider.py
@@ -181,4 +181,8 @@ def get_phone_provider() -> PhoneProvider:
     if len(_providers) == 0:
         for provider_alias, importpath in settings.PHONE_PROVIDERS.items():
             _providers[provider_alias] = import_string(importpath)()
+
+    if live_settings.PHONE_PROVIDER not in settings.PHONE_PROVIDERS.keys():
+        return _providers[settings.DEFAULT_PHONE_PROVIDER]
+
     return _providers[live_settings.PHONE_PROVIDER]

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -21,7 +21,6 @@ CURRENTLY_UNDERGOING_MAINTENANCE_MESSAGE = os.environ.get("CURRENTLY_UNDERGOING_
 IS_IN_MAINTENANCE_MODE = CURRENTLY_UNDERGOING_MAINTENANCE_MESSAGE is not None
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -729,6 +728,7 @@ PYROSCOPE_AUTH_TOKEN = os.getenv("PYROSCOPE_AUTH_TOKEN", "")
 
 # map of phone provider alias to importpath.
 # Used in get_phone_provider function to dynamically load current provider.
+DEFAULT_PHONE_PROVIDER = "twilio"
 PHONE_PROVIDERS = {
     "twilio": "apps.twilioapp.phone_provider.TwilioPhoneProvider",
     # "simple": "apps.phone_notifications.simple_phone_provider.SimplePhoneProvider",
@@ -737,7 +737,7 @@ PHONE_PROVIDERS = {
 if IS_OPEN_SOURCE:
     PHONE_PROVIDERS["zvonok"] = "apps.zvonok.phone_provider.ZvonokPhoneProvider"
 
-PHONE_PROVIDER = os.environ.get("PHONE_PROVIDER", default="twilio")
+PHONE_PROVIDER = os.environ.get("PHONE_PROVIDER", default=DEFAULT_PHONE_PROVIDER)
 
 ZVONOK_API_KEY = os.getenv("ZVONOK_API_KEY", None)
 ZVONOK_CAMPAIGN_ID = os.getenv("ZVONOK_CAMPAIGN_ID", None)


### PR DESCRIPTION
# What this PR does

Sets a default value for the PHONE_PROVIDER setting and replaces the value of PHONE_PROVIDER with this default value if it is not valid.

## Which issue(s) this PR fixes

- [#2520](https://github.com/grafana/oncall/issues/2520)
- [#2323](https://github.com/grafana/oncall/issues/2323)

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
