### PR TITLE
Fix authorization header masked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `page_size`, `current_page_number`, and `total_pages` attributes to paginated API responses by @joeyorlando ([#2471](https://github.com/grafana/oncall/pull/2471))
 
+### Fixed
+
+- New webhooks incorrectly masking authorization header by @mderynck ([#2541](https://github.com/grafana/oncall/pull/2541))
+
 ## v1.3.11 (2023-07-13)
 
 ### Added

--- a/engine/apps/webhooks/tasks/trigger_webhook.py
+++ b/engine/apps/webhooks/tasks/trigger_webhook.py
@@ -96,9 +96,10 @@ def _build_payload(webhook, alert_group, user):
 
 
 def mask_authorization_header(headers):
-    if "Authorization" in headers:
-        headers["Authorization"] = WEBHOOK_FIELD_PLACEHOLDER
-    return headers
+    masked_headers = headers.copy()
+    if "Authorization" in masked_headers:
+        masked_headers["Authorization"] = WEBHOOK_FIELD_PLACEHOLDER
+    return masked_headers
 
 
 def make_request(webhook, alert_group, data):
@@ -123,8 +124,8 @@ def make_request(webhook, alert_group, data):
         if triggered:
             status["url"] = webhook.build_url(data)
             request_kwargs = webhook.build_request_kwargs(data, raise_data_errors=True)
-            headers = mask_authorization_header(request_kwargs.get("headers", {}))
-            status["request_headers"] = json.dumps(headers)
+            display_headers = mask_authorization_header(request_kwargs.get("headers", {}))
+            status["request_headers"] = json.dumps(display_headers)
             if "json" in request_kwargs:
                 status["request_data"] = json.dumps(request_kwargs["json"])
             else:


### PR DESCRIPTION
# What this PR does
Fix authorization header was being masked in the requests instead of only in logs

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
