### PR TITLE
Set is_escalation_finished to True if alert group won't be escalated

### DIFF
--- a/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
@@ -20,6 +20,7 @@ if typing.TYPE_CHECKING:
     from apps.alerts.models import ChannelFilter
 
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 # Is a delay to prevent intermediate activity by system in case user is doing some multi-step action.
 # For example if user wants to unack and ack we don't need to launch escalation right after unack.

--- a/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
@@ -229,13 +229,13 @@ class EscalationSnapshotMixin:
         """
         from apps.alerts.models import AlertGroup
 
-        is_on_maintenace_or_debug_mode = self.channel.maintenance_mode is not None
+        is_on_maintenance_or_debug_mode = self.channel.maintenance_mode is not None
 
-        if self.is_restricted or is_on_maintenace_or_debug_mode or not self.escalation_chain_exists:
+        if self.is_restricted or is_on_maintenance_or_debug_mode or not self.escalation_chain_exists:
             logger.debug(
                 f"Not escalating alert group w/ pk: {self.pk}\n"
                 f"is_restricted: {self.is_restricted}\n"
-                f"is_on_maintenace_or_debug_mode: {is_on_maintenace_or_debug_mode}\n"
+                f"is_on_maintenance_or_debug_mode: {is_on_maintenance_or_debug_mode}\n"
                 f"escalation_chain_exists: {self.escalation_chain_exists}"
             )
             # set is_escalation_finished to True as this alert group won't be escalated

--- a/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
@@ -238,6 +238,8 @@ class EscalationSnapshotMixin:
                 f"is_on_maintenace_or_debug_mode: {is_on_maintenace_or_debug_mode}\n"
                 f"escalation_chain_exists: {self.escalation_chain_exists}"
             )
+            # set is_escalation_finished to True as this alert group won't be escalated
+            AlertGroup.objects.filter(pk=self.pk).update(is_escalation_finished=True)
             return
 
         logger.debug(f"Start escalation for alert group with pk: {self.pk}")


### PR DESCRIPTION
# What this PR does
Set is_escalation_finished to True if alert group won't be escalated due to active maintenance, absence of escalation chain or being restricted
Fix logging

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
