### PR TITLE
Add notifications:read permission to OnCaller role

### DIFF
--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -339,6 +339,7 @@
           { "action": "grafana-oncall-app.chatops:read" },
           { "action": "grafana-oncall-app.outgoing-webhooks:read" },
           { "action": "grafana-oncall-app.maintenance:read" },
+          { "action": "grafana-oncall-app.notifications:read" },
           { "action": "grafana-oncall-app.notification-settings:read" },
           { "action": "grafana-oncall-app.user-settings:read" },
           { "action": "grafana-oncall-app.other-settings:read" }


### PR DESCRIPTION
This should enable users with the OnCaller role to be added in a schedule rotation.

Related to
https://github.com/grafana/support-escalations/issues/6883