### PR TITLE
Helm migrate job - support custom annotations

### DIFF
--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -6,8 +6,15 @@ metadata:
   name: {{ printf "%s-migrate" (include "oncall.engine.fullname" .) }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
+    {{- with .Values.migrate.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- else }}
   name: {{ printf "%s-migrate-%s" (include "oncall.engine.fullname" .) (now | date "2006-01-02-15-04-05") }}
+  {{- with .Values.migrate.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   labels:
     {{- include "oncall.engine.labels" . | nindent 4 }}

--- a/helm/oncall/tests/migrate_annotations_test.yaml
+++ b/helm/oncall/tests/migrate_annotations_test.yaml
@@ -1,0 +1,48 @@
+suite: test migrate annotations
+templates:
+  - engine/job-migrate.yaml
+release:
+  name: oncall
+tests:
+  - it: migrate.useHook=false -> should not provide an annotations block
+    set:
+      migrate.useHook: false
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: migrate.useHook=true -> should only provide the "helm.sh/hook" annotation
+    set:
+      migrate.useHook: true
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            "helm.sh/hook": pre-install,pre-upgrade
+
+  - it: migrate.useHook=false and annotations set -> should only contain the custom annotations
+    set:
+      migrate.useHook: false
+      migrate.annotations:
+        some-annotation: some-value
+        other-annotation: other-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            some-annotation: some-value
+            other-annotation: other-value
+
+  - it: migrate.useHook=true and annotations set -> should contain the custom annotations and the "helm.sh/hook" annotation
+    set:
+      migrate.useHook: true
+      migrate.annotations:
+        some-annotation: some-value
+        other-annotation: other-value
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            "helm.sh/hook": pre-install,pre-upgrade
+            some-annotation: some-value
+            other-annotation: other-value

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -191,6 +191,7 @@ migrate:
   ttlSecondsAfterFinished: 20
   # use a helm hook to manage the migration job
   useHook: false
+  annotations: {}
 
   ## Affinity for pod assignment
   ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity


### PR DESCRIPTION
# What this PR does
Adds support for custom annotations on the helm chart's migrate job

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/1618

## Checklist

- [X] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
