### PR TITLE
Use UserSettingsWrite instead of OtherSettingsWrite for phone tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Do not show override shortcut when web overrides are disabled ([#2745](https://github.com/grafana/oncall/pull/2745))
 - Handle ical schedule import with duplicated event UIDs ([#2760](https://github.com/grafana/oncall/pull/2760))
+- Allow Editor to access Phone Verification ([#2772](https://github.com/grafana/oncall/pull/2772))
 
 ## v1.3.22 (2023-08-03)
 

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/CloudPhoneSettings/CloudPhoneSettings.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/CloudPhoneSettings/CloudPhoneSettings.tsx
@@ -112,7 +112,7 @@ const CloudPhoneSettings = observer((props: CloudPhoneSettingsProps) => {
 
   return (
     <WithPermissionControlDisplay
-      userAction={UserActions.OtherSettingsWrite}
+      userAction={UserActions.UserSettingsWrite}
       title="OnCall uses Grafana Cloud for SMS and phone call notifications"
     >
       <VerticalGroup spacing="lg">

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/PhoneVerification/PhoneVerification.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/PhoneVerification/PhoneVerification.tsx
@@ -188,7 +188,7 @@ const PhoneVerification = observer((props: PhoneVerificationProps) => {
   }
 
   return (
-    <WithPermissionControlDisplay userAction={UserActions.OtherSettingsWrite}>
+    <WithPermissionControlDisplay userAction={UserActions.UserSettingsWrite}>
       <VerticalGroup>
         {isPhoneValid && !user.verified_phone_number && (
           <Alert severity="info" title="You will receive alerts to a new number after verification" />


### PR DESCRIPTION
# What this PR does

Sets the correct permission when accessing Phone Verification screen (Cloud/OSS)

## Which issue(s) this PR fixes

Fix for https://github.com/grafana/oncall/issues/2761

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
