### PR TITLE
Update all make docs CI to match

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -83,9 +83,8 @@ jobs:
         # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
         # that no refs to external content can be used as these refs will not resolve in the
         # docs-base image.
-        # Use alternative image (dbd975af06) until make-docs 3.0.0 is rolled out everywhere.
         run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:dbd975af06 /bin/bash -c 'echo -e "---\\nredirectURL: /hugo/content/docs/oncall/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/oncall/_index.md; make hugo'
+          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'echo -e "---\\nredirectURL: /hugo/content/docs/oncall/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/oncall/_index.md; make hugo'
 
   lint-migrations-backend-mysql-rabbitmq:
     name: "Lint database migrations"

--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -18,7 +18,7 @@ jobs:
         # that no refs to external content can be used as these refs will not resolve in the
         # docs-base image.
         run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'echo -e "---\\nredirectURL: /hugo/content/docs/oncall/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/oncall/_index.md; make hugo'
 
   sync:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -17,11 +17,11 @@ jobs:
         uses: "actions/checkout@v3"
       - name:
           "Build website"
-          # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
-          # that no refs to external content can be used as these refs will not resolve in the
-          # docs-base image.
+        # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
+        # that no refs to external content can be used as these refs will not resolve in the
+        # docs-base image.
         run: |
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'make hugo'
+          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest -e HUGO_REFLINKSERRORLEVEL=ERROR --rm grafana/docs-base:latest /bin/bash -c 'echo -e "---\\nredirectURL: /hugo/content/docs/oncall/latest/\\ntype: redirect\\nversioned: true\\n---\\n" > /hugo/content/docs/oncall/_index.md; make hugo'
 
   sync:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
My previous PR only updated the CI that ran on PRs, I forgot about the CD for releases.

Fixes https://github.com/grafana/oncall/actions/runs/5547818896.

You can see that this will resolve the problem because it is what allows the PR CI to pass. I just forgot to include it in the release CD.