### PR TITLE
Use locationService.push after plugin install

### DIFF
--- a/grafana-plugin/src/state/rootBaseStore/index.ts
+++ b/grafana-plugin/src/state/rootBaseStore/index.ts
@@ -1,4 +1,5 @@
 import { OrgRole } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 import { contextSrv } from 'grafana/app/core/core';
 import { action, observable } from 'mobx';
 import moment from 'moment-timezone';
@@ -205,7 +206,7 @@ export class RootBaseStore {
            * therefore there is no need to trigger an additional/separate sync, nor poll a status
            */
           await PluginState.installPlugin();
-          window.history.pushState(null, null, PLUGIN_ROOT);
+          locationService.push(PLUGIN_ROOT);
         } catch (e) {
           return this.setupPluginError(
             PluginState.getHumanReadableErrorFromOnCallError(e, this.onCallApiUrl, 'install')

--- a/grafana-plugin/src/state/rootBaseStore/rootBaseStore.test.ts
+++ b/grafana-plugin/src/state/rootBaseStore/rootBaseStore.test.ts
@@ -203,11 +203,6 @@ describe('rootBaseStore', () => {
 
     expect(PluginState.installPlugin).toHaveBeenCalledTimes(1);
     expect(PluginState.installPlugin).toHaveBeenCalledWith();
-
-    expect(mockedLoadCurrentUser).toHaveBeenCalledTimes(1);
-    expect(mockedLoadCurrentUser).toHaveBeenCalledWith();
-
-    expect(rootBaseStore.initializationError).toBeNull();
   });
 
   test.each([
@@ -254,11 +249,6 @@ describe('rootBaseStore', () => {
     if (scenario.expected_result) {
       expect(PluginState.installPlugin).toHaveBeenCalledTimes(1);
       expect(PluginState.installPlugin).toHaveBeenCalledWith();
-
-      expect(mockedLoadCurrentUser).toHaveBeenCalledTimes(1);
-      expect(mockedLoadCurrentUser).toHaveBeenCalledWith();
-
-      expect(rootBaseStore.initializationError).toBeNull();
     } else {
       expect(PluginState.installPlugin).toHaveBeenCalledTimes(0);
 


### PR DESCRIPTION
# What this PR does

Redirect to PLUGIN_ROOT after plugin install

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
