### PR TITLE
Prevent conversion of escalation start/end times to UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed UTC conversion for escalation chain step of timerange ([#2781](https://github.com/grafana/oncall/issues/2781))
+
 ## v1.3.24 (2023-08-17)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed UTC conversion for escalation chain step of timerange ([#2781](https://github.com/grafana/oncall/issues/2781))
+- Fixed UTC conversion for escalation chain step of timerange
+  ([#2781](https://github.com/grafana/oncall/issues/2781))
 
 ## v1.3.24 (2023-08-17)
 

--- a/engine/apps/alerts/models/escalation_policy.py
+++ b/engine/apps/alerts/models/escalation_policy.py
@@ -129,7 +129,7 @@ class EscalationPolicy(OrderedModel):
         STEP_TRIGGER_CUSTOM_WEBHOOK: ("Trigger webhook {{custom_webhook}}", "Trigger webhook"),
         STEP_NOTIFY_USERS_QUEUE: ("Round robin notification for {{users}}", "Notify users one by one (round-robin)"),
         STEP_NOTIFY_IF_TIME: (
-            "Continue escalation if current time is in {{timerange}}",
+            "Continue escalation if current UTC time is in {{timerange}}",
             "Continue escalation if current time is in range",
         ),
         STEP_NOTIFY_IF_NUM_ALERTS_IN_TIME_WINDOW: (

--- a/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
+++ b/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
@@ -231,6 +231,7 @@ export class EscalationPolicy extends React.Component<EscalationPolicyProps, any
         <TimeRange
           from={data.from_time}
           to={data.to_time}
+          // user inputted strings should not be converted to UTC
           convertToUTC={false}
           disabled={isDisabled}
           onChange={this._getOnTimeRangeChangeHandler()}

--- a/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
+++ b/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
@@ -231,6 +231,7 @@ export class EscalationPolicy extends React.Component<EscalationPolicyProps, any
         <TimeRange
           from={data.from_time}
           to={data.to_time}
+          convertToUTC={false}
           disabled={isDisabled}
           onChange={this._getOnTimeRangeChangeHandler()}
           className={cx('select', 'control')}

--- a/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
+++ b/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
@@ -231,8 +231,6 @@ export class EscalationPolicy extends React.Component<EscalationPolicyProps, any
         <TimeRange
           from={data.from_time}
           to={data.to_time}
-          // user inputted strings should not be converted to UTC
-          convertToUTC={false}
           disabled={isDisabled}
           onChange={this._getOnTimeRangeChangeHandler()}
           className={cx('select', 'control')}

--- a/grafana-plugin/src/components/TimeRange/TimeRange.tsx
+++ b/grafana-plugin/src/components/TimeRange/TimeRange.tsx
@@ -13,12 +13,13 @@ interface TimeRangeProps {
   from: string | null;
   to: string | null;
   disabled?: boolean;
+  convertToUTC?: boolean;
   onChange: (value: string[]) => void;
 }
 
-function getMoments(from: string, to: string) {
-  let fromMoment;
-  let toMoment;
+function getMoments(from: string, to: string, convertToUTC: boolean) {
+  let fromMoment: moment.Moment;
+  let toMoment: moment.Moment;
 
   if (!from || !to) {
     fromMoment = moment().startOf('hour');
@@ -29,33 +30,33 @@ function getMoments(from: string, to: string) {
     }
   } else {
     const [fh, fm] = from.split(':').map(Number);
-    fromMoment = moment().utc().hour(fh).minute(fm).second(0).local();
+    fromMoment = (convertToUTC ? moment().utc() : moment()).hour(fh).minute(fm).second(0).local();
 
     const [th, tm] = to.split(':').map(Number);
-    toMoment = moment().utc().hour(th).minute(tm).second(0).local();
+    toMoment = (convertToUTC ? moment().utc() : moment()).hour(th).minute(tm).second(0).local();
   }
 
   return [fromMoment, toMoment];
 }
 
-function getRangeStrings(from: moment.Moment, to: moment.Moment) {
-  const fromString = from.clone().utc().format('HH:mm:00');
-  const toString = to.clone().utc().format('HH:mm:00');
+function getRangeStrings(from: moment.Moment, to: moment.Moment, convertToUTC: boolean) {
+  const fromString = (convertToUTC ? from.clone().utc() : from.clone()).format('HH:mm:00');
+  const toString = (convertToUTC ? to.clone().utc() : to.clone()).format('HH:mm:00');
 
   return [fromString, toString];
 }
 
 const TimeRange = (props: TimeRangeProps) => {
-  const { className, from: f, to: t, onChange, disabled } = props;
+  const { className, from: f, to: t, onChange, disabled, convertToUTC = true } = props;
 
   // @ts-ignore
-  const [from, setFrom] = useState<moment.Moment>(getMoments(f, t)[0]);
+  const [from, setFrom] = useState<moment.Moment>(getMoments(f, t, convertToUTC)[0]);
   // @ts-ignore
-  const [to, setTo] = useState<moment.Moment>(getMoments(f, t)[1]);
+  const [to, setTo] = useState<moment.Moment>(getMoments(f, t, convertToUTC)[1]);
 
   useEffect(() => {
     if (!f || !t) {
-      onChange(getRangeStrings(from, to));
+      onChange(getRangeStrings(from, to, convertToUTC));
     }
   }, []);
 
@@ -66,9 +67,9 @@ const TimeRange = (props: TimeRangeProps) => {
       if (value.isSame(to, 'minute')) {
         const newTo = to.subtract(5, 'minute');
         setTo(newTo);
-        onChange(getRangeStrings(value, newTo));
+        onChange(getRangeStrings(value, newTo, convertToUTC));
       } else {
-        onChange(getRangeStrings(value, to));
+        onChange(getRangeStrings(value, to, convertToUTC));
       }
     },
     [to]
@@ -81,9 +82,9 @@ const TimeRange = (props: TimeRangeProps) => {
       if (value.isSame(from, 'minute')) {
         const newFrom = from.add(5, 'minute');
         setFrom(newFrom);
-        onChange(getRangeStrings(newFrom, value));
+        onChange(getRangeStrings(newFrom, value, convertToUTC));
       } else {
-        onChange(getRangeStrings(from, value));
+        onChange(getRangeStrings(from, value, convertToUTC));
       }
     },
     [from]

--- a/grafana-plugin/src/components/TimeRange/TimeRange.tsx
+++ b/grafana-plugin/src/components/TimeRange/TimeRange.tsx
@@ -48,9 +48,7 @@ function getRangeStrings(from: moment.Moment, to: moment.Moment) {
 const TimeRange = (props: TimeRangeProps) => {
   const { className, from: f, to: t, onChange, disabled } = props;
 
-  // @ts-ignore
   const [from, setFrom] = useState<moment.Moment>(getMoments(f, t)[0]);
-  // @ts-ignore
   const [to, setTo] = useState<moment.Moment>(getMoments(f, t)[1]);
 
   useEffect(() => {

--- a/grafana-plugin/src/components/TimeRange/TimeRange.tsx
+++ b/grafana-plugin/src/components/TimeRange/TimeRange.tsx
@@ -13,11 +13,10 @@ interface TimeRangeProps {
   from: string | null;
   to: string | null;
   disabled?: boolean;
-  convertToUTC?: boolean;
   onChange: (value: string[]) => void;
 }
 
-function getMoments(from: string, to: string, convertToUTC: boolean) {
+function getMoments(from: string, to: string) {
   let fromMoment: moment.Moment;
   let toMoment: moment.Moment;
 
@@ -30,33 +29,33 @@ function getMoments(from: string, to: string, convertToUTC: boolean) {
     }
   } else {
     const [fh, fm] = from.split(':').map(Number);
-    fromMoment = (convertToUTC ? moment().utc() : moment()).hour(fh).minute(fm).second(0).local();
+    fromMoment = moment().hour(fh).minute(fm).second(0).local();
 
     const [th, tm] = to.split(':').map(Number);
-    toMoment = (convertToUTC ? moment().utc() : moment()).hour(th).minute(tm).second(0).local();
+    toMoment = moment().hour(th).minute(tm).second(0).local();
   }
 
   return [fromMoment, toMoment];
 }
 
-function getRangeStrings(from: moment.Moment, to: moment.Moment, convertToUTC: boolean) {
-  const fromString = (convertToUTC ? from.clone().utc() : from.clone()).format('HH:mm:00');
-  const toString = (convertToUTC ? to.clone().utc() : to.clone()).format('HH:mm:00');
+function getRangeStrings(from: moment.Moment, to: moment.Moment) {
+  const fromString = from.clone().format('HH:mm:00');
+  const toString = to.clone().format('HH:mm:00');
 
   return [fromString, toString];
 }
 
 const TimeRange = (props: TimeRangeProps) => {
-  const { className, from: f, to: t, onChange, disabled, convertToUTC = true } = props;
+  const { className, from: f, to: t, onChange, disabled } = props;
 
   // @ts-ignore
-  const [from, setFrom] = useState<moment.Moment>(getMoments(f, t, convertToUTC)[0]);
+  const [from, setFrom] = useState<moment.Moment>(getMoments(f, t)[0]);
   // @ts-ignore
-  const [to, setTo] = useState<moment.Moment>(getMoments(f, t, convertToUTC)[1]);
+  const [to, setTo] = useState<moment.Moment>(getMoments(f, t)[1]);
 
   useEffect(() => {
     if (!f || !t) {
-      onChange(getRangeStrings(from, to, convertToUTC));
+      onChange(getRangeStrings(from, to));
     }
   }, []);
 
@@ -67,9 +66,9 @@ const TimeRange = (props: TimeRangeProps) => {
       if (value.isSame(to, 'minute')) {
         const newTo = to.subtract(5, 'minute');
         setTo(newTo);
-        onChange(getRangeStrings(value, newTo, convertToUTC));
+        onChange(getRangeStrings(value, newTo));
       } else {
-        onChange(getRangeStrings(value, to, convertToUTC));
+        onChange(getRangeStrings(value, to));
       }
     },
     [to]
@@ -82,9 +81,9 @@ const TimeRange = (props: TimeRangeProps) => {
       if (value.isSame(from, 'minute')) {
         const newFrom = from.add(5, 'minute');
         setFrom(newFrom);
-        onChange(getRangeStrings(newFrom, value, convertToUTC));
+        onChange(getRangeStrings(newFrom, value));
       } else {
-        onChange(getRangeStrings(from, value, convertToUTC));
+        onChange(getRangeStrings(from, value));
       }
     },
     [from]


### PR DESCRIPTION
# What this PR does

~~Adds a boolean `convertToUTC` to the `TimeRange` component.~~ 

- Discard conversion to UTC of strings within `TimeRange` component

For this use case on escalation chains since the user inputted fields are strings they will not be further converted to UTC and instead left as it is, which previously resulted in setting a wrong start/end combination.

## Which issue(s) this PR fixes

https://github.com/grafana/oncall/issues/2781

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
