### PR TITLE
Remove unnecessary team checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update direct paging docs by @vadimkerr ([#2600](https://github.com/grafana/oncall/pull/2600))
+- Remove unnecessary team checks in public API by @vadimkerr ([#2606](https://github.com/grafana/oncall/pull/2606))
 
 ### Fixed
 

--- a/engine/apps/public_api/serializers/escalation_policies.py
+++ b/engine/apps/public_api/serializers/escalation_policies.py
@@ -109,18 +109,6 @@ class EscalationPolicySerializer(EagerLoadingMixin, OrderedModelSerializer):
 
         return step_type
 
-    def validate_action_to_trigger(self, action_to_trigger):
-        if action_to_trigger.team != self.escalation_chain.team:
-            raise BadRequest(detail="Action must be assigned to the same team as the escalation chain")
-
-        return action_to_trigger
-
-    def validate_notify_on_call_from_schedule(self, schedule):
-        if schedule.team != self.escalation_chain.team:
-            raise BadRequest(detail="Schedule must be assigned to the same team as the escalation chain")
-
-        return schedule
-
     def create(self, validated_data):
         validated_data = self._correct_validated_data(validated_data)
         return super().create(validated_data)

--- a/engine/apps/public_api/serializers/routes.py
+++ b/engine/apps/public_api/serializers/routes.py
@@ -115,21 +115,6 @@ class BaseChannelFilterSerializer(OrderedModelSerializer):
                 notification_backends[backend_id] = current.get(backend_id, {}) | notification_backends[backend_id]
         return notification_backends
 
-    def validate_escalation_chain_id(self, escalation_chain):
-        if escalation_chain is None:
-            return escalation_chain
-        if self.instance is not None:
-            alert_receive_channel = self.instance.alert_receive_channel
-        else:
-            alert_receive_channel = AlertReceiveChannel.objects.get(
-                public_primary_key=self.initial_data["integration_id"]
-            )
-
-        if escalation_chain.team != alert_receive_channel.team:
-            raise BadRequest(detail="Escalation chain must be assigned to the same team as the integration")
-
-        return escalation_chain
-
 
 class RoutingTypeField(fields.CharField):
     def to_representation(self, value):

--- a/engine/apps/public_api/serializers/schedules_calendar.py
+++ b/engine/apps/public_api/serializers/schedules_calendar.py
@@ -35,17 +35,7 @@ class ScheduleCalendarSerializer(ScheduleBaseSerializer):
         }
 
     def validate_shifts(self, shifts):
-        # Get team_id from instance, if it exists, otherwise get it from initial data.
-        if self.instance and self.instance.team:
-            team_id = self.instance.team.public_primary_key
-        else:
-            # Terraform sends empty string instead of None. In this case change team_id value to None.
-            team_id = self.initial_data.get("team_id") or None
-
         for shift in shifts:
-            shift_team_id = shift.team.public_primary_key if shift.team else None
-            if shift_team_id != team_id:
-                raise BadRequest(detail="Shifts must be assigned to the same team as the schedule")
             if shift.type == CustomOnCallShift.TYPE_OVERRIDE:
                 raise BadRequest(detail="Shifts of type override are not supported in this schedule")
 

--- a/engine/apps/public_api/serializers/schedules_web.py
+++ b/engine/apps/public_api/serializers/schedules_web.py
@@ -6,7 +6,6 @@ from apps.schedules.tasks import (
     schedule_notify_about_gaps_in_schedule,
 )
 from common.api_helpers.custom_fields import TeamPrimaryKeyRelatedField, UsersFilteredByOrganizationField
-from common.api_helpers.exceptions import BadRequest
 from common.timezones import TimeZoneField
 
 
@@ -30,16 +29,6 @@ class ScheduleWebSerializer(ScheduleBaseSerializer):
             "on_call_now",
             "shifts",
         ]
-
-    def validate_shifts(self, shifts):
-        # Get team_id from instance, if it exists, otherwise get it from initial data.
-        # Handle empty string instead of None. In this case change team_id value to None.
-        team_id = self.instance.team_id if self.instance else (self.initial_data.get("team_id") or None)
-        for shift in shifts:
-            if shift.team_id != team_id:
-                raise BadRequest(detail="Shifts must be assigned to the same team as the schedule")
-
-        return shifts
 
     def to_internal_value(self, data):
         if data.get("shifts", []) is None:  # handle a None value

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -53,6 +53,7 @@ check [Readme](https://github.com/grafana/terraform-provider-grafana/blob/master
       dev_overrides {
           "grafana/grafana" = "/path/to/your/grafana/terraform-provider" # this path is the directory where the binary is built
       }
+   }
     ```
 
 1. Create a new directory and a `main.tf` file with the following content:


### PR DESCRIPTION
# What this PR does

Removes unnecessary team checks enforced by public API, as they seem to be outdated and not aligned with the web UI and docs.

From public [docs](https://grafana.com/docs/oncall/latest/user-and-team-management/#manage-teams-in-grafana-oncall):
> Resources from different teams can be connected with one another. For instance, you can create an integration in one team, set up multiple routes for the integration, and utilize escalation chains from other teams. Users, schedules, and outgoing webhooks from other teams can also be included in the escalation chain.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
