### PR TITLE
Fix `alerts.0028` migration for SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix one of the latest migrations failing on SQLite by @vadimkerr ([#2680](https://github.com/grafana/oncall/pull/2680))
+
 ## v1.3.18 (2023-07-28)
 
 ### Changed

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     libmariadb-dev \
     libpq-dev \
-    netcat-openbsd \
+    netcat-traditional \
     curl \
     bash \
     git \

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim-buster AS base
+FROM python:3.11.4-slim-bookworm AS base
 
 # Create a group and user to run an app
 ENV APP_USER=appuser
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     libmariadb-dev \
     libpq-dev \
-    netcat \
+    netcat-openbsd \
     curl \
     bash \
     git \


### PR DESCRIPTION
# What this PR does

Fixes an issue with [alerts.0028](https://github.com/grafana/oncall/blob/f77a54b518ab8f1f42e33ca43328b75fde1903b9/engine/apps/alerts/migrations/0028_drop_alertreceivechannel_restricted_at.py) migration failing on SQLite with the following error: `sqlite3.OperationalError: near "DROP": syntax error`. 

The issue is fixed by updating the SQLite version from `3.27.2` to `3.40.1` (SQLite `3.35.0` introduced native support for dropping columns as per this [SO answer](https://stackoverflow.com/a/66399224)).

However, I couldn't find an easy way to independently update SQLite, since it's bundled into Python's standard library.
Updating the Docker image to use the latest Debian stable release fixes the issue as it already comes with SQLite `3.40.1` out of the box. So this PR effectively bumps the Debian version from 10 to 12, and bumps the Python version from `3.11.3` to `3.11.4`.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
