### PR TITLE
Always update last_heartbeat_time async

### DIFF
--- a/engine/apps/integrations/views.py
+++ b/engine/apps/integrations/views.py
@@ -3,7 +3,6 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.db import OperationalError
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -325,10 +324,6 @@ class IntegrationHeartBeatAPIView(AlertChannelDefiningMixin, IntegrationHeartBea
         return Response(status=200)
 
     def _process_heartbeat_signal(self, request, alert_receive_channel):
-        try:
-            process_heartbeat_task(alert_receive_channel.pk)
-        # If database is not ready, fallback to celery task
-        except OperationalError:
-            process_heartbeat_task.apply_async(
-                (alert_receive_channel.pk,),
-            )
+        process_heartbeat_task.apply_async(
+            (alert_receive_channel.pk,),
+        )


### PR DESCRIPTION
# What this PR does
If the same heartbeat is requested at a high rate it can create lock contention when updating the timestamp in the DB. Moving to always run update in task should free up the connection on the API server faster, although the task might still see some lock wait time.

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
