### PR TITLE
Add filter_shift_swaps endpoint to schedules API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Add filter_shift_swaps endpoint to schedules API ([#2684](https://github.com/grafana/oncall/pull/2684))
+
 ## v1.3.19 (2023-07-28)
 
 ### Fixed

--- a/engine/apps/api/tests/test_shift_swaps.py
+++ b/engine/apps/api/tests/test_shift_swaps.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIClient
 
 from apps.api.permissions import LegacyAccessControlRole
 from apps.schedules.models import OnCallScheduleWeb, ShiftSwapRequest
+from common.api_helpers.utils import serialize_datetime_as_utc_timestamp
 from common.insight_log import EntityEvent
 
 description = "my shift swap request"
@@ -36,18 +37,14 @@ def ssr_setup(
     return _ssr_setup
 
 
-def _convert_dt_to_sr(dt: datetime.datetime) -> str:
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-
-
 def _construct_serialized_object(ssr: ShiftSwapRequest, status="open", description=None, benefactor=None):
     return {
         "id": ssr.public_primary_key,
-        "created_at": _convert_dt_to_sr(ssr.created_at),
-        "updated_at": _convert_dt_to_sr(ssr.updated_at),
+        "created_at": serialize_datetime_as_utc_timestamp(ssr.created_at),
+        "updated_at": serialize_datetime_as_utc_timestamp(ssr.updated_at),
         "schedule": ssr.schedule.public_primary_key,
-        "swap_start": _convert_dt_to_sr(ssr.swap_start),
-        "swap_end": _convert_dt_to_sr(ssr.swap_end),
+        "swap_start": serialize_datetime_as_utc_timestamp(ssr.swap_start),
+        "swap_end": serialize_datetime_as_utc_timestamp(ssr.swap_end),
         "beneficiary": ssr.beneficiary.public_primary_key,
         "status": status,
         "benefactor": benefactor,
@@ -172,8 +169,8 @@ def test_create(
     ssr = ShiftSwapRequest.objects.get(public_primary_key=response.json()["id"])
     expected_response = _construct_serialized_object(ssr) | {
         **data,
-        "swap_start": _convert_dt_to_sr(tomorrow),
-        "swap_end": _convert_dt_to_sr(two_days_from_now),
+        "swap_start": serialize_datetime_as_utc_timestamp(tomorrow),
+        "swap_end": serialize_datetime_as_utc_timestamp(two_days_from_now),
     }
 
     assert response.status_code == status.HTTP_201_CREATED
@@ -282,8 +279,8 @@ def test_update(
     data = {
         "description": "hellooooo world",
         "schedule": ssr.schedule.public_primary_key,
-        "swap_start": _convert_dt_to_sr(ssr.swap_start),
-        "swap_end": _convert_dt_to_sr(ssr.swap_end),
+        "swap_start": serialize_datetime_as_utc_timestamp(ssr.swap_start),
+        "swap_end": serialize_datetime_as_utc_timestamp(ssr.swap_end),
     }
 
     response = client.put(url, data=json.dumps(data), content_type="application/json", **auth_headers)
@@ -380,8 +377,8 @@ def test_update_own_ssr_permissions(ssr_setup, make_user_auth_headers, role, exp
     data = {
         "description": "hellooooo world",
         "schedule": ssr.schedule.public_primary_key,
-        "swap_start": _convert_dt_to_sr(ssr.swap_start),
-        "swap_end": _convert_dt_to_sr(ssr.swap_end),
+        "swap_start": serialize_datetime_as_utc_timestamp(ssr.swap_start),
+        "swap_end": serialize_datetime_as_utc_timestamp(ssr.swap_end),
     }
 
     response = client.put(
@@ -449,8 +446,8 @@ def test_partial_update_time_related_fields(ssr_setup, make_user_auth_headers):
     auth_headers = make_user_auth_headers(beneficiary, token)
 
     # but if we do PATCH a time related field, we must specify all the time fields
-    swap_start = {"swap_start": _convert_dt_to_sr(tomorrow + datetime.timedelta(days=5))}
-    swap_end = {"swap_end": _convert_dt_to_sr(tomorrow + datetime.timedelta(days=10))}
+    swap_start = {"swap_start": serialize_datetime_as_utc_timestamp(tomorrow + datetime.timedelta(days=5))}
+    swap_end = {"swap_end": serialize_datetime_as_utc_timestamp(tomorrow + datetime.timedelta(days=10))}
     valid = swap_start | swap_end
 
     for case in [swap_start, swap_end]:
@@ -518,8 +515,8 @@ def test_benefactor_and_beneficiary_are_read_only_fields(ssr_setup, make_user_au
     base_data = {
         "description": "hellooooo world",
         "schedule": ssr.schedule.public_primary_key,
-        "swap_start": _convert_dt_to_sr(ssr.swap_start),
-        "swap_end": _convert_dt_to_sr(ssr.swap_end),
+        "swap_start": serialize_datetime_as_utc_timestamp(ssr.swap_start),
+        "swap_end": serialize_datetime_as_utc_timestamp(ssr.swap_end),
     }
 
     update_beneficiary = {"beneficiary": benefactor.public_primary_key}
@@ -634,7 +631,9 @@ def test_take(ssr_setup, make_user_auth_headers):
 
     assert response.status_code == status.HTTP_200_OK
     assert response_json == expected_response
-    assert updated_at != _convert_dt_to_sr(ssr.updated_at)  # validate that updated_at is auto-updated on take
+    assert updated_at != serialize_datetime_as_utc_timestamp(
+        ssr.updated_at
+    )  # validate that updated_at is auto-updated on take
 
     url = reverse("api-internal:shift_swap-detail", kwargs={"pk": ssr.public_primary_key})
     response = client.get(url, format="json", **auth_headers)

--- a/engine/common/api_helpers/utils.py
+++ b/engine/common/api_helpers/utils.py
@@ -161,3 +161,7 @@ def get_date_range_from_request(request: Request) -> typing.Tuple[str, datetime.
 
 def check_phone_number_is_valid(phone_number):
     return re.match(r"^\+\d{8,15}$", phone_number) is not None
+
+
+def serialize_datetime_as_utc_timestamp(dt: datetime.datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")


### PR DESCRIPTION
Example request/response

`GET /api/internal/v1/schedules/SVV8E9JGLLR9T/filter_shift_swaps/?date=2023-07-22&days=9`

```
{
	"shift_swaps": [
		{
			"id": "SSR1QJ93UNCUPC4",
			"created_at": "2023-07-27T12:55:32.188232Z",
			"updated_at": "2023-07-28T13:28:08.027124Z",
			"status": "taken",
			"schedule": "SVV8E9JGLLR9T",
			"swap_start": "2023-07-24T21:00:00.000000Z",
			"swap_end": "2023-08-04T03:00:00.000000Z",
			"description": null,
			"beneficiary": "UWJWIN8MQ1GYL",
			"benefactor": "UVSKHRA4YU328"
		}
	]
}
```