### PR TITLE
Alerting integration use get for receiver key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Address bug when a Shift Swap Request is accepted either via the web or mobile UI, and the Slack message is not
   updated to reflect the latest state by @joeyorlando ([#2886](https://github.com/grafana/oncall/pull/2886))
+- Fix issue where Grafana integration would fail to parse alerting config for routes without receivers @mderynck
+  ([#2894](https://github.com/grafana/oncall/pull/2894))
 
 ## v1.3.27 (2023-08-25)
 

--- a/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
+++ b/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
@@ -374,7 +374,7 @@ class GrafanaAlertingSyncManager:
             return True
         routes = route_config.get("routes", [])
         for route in routes:
-            if route["receiver"] == receiver_name:
+            if route.get("receiver") == receiver_name:
                 return True
             if route.get("routes"):
                 if self._recursive_check_contact_point_is_in_routes(route, receiver_name):


### PR DESCRIPTION
# What this PR does
Fixes an issue where OnCall could not parse Alerting configuration if there was a route created without a receiver.  The case where this comes up is a notification policy matcher is defined for the purpose of ignoring certain label values before continuing on to other matching rules.

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
