### PR TITLE
Update Users.tsx

### DIFF
--- a/grafana-plugin/src/pages/users/Users.tsx
+++ b/grafana-plugin/src/pages/users/Users.tsx
@@ -192,7 +192,7 @@ class Users extends React.Component<UsersProps, UsersState> {
                         <Text type="secondary">
                           All Grafana users listed below to set notification preferences. To manage permissions or add
                           new users, please visit{' '}
-                          <a href="/org/users" target="_blank">
+                          <a href="/admin/users" target="_blank">
                             Grafana user management
                           </a>
                         </Text>


### PR DESCRIPTION
Update "Grafana user management" url from `/org/users` to `/admin/users` on the OnCall Users page.

# What this PR does
Currently in my Grafana Cloud instance when I click the link for "Grafana user management" on the Users page of the OnCall app it takes me to the `/org/users` page, which shows a 404 error (but also kinda loads).

<img width="891" alt="2023-07-14_13-00-06" src="https://github.com/grafana/oncall/assets/13998241/077172b8-387b-415e-af92-d394480fef1f">

## Which issue(s) this PR fixes
Discussed in Slack here: https://raintank-corp.slack.com/archives/C0229FD3CE9/p1689006468472659

In my cloud instance the users page is found on `/admin/users`. 

<img width="965" alt="2023-07-14_13-01-33" src="https://github.com/grafana/oncall/assets/13998241/4e74000c-1713-406d-b23b-1691925158e6">

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
