### PR TITLE
Remove v prefix from plugin version on build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
       - apt-get update
       - apt-get --assume-yes install jq
       - cd grafana-plugin/
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq '.version="${DRONE_TAG#v}"' package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
+      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq ".version=\"${DRONE_TAG#v}\"" package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
       - yarn --network-timeout 500000
       - yarn build
       - ls ./
@@ -179,7 +179,7 @@ steps:
       - apt-get update
       - apt-get --assume-yes install jq
       - cd grafana-plugin/
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq '.version="${DRONE_TAG#v}"' package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
+      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq ".version=\"${DRONE_TAG#v}\"" package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
       - yarn --network-timeout 500000
       - yarn build
       - ls ./
@@ -334,6 +334,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 95e5d7a117c5ce0776d1a614aef1bf09f67c33caaf72554134caf5295cdc019c
+hmac: 28b2aecc443cfb232625cd8afc92e44a6cbf2d37cd991b0099b07521225855bf
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
       - apt-get update
       - apt-get --assume-yes install jq
       - cd grafana-plugin/
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq '.version="${DRONE_TAG}"' package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
+      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq '.version="${DRONE_TAG#v}"' package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
       - yarn --network-timeout 500000
       - yarn build
       - ls ./
@@ -179,7 +179,7 @@ steps:
       - apt-get update
       - apt-get --assume-yes install jq
       - cd grafana-plugin/
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq '.version="${DRONE_TAG}"' package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
+      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else jq '.version="${DRONE_TAG#v}"' package.json > package.new && mv package.new package.json && jq '.version' package.json; fi
       - yarn --network-timeout 500000
       - yarn build
       - ls ./
@@ -334,6 +334,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: be10373849d65e1f90bce64c7468d5cf5bac546285226ff8931a8b953163a752
+hmac: 95e5d7a117c5ce0776d1a614aef1bf09f67c33caaf72554134caf5295cdc019c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -231,7 +231,7 @@ steps:
     image: alpine
     commands:
       - apk add --no-cache bash sed
-      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else sed "0,/VERSION.*/ s/VERSION.*/VERSION = \"${DRONE_TAG}\"/g" engine/settings/base.py > engine/settings/base.temp && mv engine/settings/base.temp engine/settings/base.py; fi
+      - if [ -z "$DRONE_TAG" ]; then echo "No tag, not modifying version"; else sed "0,/VERSION.*/ s/VERSION.*/VERSION = \"${DRONE_TAG#v}\"/g" engine/settings/base.py > engine/settings/base.temp && mv engine/settings/base.temp engine/settings/base.py; fi
       - cat engine/settings/base.py | grep VERSION | head -1
 
   - name: build and push docker image
@@ -334,6 +334,6 @@ kind: secret
 name: drone_token
 ---
 kind: signature
-hmac: 28b2aecc443cfb232625cd8afc92e44a6cbf2d37cd991b0099b07521225855bf
+hmac: 1ca79af7b8ada54237e4fb78fffb9314babc00b3a8a4866ec454d32356bc067b
 
 ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `PHONE_PROVIDER` configuration check by @sreway ([#2523](https://github.com/grafana/oncall/pull/2523))
 - Deprecate `/oncall` Slack command, update direct paging functionality by @vadimkerr ([#2537](https://github.com/grafana/oncall/pull/2537))
+- Change plugin version to drop the `v` prefix. ([#2540](https://github.com/grafana/oncall/pull/2540))
 
 ## v1.3.13 (2023-07-17)
 


### PR DESCRIPTION
Related to https://github.com/grafana/oncall/issues/458

Change version naming for plugin and docker releases to drop the `v` prefix (ie. `1.2.3` instead of `v1.2.3`).
Update both to keep consistency between plugin and engine versions, which are also checked to match.