### PR TITLE
Added REDIS_PORT mapping from values

### DIFF
--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -500,11 +500,19 @@
 {{- end }}
 {{- end }}
 
+{{- define "snippet.redis.port" -}}
+{{ if not .Values.redis.enabled -}}
+  {{ required "externalRedis.port is required if not redis.enabled" .Values.externalRedis.port | quote }}
+{{- else -}}
+  6379
+{{- end }}
+{{- end }}
+
 {{- define "snippet.redis.env" -}}
 - name: REDIS_HOST
   value: {{ include "snippet.redis.host" . }}
 - name: REDIS_PORT
-  value: "6379"
+  value: "{{ include "snippet.redis.port" . }}"
 - name: REDIS_PASSWORD
   valueFrom:
     secretKeyRef:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -361,6 +361,8 @@ redis:
 externalRedis:
   host:
   password:
+  # To select a redis database you must use 6379/2
+  port: "6379"
   # Use an existing secret for the redis password
   existingSecret:
   # The key in the secret containing the redis password


### PR DESCRIPTION
# What this PR does
Now we can use custom redis port with specific database number

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
