### PR TITLE
Current responders -> Additional Responders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update Slack "invite" feature to use direct paging by @vadimkerr ([#2562](https://github.com/grafana/oncall/pull/2562))
+- Change "Current responders" to "Additional Responders" in web UI by @vadimkerr ([#2567](https://github.com/grafana/oncall/pull/2567))
 
 ## v1.3.14 (2023-07-17)
 

--- a/grafana-plugin/src/pages/incident/parts/PagedUsers.tsx
+++ b/grafana-plugin/src/pages/incident/parts/PagedUsers.tsx
@@ -52,7 +52,7 @@ const PagedUsers = observer((props: PagedUsersProps) => {
   return (
     <div className={cx('paged-users')}>
       <Text.Title type="primary" level={4} className={cx('timeline-title')}>
-        Current responders
+        Additional responders
       </Text.Title>
       <ul className={cx('paged-users-list')}>
         {pagedUsers.map((pagedUser) => {


### PR DESCRIPTION
# What this PR does

Changes wording so it's clear that only "additional" responders (i.e. users paged through direct paging) are shown in this section, and users paged via escalation chain are not shown.

Before:

<img width="601" alt="Screenshot 2023-07-18 at 10 15 28" src="https://github.com/grafana/oncall/assets/20116910/a152692f-2f2b-46e5-b51a-71acc9a25b7d">

After:

<img width="601" alt="Screenshot 2023-07-18 at 10 16 06" src="https://github.com/grafana/oncall/assets/20116910/6ff95c72-a883-4a7a-a81a-4ae7fe11877f">

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
