### PR TITLE
Set next step eta to None if escalation was paused

### DIFF
--- a/engine/apps/alerts/escalation_snapshot/snapshot_classes/escalation_policy_snapshot.py
+++ b/engine/apps/alerts/escalation_snapshot/snapshot_classes/escalation_policy_snapshot.py
@@ -518,6 +518,7 @@ class EscalationPolicySnapshot:
     def _get_result_tuple(
         self, eta=None, stop_escalation=False, start_from_beginning=False, pause_escalation=False
     ) -> StepExecutionResultData:
-        # use default delay for eta, if eta was not counted by step
-        eta = eta or timezone.now() + datetime.timedelta(seconds=NEXT_ESCALATION_DELAY)
+        # use default delay for eta, if eta was not counted by step and escalation was not paused
+        if not pause_escalation:
+            eta = eta or timezone.now() + datetime.timedelta(seconds=NEXT_ESCALATION_DELAY)
         return self.StepExecutionResultData(eta, stop_escalation, start_from_beginning, pause_escalation)

--- a/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
+++ b/engine/apps/alerts/tests/test_escalation_policy_snapshot.py
@@ -368,15 +368,15 @@ def test_escalation_step_notify_if_num_alerts_in_window(
     )
 
     escalation_policy_snapshot = get_escalation_policy_snapshot_from_model(notify_if_3_alerts_per_1_minute)
-    expected_eta = timezone.now() + timezone.timedelta(seconds=NEXT_ESCALATION_DELAY)
+    expected_eta = None  # eta is None if escalation was paused
     result = escalation_policy_snapshot.execute(alert_group, reason)
     expected_result = EscalationPolicySnapshot.StepExecutionResultData(
-        eta=result.eta,
+        eta=expected_eta,
         stop_escalation=False,
         pause_escalation=True,
         start_from_beginning=False,
     )
-    assert expected_eta + timezone.timedelta(seconds=15) > result.eta > expected_eta - timezone.timedelta(seconds=15)
+    assert result.eta == expected_eta
     assert result == expected_result
     assert notify_if_3_alerts_per_1_minute.log_records.filter(
         type=AlertGroupLogRecord.TYPE_ESCALATION_TRIGGERED


### PR DESCRIPTION
# What this PR does
Set next step eta to None if escalation was paused (escalation step "Continue escalation if num alerts > X in time window"

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2028

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
