### PR TITLE
increase mobile app verification token TTL from 1 minute to 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Increase mobile app verification token TTL by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+- Increase mobile app verification token TTL by @joeyorlando ([#2859](https://github.com/grafana/oncall/pull/2859))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Increase mobile app verification token TTL by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+
 ### Fixed
 
 - Changed HTTP Endpoint to Email for inbound email integrations

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -53,7 +53,6 @@ services:
       labels: *oncall-labels
     environment:
       ONCALL_API_URL: http://host.docker.internal:8080
-      MOBILE_APP_QR_INTERVAL_QUEUE: 290000 # 4 minutes and 50 seconds
     volumes:
       - ./grafana-plugin:/etc/app
       - node_modules_dev:/etc/app/node_modules

--- a/engine/apps/mobile_app/models.py
+++ b/engine/apps/mobile_app/models.py
@@ -2,7 +2,6 @@ from __future__ import annotations  # https://stackoverflow.com/a/33533514
 
 import typing
 
-from django.conf import settings
 from django.core import validators
 from django.db import models
 from django.utils import timezone
@@ -15,7 +14,7 @@ from apps.mobile_app.types import MessageType, Platform
 if typing.TYPE_CHECKING:
     from apps.user_management.models import Organization, User
 
-MOBILE_APP_AUTH_VERIFICATION_TOKEN_TIMEOUT_SECONDS = 60 * (5 if settings.DEBUG else 1)
+MOBILE_APP_AUTH_VERIFICATION_TOKEN_TIMEOUT_SECONDS = 60 * 5  # 5 minutes
 
 
 def get_expire_date():

--- a/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.tsx
+++ b/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.tsx
@@ -27,9 +27,12 @@ type Props = {
 };
 
 const INTERVAL_MIN_THROTTLING = 500;
-const INTERVAL_QUEUE_QR = process.env.MOBILE_APP_QR_INTERVAL_QUEUE
-  ? parseInt(process.env.MOBILE_APP_QR_INTERVAL_QUEUE, 10)
-  : 50000;
+/**
+ * 290_000 = 4 minutes and 50 seconds
+ * QR code token has a TTL of 5 minutes
+ * This means we will fetch a new token just before the current one expires
+ */
+const INTERVAL_QUEUE_QR = 290_000;
 const INTERVAL_POLLING = 5000;
 const BACKEND = 'MOBILE_APP';
 

--- a/grafana-plugin/webpack.config.js
+++ b/grafana-plugin/webpack.config.js
@@ -145,7 +145,6 @@ module.exports.getWebpackConfig = (config, options) => {
        */
       new webpack.EnvironmentPlugin({
         ONCALL_API_URL: null,
-        MOBILE_APP_QR_INTERVAL_QUEUE: null,
       }),
       new webpack.DefinePlugin({
         'process.env': JSON.stringify(dotenv.config().parsed),


### PR DESCRIPTION
# What this PR does

Trying to connect a mobile app emulator, following the instructions [here](https://github.com/grafana/oncall-mobile-app#getting-started), to a cloud stack is incredibly difficult given the 1 minute token TTL. You need to retrieve the token from the HTTP response in your browser's inspect panel, plug that token into the `make run` command and cross your fingers that the emulator starts up in < 45 seconds before the token expires.

This PR increases the verification token TTL from 1 minute to 5 minutes.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
