### PR TITLE
Add stack slug to organization options for direct paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Add stack slug to organization options for direct paging Slash command by @vadimkerr ([#2743](https://github.com/grafana/oncall/pull/2743))
+
 ## v1.3.22 (2023-08-03)
 
 ### Added

--- a/engine/apps/slack/scenarios/paging.py
+++ b/engine/apps/slack/scenarios/paging.py
@@ -515,7 +515,7 @@ def _get_organization_select(
             {
                 "text": {
                     "type": "plain_text",
-                    "text": f"{org.org_title}",
+                    "text": f"{org.org_title} ({org.stack_slug})",
                     "emoji": True,
                 },
                 "value": f"{org.pk}",

--- a/engine/apps/slack/tests/test_scenario_steps/test_paging.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_paging.py
@@ -24,7 +24,9 @@ from apps.slack.scenarios.paging import (
     OnPagingUserChange,
     Policy,
     StartDirectPaging,
+    _get_organization_select,
 )
+from apps.user_management.models import Organization
 
 
 def make_slack_payload(
@@ -401,3 +403,13 @@ def test_remove_schedule(make_organization_and_user_with_slack_identities, make_
     metadata = json.loads(mock_slack_api_call.call_args.kwargs["view"]["private_metadata"])
     assert metadata[DataKey.SCHEDULES] == {}
     assert metadata[DataKey.USERS] == {str(user.pk): Policy.DEFAULT}
+
+
+@pytest.mark.django_db
+def test_get_organization_select(make_organization):
+    organization = make_organization(org_title="Organization", stack_slug="stack_slug")
+    select = _get_organization_select(Organization.objects.filter(pk=organization.pk), organization, "test")
+
+    assert len(select["element"]["options"]) == 1
+    assert select["element"]["options"][0]["value"] == str(organization.pk)
+    assert select["element"]["options"][0]["text"]["text"] == "Organization (stack_slug)"


### PR DESCRIPTION
# What this PR does

Adds stack slug to organization options for `/escalate` (a single Grafana org might have multiple stacks).

<img width="514" alt="Screenshot 2023-08-03 at 14 24 58" src="https://github.com/grafana/oncall/assets/20116910/4a43867d-6f6e-4050-a30e-204aeaded663">

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
