### PR TITLE
Update basic data after installation

### DIFF
--- a/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
+++ b/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
@@ -103,7 +103,6 @@ export const Root = observer((props: AppRootProps) => {
 
   const updateBasicData = async () => {
     await store.updateBasicData();
-    await store.alertGroupStore.fetchIRMPlan();
   };
 
   const location = useLocation();

--- a/grafana-plugin/src/state/rootBaseStore/index.ts
+++ b/grafana-plugin/src/state/rootBaseStore/index.ts
@@ -125,6 +125,7 @@ export class RootBaseStore {
       this.escalationPolicyStore.updateWebEscalationPolicyOptions(),
       this.escalationPolicyStore.updateEscalationPolicyOptions(),
       this.escalationPolicyStore.updateNumMinutesInWindowOptions(),
+      this.alertGroupStore.fetchIRMPlan(),
     ]);
   }
 
@@ -198,6 +199,7 @@ export class RootBaseStore {
            * therefore there is no need to trigger an additional/separate sync, nor poll a status
            */
           await PluginState.installPlugin();
+          this.updateBasicData();
         } catch (e) {
           return this.setupPluginError(
             PluginState.getHumanReadableErrorFromOnCallError(e, this.onCallApiUrl, 'install')


### PR DESCRIPTION
# What this PR does
Adding additional `UpdateBasicData` after installation, to handle that case
1. Plugin calls `UpdateBasicData` in parallel to `setupPlugin` which handles sync/install
2. If plugin is not installed, `UpdateBasicData` from step 1 will fail with 403s

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
