### PR TITLE
fix make start command when using mysql/postgres as db

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -35,7 +35,7 @@ environment variable.
    **NOTE**: the `docker-compose-developer.yml` file uses some syntax/features that are only supported by Docker Compose
    v2. For instructions on how to enable this (if you haven't already done so),
    see [here](https://www.docker.com/blog/announcing-compose-v2-general-availability/). Ensure you have Docker Compose
-   version 2.10 or above installed - update instructions are [here](https://docs.docker.com/compose/install/linux/).
+   version 2.20.2 or above installed - update instructions are [here](https://docs.docker.com/compose/install/linux/).
 2. Run `make init start`. By default this will run everything in Docker, using SQLite as the database and Redis as the
    message broker/cache. See [`COMPOSE_PROFILES`](#compose_profiles) below for more details on how to swap
    out/disable which components are run in Docker.

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -144,12 +144,16 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       mysql:
         condition: service_healthy
+        required: false
       rabbitmq:
         condition: service_healthy
+        required: false
       redis:
         condition: service_healthy
+        required: false
     profiles:
       - engine
 
@@ -208,7 +212,7 @@ services:
     container_name: mysql
     labels: *oncall-labels
     image: mysql:8.0.32
-    command: >
+    command: >-
       --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4
       --collation-server=utf8mb4_unicode_ci --max_connections=1024
     restart: always
@@ -236,7 +240,7 @@ services:
     container_name: mysql_to_create_grafana_db
     labels: *oncall-labels
     image: mysql:8.0.32
-    command: >
+    command: >-
       bash -c "mysql -h mysql -uroot -pempty
       -e 'CREATE DATABASE IF NOT EXISTS grafana CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
     depends_on:
@@ -276,7 +280,7 @@ services:
     container_name: postgres_to_create_grafana_db
     labels: *oncall-labels
     image: postgres:14.4
-    command: >
+    command: >-
       bash -c "PGPASSWORD=empty psql -U postgres
       -h postgres -tc \"SELECT 1 FROM pg_database WHERE datname = 'grafana'\" | grep -q 1 || PGPASSWORD=empty psql
       -U postgres -h postgres -c \"CREATE DATABASE grafana\""
@@ -326,8 +330,10 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: false
       mysql:
         condition: service_healthy
+        required: false
     profiles:
       - grafana
 volumes:

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -28,8 +28,7 @@ services:
     restart: always
     ports:
       - "8080:8080"
-    command: >
-      sh -c "uwsgi --ini uwsgi.ini"
+    command: sh -c "uwsgi --ini uwsgi.ini"
     environment: *oncall-environment
     depends_on:
       mysql:
@@ -68,7 +67,7 @@ services:
 
   mysql:
     image: mysql:8.0.32
-    command: >
+    command: >-
       --default-authentication-plugin=mysql_native_password
       --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     restart: always
@@ -123,7 +122,7 @@ services:
 
   mysql_to_create_grafana_db:
     image: mysql:8.0.32
-    command: >
+    command: >-
       bash -c "mysql -h ${MYSQL_HOST:-mysql} -uroot -p${MYSQL_PASSWORD:?err}
       -e 'CREATE DATABASE IF NOT EXISTS grafana CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ services:
     restart: always
     ports:
       - "8080:8080"
-    command: >
-      sh -c "uwsgi --ini uwsgi.ini"
+    command: sh -c "uwsgi --ini uwsgi.ini"
     environment: *oncall-environment
     volumes:
       - oncall_data:/var/lib/oncall


### PR DESCRIPTION
# What this PR does

Tested `make start` w/ both `mysql` and `postgres` in `COMPOSE_PROFILES` and things spin up properly.

- Fixes some `yaml` formatting issues introduced [here](https://github.com/grafana/oncall/pull/2728/files#diff-f5d10b03472abe3719098ae8a8855468e92524ebe790c39a34d2c632f3f0486d) in #2728 which were causing the `mysql` container to fail to start up when running `make start`
- Addresses #2492 by specifying `required: false` under `depends_on`, for containers in `docker-compose-developer.yml` which have container(s) which may be conditionally spun-up based on `COMPOSE_PROFILES`. Basically in v2.20.2 they introduced [this change](https://github.com/docker/compose/releases/tag/v2.20.2#:~:text=Add%20support%20of%20depends_on.required%20attribute%20by) which was a breaking change for our setup and preventing us from upgrading to >= 2.19.0.

## Which issue(s) this PR fixes

Closes #2492 

‼️ with this PR you will need to make sure you are running `docker-compose` >= `v2.20.2`, otherwise 👇  ‼️ 

![image](https://github.com/grafana/oncall/assets/9406895/312bdeb7-e1c5-4774-b2e9-6facddd641c1)


## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
