### PR TITLE
add option for sidecar containers in helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [Helm] Add `extraContainers` for engine and celery pods to define sidecars by @lu1as ([#2650](https://github.com/grafana/oncall/pull/2650))
+- [Helm] Add `extraContainers` for engine, celery and migrate-job pods to define sidecars by @lu1as ([#2650](https://github.com/grafana/oncall/pull/2650))
 
 ## v1.3.18 (2023-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Apply swap requests details to schedule events ([#2677](https://github.com/grafana/oncall/pull/2677))
 
+### Added
+
+- [Helm] Add `extraContainers` for engine and celery pods to define sidecars by @lu1as ([#2650](https://github.com/grafana/oncall/pull/2650))
+
 ## v1.3.18 (2023-07-28)
 
 ### Changed

--- a/helm/oncall/templates/celery/_deployment.tpl
+++ b/helm/oncall/templates/celery/_deployment.tpl
@@ -90,4 +90,7 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.celery.resources | nindent 12 }}
+      {{- with .Values.celery.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
 {{- end}}

--- a/helm/oncall/templates/engine/deployment.yaml
+++ b/helm/oncall/templates/engine/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             timeoutSeconds: 3
           resources:
             {{- toYaml .Values.engine.resources | nindent 12 }}
+      {{- with .Values.engine.extraContainers }}
+        {{- tpl . $ | nindent 8 }}
+      {{- end }}
       {{- with .Values.engine.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -93,4 +93,7 @@ spec:
           {{- include "oncall.extraEnvs" . | nindent 12 }}
         resources:
           {{- toYaml .Values.engine.resources | nindent 12 }}
+      {{- with .Values.migrate.extraContainers }}
+      {{- tpl . $ | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/helm/oncall/tests/extra_containers_celery_test.yaml
+++ b/helm/oncall/tests/extra_containers_celery_test.yaml
@@ -1,0 +1,25 @@
+suite: test extra containers for celery pod
+templates:
+  - celery/deployment-celery.yaml
+release:
+  name: oncall
+tests:
+  - it: celery.extraContainers="" -> should not create additional containers
+    set:
+      celery.extraContainers: ""
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count : 1
+
+  - it: celery.extraContainers -> should add sidecar containers
+    set:
+      celery.extraContainers: |
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: cloud-sql-proxy
+            image: gcr.io/cloud-sql-connectors/cloud-sql-proxy

--- a/helm/oncall/tests/extra_containers_engine_test.yaml
+++ b/helm/oncall/tests/extra_containers_engine_test.yaml
@@ -1,0 +1,25 @@
+suite: test extra containers for engine pod
+templates:
+  - engine/deployment.yaml
+release:
+  name: oncall
+tests:
+  - it: engine.extraContainers="" -> should not create additional containers
+    set:
+      engine.extraContainers: ""
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count : 1
+
+  - it: engine.extraContainers -> should add sidecar containers
+    set:
+      engine.extraContainers: |
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: cloud-sql-proxy
+            image: gcr.io/cloud-sql-connectors/cloud-sql-proxy

--- a/helm/oncall/tests/migrate_extra_containers_test.yaml
+++ b/helm/oncall/tests/migrate_extra_containers_test.yaml
@@ -1,0 +1,25 @@
+suite: test migrate extra containers
+templates:
+  - engine/job-migrate.yaml
+release:
+  name: oncall
+tests:
+  - it: migrate.extraContainers="" -> should not create additional containers
+    set:
+      migrate.extraContainers: ""
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count : 1
+
+  - it: migrate.extraContainers -> should add sidecar containers
+    set:
+      migrate.extraContainers: |
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy
+    asserts:
+      - contains:
+          path: spec.template.spec.containers
+          content:
+            name: cloud-sql-proxy
+            image: gcr.io/cloud-sql-connectors/cloud-sql-proxy

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -65,6 +65,16 @@ engine:
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
 
+  # Extra containers which runs as sidecar
+  extraContainers: ""
+  # extraContainers: |
+  # - name: cloud-sql-proxy
+  #   image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.2
+  #   args:
+  #     - --private-ip
+  #     - --port=5432
+  #     - example:europe-west3:grafana-oncall-db
+
 # Celery workers pods configuration
 celery:
   replicaCount: 1
@@ -110,6 +120,16 @@ celery:
   ## Priority class for the pods
   ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   priorityClassName: ""
+
+  # Extra containers which runs as sidecar
+  extraContainers: ""
+  # extraContainers: |
+  # - name: cloud-sql-proxy
+  #   image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.2
+  #   args:
+  #     - --private-ip
+  #     - --port=5432
+  #     - example:europe-west3:grafana-oncall-db
 
 oncall:
   # Override default MIRAGE_CIPHER_IV (must be 16 bytes long)

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -241,6 +241,15 @@ migrate:
   ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
 
+  # Extra containers which runs as sidecar
+  extraContainers: ""
+  # extraContainers: |
+  # - name: cloud-sql-proxy
+  #   image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.2
+  #   args:
+  #     - --private-ip
+  #     - --port=5432
+  #     - example:europe-west3:grafana-oncall-db
 
 # Sets environment variables with name capitalized and prefixed with UWSGI_, and dashes are substituted with underscores.
 # see more: https://uwsgi-docs.readthedocs.io/en/latest/Configuration.html#environment-variables


### PR DESCRIPTION
# What this PR does
Adds support for defining extra containers which run as sidecar alongside the celery and engine containers 

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
