### PR TITLE
remove excess alerts_alert table save

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -257,15 +257,12 @@ class Alert(models.Model):
         return distinction
 
 
-def listen_for_alert_model_save(sender, instance, created, *args, **kwargs):
+def listen_for_alert_model_save(sender: Alert, instance: Alert, created: bool, *args, **kwargs):
     AlertGroup = apps.get_model("alerts", "AlertGroup")
     """
     Here we invoke AlertShootingStep by model saving action.
     """
     if created:
-        # RFCT - why additinal save ?
-        instance.save()
-
         group = instance.group
         # Store exact alert which resolved group.
         if group.resolved_by == AlertGroup.SOURCE and group.resolved_by_alert is None:
@@ -278,7 +275,7 @@ def listen_for_alert_model_save(sender, instance, created, *args, **kwargs):
             distribute_alert.apply_async((instance.pk,), countdown=TASK_DELAY_SECONDS)
 
 
-# Connect signal to  base Alert class
+# Connect signal to base Alert class
 post_save.connect(listen_for_alert_model_save, Alert)
 
 # And subscribe for events from child classes


### PR DESCRIPTION
# What this PR does

This `instance.save()` call basically results in an extra/unnecessary `UPDATE` statement, for each inserted alert.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
