### PR TITLE
Fix slack channels sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-- Fixed Slack channels sync by @Ferril ([#2571](https://github.com/grafana/oncall/pull/2571))
-
 ### Changed
 
 - Deprecate `AlertGroup.is_archived` column. Column will be removed in a subsequent release. By @joeyorlando ([#2524](https://github.com/grafana/oncall/pull/2524)).
@@ -20,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix duplicate orders on routes and escalation policies by @vadimkerr ([#2568](https://github.com/grafana/oncall/pull/2568))
+- Fixed Slack channels sync by @Ferril ([#2571](https://github.com/grafana/oncall/pull/2571))
 
 ## v1.3.14 (2023-07-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed Slack channels sync by @Ferril ([#2571](https://github.com/grafana/oncall/pull/2571))
+
 ### Changed
 
 - Deprecate `AlertGroup.is_archived` column. Column will be removed in a subsequent release. By @joeyorlando ([#2524](https://github.com/grafana/oncall/pull/2524)).

--- a/engine/apps/slack/slack_client/slack_client.py
+++ b/engine/apps/slack/slack_client/slack_client.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional, Tuple
 
 from django.apps import apps
 from django.utils import timezone
@@ -53,6 +54,39 @@ class SlackClientWithErrorHandling(SlackClient):
             cumulative_response[listed_key] += response[listed_key]
 
         return cumulative_response
+
+    def paginated_api_call_with_ratelimit(self, *args, **kwargs) -> Tuple[dict, Optional[str], bool]:
+        """
+        This method do paginated api call and handle slack rate limit error in order to return collected data and have
+        ability to continue doing paginated requests from the last successful cursor. Return last successful cursor
+        instead of next cursor to avoid data loss during delay time
+        """
+        # It's a key from response which is paginated. For example "users" or "channels"
+        listed_key = kwargs["paginated_key"]
+        cumulative_response = {}
+        cursor = kwargs.get("cursor")
+        rate_limited = False
+
+        try:
+            response = self.api_call(*args, **kwargs)
+            cumulative_response = response
+            cursor = response["response_metadata"]["next_cursor"]
+
+            while (
+                "response_metadata" in response
+                and "next_cursor" in response["response_metadata"]
+                and response["response_metadata"]["next_cursor"] != ""
+            ):
+                next_cursor = response["response_metadata"]["next_cursor"]
+                kwargs["cursor"] = next_cursor
+                response = self.api_call(*args, **kwargs)
+                cumulative_response[listed_key] += response[listed_key]
+                cursor = next_cursor
+
+        except SlackAPIRateLimitException:
+            rate_limited = True
+
+        return cumulative_response, cursor, rate_limited
 
     def api_call(self, *args, **kwargs):
         DynamicSetting = apps.get_model("base", "DynamicSetting")

--- a/engine/apps/slack/tasks.py
+++ b/engine/apps/slack/tasks.py
@@ -624,6 +624,7 @@ def populate_slack_channels_for_team(slack_team_identity_id: int, cursor: Option
             start_populate_slack_channels_for_team(slack_team_identity_id, delay, cursor)
         else:
             # delete excess channels
+            assert collected_channels
             channel_ids_to_delete = existing_channel_ids - collected_channels
             slack_team_identity.cached_channels.filter(slack_id__in=channel_ids_to_delete).delete()
             cache.delete(collected_channels_key)

--- a/engine/apps/slack/tests/test_populate_slack_channels.py
+++ b/engine/apps/slack/tests/test_populate_slack_channels.py
@@ -23,14 +23,21 @@ def test_populate_slack_channels_for_team(make_organization_with_slack_team_iden
         )
     )
 
-    response = {
-        "channels": (
-            {"id": "C111111111", "name": "test1", "is_archived": False, "is_shared": False},
-            {"id": "C222222222", "name": "test_changed_name", "is_archived": False, "is_shared": True},
-            {"id": "C333333333", "name": "test3", "is_archived": False, "is_shared": True},
-        )
-    }
-    with patch.object(SlackClientWithErrorHandling, "paginated_api_call", return_value=response):
+    response, cursor, rate_limited = (
+        {
+            "channels": (
+                {"id": "C111111111", "name": "test1", "is_archived": False, "is_shared": False},
+                {"id": "C222222222", "name": "test_changed_name", "is_archived": False, "is_shared": True},
+                {"id": "C333333333", "name": "test3", "is_archived": False, "is_shared": True},
+            )
+        },
+        None,
+        False,
+    )
+
+    with patch.object(
+        SlackClientWithErrorHandling, "paginated_api_call_with_ratelimit", return_value=(response, cursor, rate_limited)
+    ):
         populate_slack_channels_for_team(slack_team_identity.pk)
 
     channels = slack_team_identity.cached_channels.all()
@@ -45,3 +52,123 @@ def test_populate_slack_channels_for_team(make_organization_with_slack_team_iden
     assert second_channel.name == "test_changed_name"
 
     assert not channels.filter(last_populated__lte=yesterday).exists()
+
+
+@patch("apps.slack.tasks.start_populate_slack_channels_for_team")
+@pytest.mark.django_db
+def test_populate_slack_channels_for_team_ratelimit(
+    mocked_start_populate_slack_channels_for_team,
+    make_organization_with_slack_team_identity,
+    make_slack_channel,
+):
+    organization, slack_team_identity = make_organization_with_slack_team_identity()
+
+    yesterday = (timezone.now() - timezone.timedelta(days=1)).date()
+    today = timezone.now().date()
+
+    _ = tuple(
+        make_slack_channel(
+            slack_team_identity=slack_team_identity, slack_id=slack_id, name=name, last_populated=yesterday
+        )
+        for slack_id, name in (
+            ("C111111111", "test1"),
+            ("C222222222", "test2"),
+            ("C444444444", "test4"),
+        )
+    )
+    # first response with rate limit error
+    response_1, cursor_1, rate_limited_1 = (
+        {"channels": ({"id": "C111111111", "name": "test1", "is_archived": False, "is_shared": False},)},
+        "TESTCURSOR1",
+        True,
+    )
+
+    # second response with rate limit error
+    response_2, cursor_2, rate_limited_2 = (
+        {
+            "channels": (
+                {"id": "C111111111", "name": "test1", "is_archived": False, "is_shared": False},
+                {"id": "C222222222", "name": "test_changed_name", "is_archived": False, "is_shared": True},
+            )
+        },
+        "TESTCURSOR2",
+        True,
+    )
+
+    # third response without rate limit error
+    response_3, cursor_3, rate_limited_3 = (
+        {
+            "channels": (
+                {"id": "C222222222", "name": "test_changed_name", "is_archived": False, "is_shared": True},
+                {"id": "C333333333", "name": "test3", "is_archived": False, "is_shared": True},
+            )
+        },
+        "",
+        False,
+    )
+    # these channels should exist after finishing populate_slack_channels_for_team
+    expected_channel_ids = {"C111111111", "C222222222", "C333333333"}
+
+    with patch.object(
+        SlackClientWithErrorHandling,
+        "paginated_api_call_with_ratelimit",
+        return_value=(response_1, cursor_1, rate_limited_1),
+    ):
+        populate_slack_channels_for_team(slack_team_identity.pk)
+
+    # expected only one channel to update and no channel to delete
+    # start_populate_slack_channels_for_team should be called
+    channels = slack_team_identity.cached_channels.all()
+    channel_1 = channels.get(slack_id="C111111111")
+    assert channel_1.last_populated == today
+
+    channel_2 = channels.get(slack_id="C222222222")
+    assert channel_2.last_populated == yesterday
+
+    assert channels.filter(slack_id="C444444444").exists()
+
+    assert mocked_start_populate_slack_channels_for_team.called
+    assert mocked_start_populate_slack_channels_for_team.call_count == 1
+
+    with patch.object(
+        SlackClientWithErrorHandling,
+        "paginated_api_call_with_ratelimit",
+        return_value=(response_2, cursor_2, rate_limited_2),
+    ):
+        populate_slack_channels_for_team(slack_team_identity.pk, cursor_1)
+
+    # expected another one channel to update and no channel to delete
+    # start_populate_slack_channels_for_team should be called
+    channels = slack_team_identity.cached_channels.all()
+
+    channel_2 = channels.get(slack_id="C222222222")
+    assert channel_2.last_populated == today
+    assert channel_2.name == "test_changed_name"
+
+    assert not channels.filter(slack_id="C333333333").exists()
+    assert channels.filter(slack_id="C444444444").exists()
+
+    assert mocked_start_populate_slack_channels_for_team.called
+    assert mocked_start_populate_slack_channels_for_team.call_count == 2
+
+    with patch.object(
+        SlackClientWithErrorHandling,
+        "paginated_api_call_with_ratelimit",
+        return_value=(response_3, cursor_3, rate_limited_3),
+    ):
+        populate_slack_channels_for_team(slack_team_identity.pk, cursor_1)
+
+    # expected one new channel and one deleted channel. List of channel ids in response and in db should be the same
+    # start_populate_slack_channels_for_team should NOT be called
+    channels = slack_team_identity.cached_channels.all()
+
+    actual_channel_ids = set(channels.values_list("slack_id", flat=True))
+    assert actual_channel_ids == expected_channel_ids
+
+    assert not channels.filter(slack_id="C444444444").exists()
+
+    channel_2 = channels.get(slack_id="C222222222")
+    assert channel_2.name == "test_changed_name"
+
+    assert not channels.filter(last_populated__lte=yesterday).exists()
+    assert mocked_start_populate_slack_channels_for_team.call_count == 2

--- a/engine/apps/slack/utils.py
+++ b/engine/apps/slack/utils.py
@@ -65,3 +65,7 @@ def format_datetime_to_slack(timestamp, format="date_short"):
 def get_cache_key_update_incident_slack_message(alert_group_pk):
     CACHE_KEY_PREFIX = "update_incident_slack_message"
     return f"{CACHE_KEY_PREFIX}_{alert_group_pk}"
+
+
+def get_populate_slack_channel_task_id_key(slack_team_identity_id):
+    return f"SLACK_CHANNELS_TASK_ID_TEAM_{slack_team_identity_id}"


### PR DESCRIPTION
# What this PR does
- Fixes issue with slack channels sync periodic tasks when we get slack rate limit exception.
- Adds check for active task id to avoid starting multiple tasks for one slack team.

Collecting channels for slack for some teams causes rate limit exception, which causes the task to restart and start collecting slack channels from the beginning. This PR adds new paginated api call and refactors the slack channel sync task to continue collect data after rate limit from the step before it was raised using `cursor` value from the slack response.


## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
