### PR TITLE
Refactoring schedule final events for reusability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsed, when they were space-delimited. This fix allows them to be _either_ space or comma-delimited.
   by @joeyorlando ([#2623](https://github.com/grafana/oncall/pull/2623))
 
+### Changed
+
+- Update checking on-call users to use schedule final events ([#2625](https://github.com/grafana/oncall/pull/2625))
+
 ## v1.3.16 (2023-07-21)
 
 ### Added

--- a/engine/apps/alerts/escalation_snapshot/snapshot_classes/escalation_policy_snapshot.py
+++ b/engine/apps/alerts/escalation_snapshot/snapshot_classes/escalation_policy_snapshot.py
@@ -275,7 +275,7 @@ class EscalationPolicySnapshot:
                 escalation_policy_step=self.step,
             )
         else:
-            notify_to_users_list = list_users_to_notify_from_ical(on_call_schedule, include_viewers=True)
+            notify_to_users_list = list_users_to_notify_from_ical(on_call_schedule)
             if notify_to_users_list is None:
                 log_record = AlertGroupLogRecord(
                     type=AlertGroupLogRecord.TYPE_ESCALATION_FAILED,

--- a/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
+++ b/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
@@ -246,7 +246,7 @@ def test_escalation_step_notify_on_call_schedule_viewer_user(
     )
     assert expected_eta + timezone.timedelta(seconds=15) > result.eta > expected_eta - timezone.timedelta(seconds=15)
     assert result == expected_result
-    assert not notify_schedule_step.log_records.filter(type=AlertGroupLogRecord.TYPE_ESCALATION_TRIGGERED).exists()
+    assert notify_schedule_step.log_records.filter(type=AlertGroupLogRecord.TYPE_ESCALATION_FAILED).exists()
     assert list(escalation_policy_snapshot.notify_to_users_queue) == []
     assert mocked_execute_tasks.called
 

--- a/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
+++ b/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
@@ -246,11 +246,8 @@ def test_escalation_step_notify_on_call_schedule_viewer_user(
     )
     assert expected_eta + timezone.timedelta(seconds=15) > result.eta > expected_eta - timezone.timedelta(seconds=15)
     assert result == expected_result
-    assert notify_schedule_step.log_records.filter(type=AlertGroupLogRecord.TYPE_ESCALATION_TRIGGERED).exists()
-    assert list(escalation_policy_snapshot.notify_to_users_queue) == list(
-        list_users_to_notify_from_ical(schedule, include_viewers=True)
-    )
-    assert list(escalation_policy_snapshot.notify_to_users_queue) == [viewer]
+    assert not notify_schedule_step.log_records.filter(type=AlertGroupLogRecord.TYPE_ESCALATION_TRIGGERED).exists()
+    assert list(escalation_policy_snapshot.notify_to_users_queue) == []
     assert mocked_execute_tasks.called
 
 

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1227,7 +1227,7 @@ def test_filter_events_final_schedule(
             "is_gap": is_gap,
             "is_override": is_override,
             "priority_level": priority,
-            "start": start_date + timezone.timedelta(hours=start, milliseconds=1 if start == 0 else 0),
+            "start": start_date + timezone.timedelta(hours=start),
             "user": user,
         }
         for start, duration, user, priority, is_gap, is_override in expected

--- a/engine/apps/api/views/on_call_shifts.py
+++ b/engine/apps/api/views/on_call_shifts.py
@@ -1,3 +1,6 @@
+import datetime
+
+import pytz
 from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
@@ -106,8 +109,13 @@ class OnCallShiftView(TeamFilteringMixin, PublicPrimaryKeyMixin, UpdateSerialize
         updated_shift_pk = self.request.data.get("shift_pk")
         shift = CustomOnCallShift(**validated_data)
         schedule = shift.schedule
+
+        pytz_tz = pytz.timezone(user_tz)
+        datetime_start = datetime.datetime.combine(starting_date, datetime.time.min, tzinfo=pytz_tz)
+        datetime_end = datetime_start + datetime.timedelta(days=days)
+
         shift_events, final_events = schedule.preview_shift(
-            shift, user_tz, starting_date, days, updated_shift_pk=updated_shift_pk
+            shift, datetime_start, datetime_end, updated_shift_pk=updated_shift_pk
         )
         data = {
             "rotation": shift_events,

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -1,6 +1,8 @@
+import datetime
 import functools
 import operator
 
+import pytz
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Count, OuterRef, Subquery
 from django.db.utils import IntegrityError
@@ -274,12 +276,16 @@ class ScheduleView(
 
     @action(detail=True, methods=["get"])
     def events(self, request, pk):
-        user_tz, date = self.get_request_timezone()
+        user_tz, starting_date = self.get_request_timezone()
         with_empty = self.request.query_params.get("with_empty", False) == "true"
         with_gap = self.request.query_params.get("with_gap", False) == "true"
 
         schedule = self.get_object()
-        events = schedule.filter_events(user_tz, date, days=1, with_empty=with_empty, with_gap=with_gap)
+
+        pytz_tz = pytz.timezone(user_tz)
+        datetime_start = datetime.datetime.combine(starting_date, datetime.time.min, tzinfo=pytz_tz)
+        datetime_end = datetime_start + datetime.timedelta(days=1)
+        events = schedule.filter_events(datetime_start, datetime_end, with_empty=with_empty, with_gap=with_gap)
 
         slack_channel = (
             {
@@ -312,19 +318,22 @@ class ScheduleView(
 
         schedule = self.get_object()
 
+        pytz_tz = pytz.timezone(user_tz)
+        datetime_start = datetime.datetime.combine(starting_date, datetime.time.min, tzinfo=pytz_tz)
+        datetime_end = datetime_start + datetime.timedelta(days=days)
+
         if filter_by is not None and filter_by != EVENTS_FILTER_BY_FINAL:
             filter_by = OnCallSchedule.PRIMARY if filter_by == EVENTS_FILTER_BY_ROTATION else OnCallSchedule.OVERRIDES
             events = schedule.filter_events(
-                user_tz,
-                starting_date,
-                days=days,
+                datetime_start,
+                datetime_end,
                 with_empty=True,
                 with_gap=resolve_schedule,
                 filter_by=filter_by,
                 all_day_datetime=True,
             )
         else:  # return final schedule
-            events = schedule.final_events(user_tz, starting_date, days)
+            events = schedule.final_events(datetime_start, datetime_end)
 
         result = {
             "id": schedule.public_primary_key,
@@ -337,11 +346,11 @@ class ScheduleView(
     @action(detail=True, methods=["get"])
     def next_shifts_per_user(self, request, pk):
         """Return next shift for users in schedule."""
-        user_tz, _ = self.get_request_timezone()
         now = timezone.now()
-        starting_date = now.date()
+        datetime_end = now + datetime.timedelta(days=30)
         schedule = self.get_object()
-        events = schedule.final_events(user_tz, starting_date, days=30)
+
+        events = schedule.final_events(now, datetime_end)
 
         users = {u.public_primary_key: None for u in schedule.related_users()}
         for e in events:
@@ -373,10 +382,11 @@ class ScheduleView(
         schedule = self.get_object()
 
         _, date = self.get_request_timezone()
+        datetime_start = datetime.datetime.combine(date, datetime.time.min, tzinfo=pytz.UTC)
         days = self.request.query_params.get("days")
         days = int(days) if days else None
 
-        return Response(schedule.quality_report(date, days))
+        return Response(schedule.quality_report(datetime_start, days))
 
     @action(detail=False, methods=["get"])
     def type_options(self, request):

--- a/engine/apps/mobile_app/tasks.py
+++ b/engine/apps/mobile_app/tasks.py
@@ -439,7 +439,8 @@ def conditionally_send_going_oncall_push_notifications_for_schedule(schedule_pk)
         return
 
     now = timezone.now()
-    schedule_final_events = schedule.final_events("UTC", now, days=7)
+    datetime_end = now + datetime.timedelta(days=7)
+    schedule_final_events = schedule.final_events(now, datetime_end)
 
     relevant_cache_keys = [
         _generate_going_oncall_push_notification_cache_key(user["pk"], schedule_event)

--- a/engine/apps/public_api/views/schedules.py
+++ b/engine/apps/public_api/views/schedules.py
@@ -149,9 +149,7 @@ class OnCallScheduleChannelView(RateLimitHeadersMixin, UpdateSerializerMixin, Mo
         end_date = serializer.validated_data["end_date"]
         days_between_start_and_end = (end_date - start_date).days
 
-        datetime_start = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=pytz.UTC) + datetime.timedelta(
-            milliseconds=1
-        )
+        datetime_start = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=pytz.UTC)
         datetime_end = datetime_start + datetime.timedelta(
             days=days_between_start_and_end - 1, hours=23, minutes=59, seconds=59
         )

--- a/engine/apps/public_api/views/schedules.py
+++ b/engine/apps/public_api/views/schedules.py
@@ -1,5 +1,7 @@
+import datetime
 import logging
 
+import pytz
 from django_filters import rest_framework as filters
 from rest_framework import status
 from rest_framework.decorators import action
@@ -147,8 +149,14 @@ class OnCallScheduleChannelView(RateLimitHeadersMixin, UpdateSerializerMixin, Mo
         end_date = serializer.validated_data["end_date"]
         days_between_start_and_end = (end_date - start_date).days
 
-        final_schedule_events: ScheduleEvents = schedule.final_events("UTC", start_date, days_between_start_and_end)
+        datetime_start = datetime.datetime.combine(start_date, datetime.time.min, tzinfo=pytz.UTC) + datetime.timedelta(
+            milliseconds=1
+        )
+        datetime_end = datetime_start + datetime.timedelta(
+            days=days_between_start_and_end - 1, hours=23, minutes=59, seconds=59
+        )
 
+        final_schedule_events: ScheduleEvents = schedule.final_events(datetime_start, datetime_end)
         logger.info(
             f"Exporting oncall shifts for schedule {pk} between dates {start_date} and {end_date}. {len(final_schedule_events)} shift events were found."
         )

--- a/engine/apps/schedules/ical_utils.py
+++ b/engine/apps/schedules/ical_utils.py
@@ -61,7 +61,6 @@ IcalEvents = typing.List[IcalEvent]
 def users_in_ical(
     usernames_from_ical: typing.List[str],
     organization: "Organization",
-    include_viewers=False,
     users_to_filter: typing.Optional["UserQuerySet"] = None,
 ) -> typing.Sequence["User"]:
     """
@@ -94,11 +93,10 @@ def users_in_ical(
             }
         )
 
-    users_found_in_ical = organization.users
-    if not include_viewers:
-        users_found_in_ical = users_found_in_ical.filter(
-            **User.build_permissions_query(RBACPermission.Permissions.SCHEDULES_WRITE, organization)
-        )
+    # users_found_in_ical = organization.users
+    users_found_in_ical = organization.users.filter(
+        **User.build_permissions_query(RBACPermission.Permissions.SCHEDULES_WRITE, organization)
+    )
 
     users_found_in_ical = users_found_in_ical.filter(
         (Q(username__in=usernames_from_ical) | Q(email__lower__in=emails_from_ical))
@@ -338,7 +336,6 @@ def list_of_empty_shifts_in_schedule(
 def list_users_to_notify_from_ical(
     schedule: "OnCallSchedule",
     events_datetime: typing.Optional[datetime.datetime] = None,
-    include_viewers: bool = False,
     users_to_filter: typing.Optional["UserQuerySet"] = None,
 ) -> typing.Sequence["User"]:
     """
@@ -349,7 +346,6 @@ def list_users_to_notify_from_ical(
         schedule,
         events_datetime,
         events_datetime,
-        include_viewers=include_viewers,
         users_to_filter=users_to_filter,
     )
 
@@ -358,35 +354,15 @@ def list_users_to_notify_from_ical_for_period(
     schedule: "OnCallSchedule",
     start_datetime: datetime.datetime,
     end_datetime: datetime.datetime,
-    include_viewers=False,
     users_to_filter=None,
 ) -> typing.Sequence["User"]:
-    # get list of iCalendars from current iCal files. If there is more than one calendar, primary calendar will always
-    # be the first
-    calendars = schedule.get_icalendars()
-    # reverse calendars to make overrides calendar the first, if schedule is iCal
-    calendars = calendars[::-1]
     users_found_in_ical: typing.Sequence["User"] = []
-    # at first check overrides calendar and return users from it if it exists and on-call users are found
-    for calendar in calendars:
-        if calendar is None:
-            continue
-        events = ical_events.get_events_from_ical_between(calendar, start_datetime, end_datetime)
+    events = schedule.final_events(start_datetime, end_datetime)
+    usernames = []
+    for event in events:
+        usernames += [u["email"] for u in event.get("users", [])]
 
-        parsed_ical_events: typing.Dict[int, typing.List[str]] = {}
-        for event in events:
-            current_usernames, current_priority = get_usernames_from_ical_event(event)
-            parsed_ical_events.setdefault(current_priority, []).extend(current_usernames)
-        # find users by usernames. if users are not found for shift, get users from lower priority
-        for _, usernames in sorted(parsed_ical_events.items(), reverse=True):
-            users_found_in_ical = users_in_ical(
-                usernames, schedule.organization, include_viewers=include_viewers, users_to_filter=users_to_filter
-            )
-            if users_found_in_ical:
-                break
-        if users_found_in_ical:
-            # if users are found in the overrides calendar, there is no need to check primary calendar
-            break
+    users_found_in_ical = users_in_ical(usernames, schedule.organization, users_to_filter=users_to_filter)
     return users_found_in_ical
 
 

--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -307,9 +307,8 @@ class OnCallSchedule(PolymorphicModel):
 
     def filter_events(
         self,
-        user_timezone,
-        starting_date,
-        days,
+        datetime_start,
+        datetime_end,
         with_empty=False,
         with_gap=False,
         filter_by=None,
@@ -320,11 +319,10 @@ class OnCallSchedule(PolymorphicModel):
         shifts = (
             list_of_oncall_shifts_from_ical(
                 self,
-                starting_date,
-                user_timezone,
+                datetime_start,
+                datetime_end,
                 with_empty,
                 with_gap,
-                days=days,
                 filter_by=filter_by,
                 from_cached_final=from_cached_final,
             )
@@ -369,26 +367,23 @@ class OnCallSchedule(PolymorphicModel):
         # combine multiple-users same-shift events into one
         return self._merge_events(events)
 
-    def final_events(self, user_tz, starting_date, days):
+    def final_events(self, datetime_start, datetime_end):
         """Return schedule final events, after resolving shifts and overrides."""
-        events = self.filter_events(
-            user_tz, starting_date, days=days, with_empty=True, with_gap=True, all_day_datetime=True
-        )
+        events = self.filter_events(datetime_start, datetime_end, with_empty=True, with_gap=True, all_day_datetime=True)
         events = self._resolve_schedule(events)
         return events
 
     def refresh_ical_final_schedule(self):
-        tz = "UTC"
         now = timezone.now()
         # window to consider: from now, -15 days + 6 months
         delta = EXPORT_WINDOW_DAYS_BEFORE
-        starting_datetime = now - datetime.timedelta(days=delta)
-        starting_date = starting_datetime.date()
         days = EXPORT_WINDOW_DAYS_AFTER + delta
+        datetime_start = now.replace(hour=0, minute=0, second=0, microsecond=0) - datetime.timedelta(days=delta)
+        datetime_end = datetime_start + datetime.timedelta(days=days - 1, hours=23, minutes=59, seconds=59)
 
         # setup calendar with final schedule shift events
         calendar = create_base_icalendar(self.name)
-        events = self.final_events(tz, starting_date, days)
+        events = self.final_events(datetime_start, datetime_end)
         updated_ids = set()
         for e in events:
             for u in e["users"]:
@@ -417,12 +412,12 @@ class OnCallSchedule(PolymorphicModel):
                         dtend_datetime = datetime.datetime.combine(
                             dtend.dt, datetime.datetime.min.time(), tzinfo=pytz.UTC
                         )
-                    if dtend_datetime and dtend_datetime < starting_datetime:
+                    if dtend_datetime and dtend_datetime < datetime_start:
                         # event ended before window start
                         continue
                     is_cancelled = component.get(ICAL_STATUS)
                     last_modified = component.get(ICAL_LAST_MODIFIED)
-                    if is_cancelled and last_modified and last_modified.dt < starting_datetime:
+                    if is_cancelled and last_modified and last_modified.dt < datetime_start:
                         # drop already ended events older than the window we consider
                         continue
                     elif is_cancelled and not last_modified:
@@ -441,17 +436,18 @@ class OnCallSchedule(PolymorphicModel):
         self.save(update_fields=["cached_ical_final_schedule"])
 
     def upcoming_shift_for_user(self, user, days=7):
-        user_tz = user.timezone or "UTC"
         now = timezone.now()
         # consider an extra day before to include events from UTC yesterday
-        starting_date = now.date() - datetime.timedelta(days=1)
+        datetime_start = now - datetime.timedelta(days=1)
+        datetime_end = datetime_start + datetime.timedelta(days=days)
+
         current_shift = upcoming_shift = None
 
         if self.cached_ical_final_schedule is None:
             # no final schedule info available
             return None, None
 
-        events = self.filter_events(user_tz, starting_date, days=days, all_day_datetime=True, from_cached_final=True)
+        events = self.filter_events(datetime_start, datetime_end, all_day_datetime=True, from_cached_final=True)
         for e in events:
             if e["end"] < now:
                 # shift is finished, ignore
@@ -475,13 +471,13 @@ class OnCallSchedule(PolymorphicModel):
         """
         # get events to consider for calculation
         if date is None:
-            today = datetime.datetime.now(tz=timezone.utc)
+            today = timezone.now()
             date = today - datetime.timedelta(days=7 - today.weekday())  # start of next week in UTC
         if days is None:
             days = 52 * 7  # consider next 52 weeks (~1 year)
+        datetime_end = date + datetime.timedelta(days=days - 1, hours=23, minutes=59, seconds=59)
 
-        events = self.final_events(user_tz="UTC", starting_date=date, days=days)
-
+        events = self.final_events(date, datetime_end)
         # an event is “good” if it's not a gap and not empty
         good_events: ScheduleEvents = [event for event in events if not event["is_gap"] and not event["is_empty"]]
         if not good_events:
@@ -757,7 +753,7 @@ class OnCallSchedule(PolymorphicModel):
             ical += f"{end_line}\r\n"
         return ical
 
-    def preview_shift(self, custom_shift, user_tz, starting_date, days, updated_shift_pk=None):
+    def preview_shift(self, custom_shift, datetime_start, datetime_end, updated_shift_pk=None):
         """Return unsaved rotation and final schedule preview events."""
         if custom_shift.type == CustomOnCallShift.TYPE_OVERRIDE:
             qs = self.custom_shifts.filter(type=CustomOnCallShift.TYPE_OVERRIDE)
@@ -790,7 +786,8 @@ class OnCallSchedule(PolymorphicModel):
         setattr(self, ical_attr, ical_file)
 
         # filter events using a temporal overriden calendar including the not-yet-saved shift
-        events = self.filter_events(user_tz, starting_date, days=days, with_empty=True, with_gap=True)
+        events = self.filter_events(datetime_start, datetime_end, with_empty=True, with_gap=True)
+
         # return preview events for affected shifts
         updated_shift_pks = {s.public_primary_key for s in extra_shifts}
         shift_events = [e.copy() for e in events if e["shift"]["pk"] in updated_shift_pks]
@@ -993,11 +990,11 @@ class OnCallScheduleCalendar(OnCallSchedule):
             ical += f"{end_line}\r\n"
         return ical
 
-    def preview_shift(self, custom_shift, user_tz, starting_date, days, updated_shift_pk=None):
+    def preview_shift(self, custom_shift, datetime_start, datetime_end, updated_shift_pk=None):
         """Return unsaved rotation and final schedule preview events."""
         if custom_shift.type != CustomOnCallShift.TYPE_OVERRIDE:
             raise ValueError("Invalid shift type")
-        return super().preview_shift(custom_shift, user_tz, starting_date, days, updated_shift_pk=updated_shift_pk)
+        return super().preview_shift(custom_shift, datetime_start, datetime_end, updated_shift_pk=updated_shift_pk)
 
     @property
     def insight_logs_type_verbal(self):

--- a/engine/apps/schedules/tests/test_ical_utils.py
+++ b/engine/apps/schedules/tests/test_ical_utils.py
@@ -83,23 +83,18 @@ def test_users_in_ical_email_case_insensitive(make_organization_and_user, make_u
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("include_viewers", [True, False])
-def test_users_in_ical_viewers_inclusion(make_organization_and_user, make_user_for_organization, include_viewers):
+def test_users_in_ical_viewers_inclusion(make_organization_and_user, make_user_for_organization):
     organization, user = make_organization_and_user()
     viewer = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
 
     usernames = [user.username, viewer.username]
-    result = users_in_ical(usernames, organization, include_viewers=include_viewers)
-    if include_viewers:
-        assert set(result) == {user, viewer}
-    else:
-        assert set(result) == {user}
+    result = users_in_ical(usernames, organization)
+    assert set(result) == {user}
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("include_viewers", [True, False])
 def test_list_users_to_notify_from_ical_viewers_inclusion(
-    make_organization_and_user, make_user_for_organization, make_schedule, make_on_call_shift, include_viewers
+    make_organization_and_user, make_user_for_organization, make_schedule, make_on_call_shift
 ):
     organization, user = make_organization_and_user()
     viewer = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
@@ -121,14 +116,10 @@ def test_list_users_to_notify_from_ical_viewers_inclusion(
 
     # get users on-call
     date = date + timezone.timedelta(minutes=5)
-    users_on_call = list_users_to_notify_from_ical(schedule, date, include_viewers=include_viewers)
+    users_on_call = list_users_to_notify_from_ical(schedule, date)
 
-    if include_viewers:
-        assert len(users_on_call) == 2
-        assert set(users_on_call) == {user, viewer}
-    else:
-        assert len(users_on_call) == 1
-        assert set(users_on_call) == {user}
+    assert len(users_on_call) == 1
+    assert set(users_on_call) == {user}
 
 
 @pytest.mark.django_db
@@ -161,7 +152,7 @@ def test_list_users_to_notify_from_ical_until_terminated_event(
     date = date + timezone.timedelta(minutes=5)
     # this should not raise despite the shift configuration (until < rotation start)
     users_on_call = list_users_to_notify_from_ical(schedule, date)
-    assert users_on_call == []
+    assert list(users_on_call) == []
 
 
 @pytest.mark.django_db

--- a/engine/apps/schedules/tests/test_quality_score.py
+++ b/engine/apps/schedules/tests/test_quality_score.py
@@ -190,7 +190,7 @@ def test_get_schedule_score_weekdays(
     assert response.json() == {
         "total_score": 86,
         "comments": [
-            {"type": "warning", "text": "Schedule has gaps (29% not covered)"},
+            {"type": "warning", "text": "Schedule has gaps (28% not covered)"},
             {"type": "info", "text": "Schedule is perfectly balanced"},
         ],
         "overloaded_users": [],
@@ -351,7 +351,7 @@ def test_get_schedule_score_all_week_imbalanced_weekends(
             {
                 "id": user.public_primary_key,
                 "username": user.username,
-                "score": 29,
+                "score": 28,
             }
             for user in users[:4]
         ],


### PR DESCRIPTION
First step towards reusing `schedule.final_events` where current / upcoming schedule shifts information is needed (eg. escalations, shift notifications, etc)