### PR TITLE
Fix next step eta for silenced alert groups

### DIFF
--- a/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
@@ -223,6 +223,19 @@ class EscalationSnapshotMixin:
         raw_next_step_eta = self.raw_escalation_snapshot.get("next_step_eta")
         return None if not raw_next_step_eta else parse(raw_next_step_eta).replace(tzinfo=pytz.UTC)
 
+    def update_next_step_eta(self, increase_by_timedelta: datetime.timedelta) -> typing.Optional[dict]:
+        """
+        update next_step_eta field directly to avoid serialization overhead
+        """
+        if not self.raw_escalation_snapshot:
+            return None
+
+        raw_next_step_eta = self.raw_escalation_snapshot.get("next_step_eta")
+        next_step_eta = parse(raw_next_step_eta).replace(tzinfo=pytz.UTC)
+        updated_next_step_eta = next_step_eta + increase_by_timedelta
+        self.raw_escalation_snapshot["next_step_eta"] = updated_next_step_eta.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        return self.raw_escalation_snapshot
+
     def start_escalation_if_needed(self, countdown=START_ESCALATION_DELAY, eta=None):
         """
         :type self:AlertGroup

--- a/engine/apps/alerts/tasks/check_escalation_finished.py
+++ b/engine/apps/alerts/tasks/check_escalation_finished.py
@@ -60,9 +60,13 @@ def audit_alert_group_escalation(alert_group: "AlertGroup") -> None:
     )
 
     if escalation_snapshot.next_step_eta_is_valid() is False:
-        raise AlertGroupEscalationPolicyExecutionAuditException(
+        msg = (
             f"{base_msg}'s escalation snapshot does not have a valid next_step_eta: {escalation_snapshot.next_step_eta}"
         )
+
+        task_logger.warning(msg)
+        raise AlertGroupEscalationPolicyExecutionAuditException(msg)
+
     task_logger.info(f"{base_msg}'s escalation snapshot has a valid next_step_eta: {escalation_snapshot.next_step_eta}")
 
     executed_escalation_policy_snapshots = escalation_snapshot.executed_escalation_policy_snapshots

--- a/engine/apps/alerts/tests/test_check_escalation_finished_task.py
+++ b/engine/apps/alerts/tests/test_check_escalation_finished_task.py
@@ -364,7 +364,11 @@ def test_check_escalation_finished_task_calls_audit_alert_group_escalation_for_e
     with pytest.raises(AlertGroupEscalationPolicyExecutionAuditException) as exc:
         check_escalation_finished_task()
 
-    assert str(exc.value) == f"The following alert group id(s) failed auditing: {alert_group1.id}, {alert_group2.id}"
+    error_msg = str(exc.value)
+
+    assert "The following alert group id(s) failed auditing:" in error_msg
+    assert str(alert_group1.id) in error_msg
+    assert str(alert_group2.id) in error_msg
 
     mocked_audit_alert_group_escalation.assert_any_call(alert_group1)
     mocked_audit_alert_group_escalation.assert_any_call(alert_group2)


### PR DESCRIPTION
# What this PR does
Update `next_step_eta` in alert group escalation snapshot when alert group is silenced for period

## Which issue(s) this PR fixes
Fixes the issue related to [this one](https://github.com/grafana/oncall-private/issues/2028)

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
