### PR TITLE
Add 'pr: no changelog' label because these PRs dont need to update the changelog

### DIFF
--- a/.github/workflows/update-make-docs.yml
+++ b/.github/workflows/update-make-docs.yml
@@ -22,6 +22,6 @@ jobs:
           git config --local user.name "grafanabot"
           git commit -m "Update \`make docs\` procedure"
           git push -v origin "refs/heads/${BRANCH}"
-          gh pr create --fill
+          gh pr create --fill --label "pr:no changelog"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
