### PR TITLE
Add

### DIFF
--- a/engine/apps/alerts/models/escalation_policy.py
+++ b/engine/apps/alerts/models/escalation_policy.py
@@ -129,7 +129,7 @@ class EscalationPolicy(OrderedModel):
         STEP_TRIGGER_CUSTOM_WEBHOOK: ("Trigger webhook {{custom_webhook}}", "Trigger webhook"),
         STEP_NOTIFY_USERS_QUEUE: ("Round robin notification for {{users}}", "Notify users one by one (round-robin)"),
         STEP_NOTIFY_IF_TIME: (
-            "Continue escalation if current time is in {{timerange}} ",
+            "Continue escalation if current UTC time is in {{timerange}} ",
             "Continue escalation if current time is in range",
         ),
         STEP_NOTIFY_IF_NUM_ALERTS_IN_TIME_WINDOW: (

--- a/engine/apps/alerts/models/escalation_policy.py
+++ b/engine/apps/alerts/models/escalation_policy.py
@@ -129,7 +129,7 @@ class EscalationPolicy(OrderedModel):
         STEP_TRIGGER_CUSTOM_WEBHOOK: ("Trigger webhook {{custom_webhook}}", "Trigger webhook"),
         STEP_NOTIFY_USERS_QUEUE: ("Round robin notification for {{users}}", "Notify users one by one (round-robin)"),
         STEP_NOTIFY_IF_TIME: (
-            "Continue escalation if current UTC time is in {{timerange}} ",
+            "Continue escalation if current UTC time is in {{timerange}}",
             "Continue escalation if current time is in range",
         ),
         STEP_NOTIFY_IF_NUM_ALERTS_IN_TIME_WINDOW: (


### PR DESCRIPTION
Change wording to make sure it's clear UTC time is used for the `Continue escalation if current time is in range` escalation step.

<img width="1249" alt="Screenshot 2023-08-02 at 14 37 22" src="https://github.com/grafana/oncall/assets/20116910/92bf9a6f-2baa-42c4-a5c5-2bc8f1b9576e">
