### PR TITLE
SSR accept Slack event - handle both slack payload types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix case where accepting a shift swap request via Slack sends an `event_callback` Slack payload type that was
-  previously being ignored by @joeyorlando ([#2886](https://github.com/grafana/oncall/pull/2886))
+- Address bug when a Shift Swap Request is accepted either via the web or mobile UI, and the Slack message is not
+  updated to reflect the latest state by @joeyorlando ([#2886](https://github.com/grafana/oncall/pull/2886))
 
 ## v1.3.27 (2023-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix case where accepting a shift swap request via Slack sends an `event_callback` Slack payload type that was
+  previously being ignored by @joeyorlando ([#2886](https://github.com/grafana/oncall/pull/2886))
+
 ## v1.3.27 (2023-08-25)
 
 ### Added

--- a/engine/apps/api/views/shift_swap.py
+++ b/engine/apps/api/views/shift_swap.py
@@ -45,6 +45,8 @@ class BaseShiftSwapViewSet(ModelViewSet):
         except exceptions.BeneficiaryCannotTakeOwnShiftSwapRequest:
             raise BadRequest(detail="A shift swap request cannot be created and taken by the same user")
 
+        update_shift_swap_request_message.apply_async((shift_swap.pk,))
+
         return ShiftSwapRequestSerializer(shift_swap).data
 
     def get_serializer_class(self):

--- a/engine/apps/public_api/tests/test_shift_swap.py
+++ b/engine/apps/public_api/tests/test_shift_swap.py
@@ -330,8 +330,10 @@ def test_delete(
     mock_update_shift_swap_request_message.apply_async.assert_called_once_with((swap.pk,))
 
 
+@patch("apps.api.views.shift_swap.update_shift_swap_request_message")
 @pytest.mark.django_db
 def test_take(
+    mock_update_shift_swap_request_message,
     make_organization_and_user_with_token,
     make_user_for_organization,
     setup_swap,
@@ -352,9 +354,13 @@ def test_take(
     assert swap.status == ShiftSwapRequest.Statuses.TAKEN
     assert swap.benefactor == another_user
 
+    mock_update_shift_swap_request_message.apply_async.assert_called_once_with((swap.pk,))
 
+
+@patch("apps.api.views.shift_swap.update_shift_swap_request_message")
 @pytest.mark.django_db
 def test_take_requires_benefactor(
+    mock_update_shift_swap_request_message,
     make_organization_and_user_with_token,
     setup_swap,
 ):
@@ -372,9 +378,13 @@ def test_take_requires_benefactor(
     assert swap.status == ShiftSwapRequest.Statuses.OPEN
     assert swap.benefactor is None
 
+    mock_update_shift_swap_request_message.apply_async.assert_not_called()
 
+
+@patch("apps.api.views.shift_swap.update_shift_swap_request_message")
 @pytest.mark.django_db
 def test_take_errors(
+    mock_update_shift_swap_request_message,
     make_organization_and_user_with_token,
     make_user_for_organization,
     setup_swap,
@@ -411,3 +421,5 @@ def test_take_errors(
     data = {"benefactor": another_user.public_primary_key}
     response = client.post(url, data, format="json", HTTP_AUTHORIZATION=f"{token}")
     assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    mock_update_shift_swap_request_message.apply_async.assert_not_called()

--- a/engine/apps/slack/scenarios/shift_swap_requests.py
+++ b/engine/apps/slack/scenarios/shift_swap_requests.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from apps.slack.constants import DIVIDER
 from apps.slack.models import SlackMessage
 from apps.slack.scenarios import scenario_step
-from apps.slack.types import Block, BlockActionType, EventPayload, EventType, PayloadType, ScenarioRoute
+from apps.slack.types import Block, BlockActionType, EventPayload, PayloadType, ScenarioRoute
 from apps.slack.utils import SlackDateFormat, format_datetime_to_slack, format_datetime_to_slack_with_time
 
 if typing.TYPE_CHECKING:
@@ -245,12 +245,6 @@ class ShiftSwapRequestFollowUp(scenario_step.ScenarioStep):
 
 
 STEPS_ROUTING: ScenarioRoute.RoutingSteps = [
-    {
-        "payload_type": PayloadType.EVENT_CALLBACK,
-        "event_type": EventType.MESSAGE,
-        "step": AcceptShiftSwapRequestStep,
-        "message_channel_type": EventType.MESSAGE_CHANNEL,
-    },
     {
         "payload_type": PayloadType.BLOCK_ACTIONS,
         "block_action_type": BlockActionType.BUTTON,

--- a/engine/apps/slack/scenarios/shift_swap_requests.py
+++ b/engine/apps/slack/scenarios/shift_swap_requests.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from apps.slack.constants import DIVIDER
 from apps.slack.models import SlackMessage
 from apps.slack.scenarios import scenario_step
-from apps.slack.types import Block, BlockActionType, EventPayload, PayloadType, ScenarioRoute
+from apps.slack.types import Block, BlockActionType, EventPayload, EventType, PayloadType, ScenarioRoute
 from apps.slack.utils import SlackDateFormat, format_datetime_to_slack, format_datetime_to_slack_with_time
 
 if typing.TYPE_CHECKING:
@@ -245,6 +245,12 @@ class ShiftSwapRequestFollowUp(scenario_step.ScenarioStep):
 
 
 STEPS_ROUTING: ScenarioRoute.RoutingSteps = [
+    {
+        "payload_type": PayloadType.EVENT_CALLBACK,
+        "event_type": EventType.MESSAGE,
+        "step": AcceptShiftSwapRequestStep,
+        "message_channel_type": EventType.MESSAGE_CHANNEL,
+    },
     {
         "payload_type": PayloadType.BLOCK_ACTIONS,
         "block_action_type": BlockActionType.BUTTON,

--- a/engine/apps/slack/tests/test_interactive_api_endpoint.py
+++ b/engine/apps/slack/tests/test_interactive_api_endpoint.py
@@ -200,6 +200,67 @@ def test_organization_not_found_scenario_doesnt_break_manage_responders(
     mock_process_scenario.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "type": "block_actions",
+            "user": {
+                "id": SLACK_USER_ID,
+            },
+            "team": {
+                "id": SLACK_TEAM_ID,
+            },
+            "actions": [
+                {
+                    "action_id": "AcceptShiftSwapRequestStep",
+                    "block_id": "G0ec",
+                    "text": {
+                        "type": "plain_text",
+                        "text": ":heavy_check_mark: Accept Shift Swap Request",
+                        "emoji": True,
+                    },
+                    "value": '{"shift_swap_request_pk": 5, "organization_id": 1}',
+                    "style": "primary",
+                    "type": "button",
+                    "action_ts": "1693208812.474860",
+                }
+            ],
+        },
+        {
+            "team_id": SLACK_TEAM_ID,
+            "context_team_id": SLACK_TEAM_ID,
+            "context_enterprise_id": None,
+            "event": {
+                "bot_id": "B029VQH5RMM",
+                "type": "message",
+                "text": "zxcvzxcv",
+                "user": SLACK_USER_ID,
+                "ts": "1692922497.094919",
+                "app_id": "A029KMD79FU",
+                "blocks": [],
+                "team": SLACK_TEAM_ID,
+                "channel": "C03KS498VGV",
+                "event_ts": "1692922497.094919",
+                "channel_type": "channel",
+            },
+            "type": "event_callback",
+            "event_id": "Ev05Q5H42VLG",
+            "event_time": 1692922497,
+            "authorizations": [
+                {
+                    "enterprise_id": None,
+                    "team_id": SLACK_TEAM_ID,
+                    "user_id": SLACK_USER_ID,
+                    "is_bot": True,
+                    "is_enterprise_install": False,
+                }
+            ],
+            "is_ext_shared_channel": False,
+            "event_context": "nmxcvnmcxvnxnmxvcmn",
+        },
+    ],
+)
 @patch("apps.slack.views.SlackEventApiEndpointView.verify_signature", return_value=True)
 @patch.object(AcceptShiftSwapRequestStep, "process_scenario")
 @pytest.mark.django_db
@@ -210,31 +271,11 @@ def test_accept_shift_swap_request(
     make_slack_user_identity,
     make_user,
     slack_team_identity,
+    payload,
 ):
     organization = make_organization(slack_team_identity=slack_team_identity)
     slack_user_identity = make_slack_user_identity(slack_team_identity=slack_team_identity, slack_id=SLACK_USER_ID)
     make_user(organization=organization, slack_user_identity=slack_user_identity)
-
-    payload = {
-        "type": "block_actions",
-        "user": {
-            "id": SLACK_USER_ID,
-        },
-        "team": {
-            "id": SLACK_TEAM_ID,
-        },
-        "actions": [
-            {
-                "action_id": "AcceptShiftSwapRequestStep",
-                "block_id": "G0ec",
-                "text": {"type": "plain_text", "text": ":heavy_check_mark: Accept Shift Swap Request", "emoji": True},
-                "value": '{"shift_swap_request_pk": 5, "organization_id": 1}',
-                "style": "primary",
-                "type": "button",
-                "action_ts": "1693208812.474860",
-            }
-        ],
-    }
 
     response = _make_request(payload)
 

--- a/engine/apps/slack/tests/test_interactive_api_endpoint.py
+++ b/engine/apps/slack/tests/test_interactive_api_endpoint.py
@@ -200,67 +200,6 @@ def test_organization_not_found_scenario_doesnt_break_manage_responders(
     mock_process_scenario.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "payload",
-    [
-        {
-            "type": "block_actions",
-            "user": {
-                "id": SLACK_USER_ID,
-            },
-            "team": {
-                "id": SLACK_TEAM_ID,
-            },
-            "actions": [
-                {
-                    "action_id": "AcceptShiftSwapRequestStep",
-                    "block_id": "G0ec",
-                    "text": {
-                        "type": "plain_text",
-                        "text": ":heavy_check_mark: Accept Shift Swap Request",
-                        "emoji": True,
-                    },
-                    "value": '{"shift_swap_request_pk": 5, "organization_id": 1}',
-                    "style": "primary",
-                    "type": "button",
-                    "action_ts": "1693208812.474860",
-                }
-            ],
-        },
-        {
-            "team_id": SLACK_TEAM_ID,
-            "context_team_id": SLACK_TEAM_ID,
-            "context_enterprise_id": None,
-            "event": {
-                "bot_id": "B029VQH5RMM",
-                "type": "message",
-                "text": "zxcvzxcv",
-                "user": SLACK_USER_ID,
-                "ts": "1692922497.094919",
-                "app_id": "A029KMD79FU",
-                "blocks": [],
-                "team": SLACK_TEAM_ID,
-                "channel": "C03KS498VGV",
-                "event_ts": "1692922497.094919",
-                "channel_type": "channel",
-            },
-            "type": "event_callback",
-            "event_id": "Ev05Q5H42VLG",
-            "event_time": 1692922497,
-            "authorizations": [
-                {
-                    "enterprise_id": None,
-                    "team_id": SLACK_TEAM_ID,
-                    "user_id": SLACK_USER_ID,
-                    "is_bot": True,
-                    "is_enterprise_install": False,
-                }
-            ],
-            "is_ext_shared_channel": False,
-            "event_context": "nmxcvnmcxvnxnmxvcmn",
-        },
-    ],
-)
 @patch("apps.slack.views.SlackEventApiEndpointView.verify_signature", return_value=True)
 @patch.object(AcceptShiftSwapRequestStep, "process_scenario")
 @pytest.mark.django_db
@@ -271,11 +210,35 @@ def test_accept_shift_swap_request(
     make_slack_user_identity,
     make_user,
     slack_team_identity,
-    payload,
 ):
     organization = make_organization(slack_team_identity=slack_team_identity)
     slack_user_identity = make_slack_user_identity(slack_team_identity=slack_team_identity, slack_id=SLACK_USER_ID)
     make_user(organization=organization, slack_user_identity=slack_user_identity)
+
+    payload = {
+        "type": "block_actions",
+        "user": {
+            "id": SLACK_USER_ID,
+        },
+        "team": {
+            "id": SLACK_TEAM_ID,
+        },
+        "actions": [
+            {
+                "action_id": "AcceptShiftSwapRequestStep",
+                "block_id": "G0ec",
+                "text": {
+                    "type": "plain_text",
+                    "text": ":heavy_check_mark: Accept Shift Swap Request",
+                    "emoji": True,
+                },
+                "value": '{"shift_swap_request_pk": 5, "organization_id": 1}',
+                "style": "primary",
+                "type": "button",
+                "action_ts": "1693208812.474860",
+            }
+        ],
+    }
 
     response = _make_request(payload)
 


### PR DESCRIPTION
# What this PR does

For whatever reason, when clicking the green "Accept shift swap request" button on a Slack message, Slack can send two different payload types. We were not registering the `event_callback` type and hence these events were being ignored and the request was not being accepted

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
