### PR TITLE
Make field rbac_enabled readonly for organization endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix Slack acknowledgment reminders by @vadimkerr ([#2769](https://github.com/grafana/oncall/pull/2769))
+- Fix issue with updating "Require resolution note" setting by @Ferril ([#2782](https://github.com/grafana/oncall/pull/2782))
 
 ## v1.3.23 (2023-08-10)
 

--- a/engine/apps/api/serializers/organization.py
+++ b/engine/apps/api/serializers/organization.py
@@ -22,7 +22,7 @@ class OrganizationSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     name = serializers.CharField(required=False, allow_null=True, allow_blank=True, source="org_title")
     slack_channel = serializers.SerializerMethodField()
 
-    rbac_enabled = serializers.BooleanField(source="is_rbac_permissions_enabled")
+    rbac_enabled = serializers.BooleanField(read_only=True, source="is_rbac_permissions_enabled")
 
     SELECT_RELATED = ["slack_team_identity"]
 

--- a/engine/apps/api/tests/test_organization.py
+++ b/engine/apps/api/tests/test_organization.py
@@ -27,6 +27,22 @@ def test_get_organization_rbac_enabled(
 
 
 @pytest.mark.django_db
+def test_update_organization_settings(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+
+    client = APIClient()
+    url = reverse("api-internal:api-organization")
+    data = {"is_resolution_note_required": True}
+
+    assert organization.is_resolution_note_required is False
+
+    response = client.put(url, format="json", data=data, **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+    organization.refresh_from_db()
+    assert organization.is_resolution_note_required is True
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "role,expected_status",
     [


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR fixes
Fixes issue with response 400 on update "Require resolution note" setting

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
