### PR TITLE
Exclude the latest alert groups from escalation finished check

### DIFF
--- a/engine/apps/alerts/tasks/check_escalation_finished.py
+++ b/engine/apps/alerts/tasks/check_escalation_finished.py
@@ -114,7 +114,7 @@ def check_escalation_finished_task() -> None:
     """
     from apps.alerts.models import AlertGroup
 
-    now = timezone.now() - datetime.timedelta(seconds=30)
+    now = timezone.now() - datetime.timedelta(minutes=5)
     two_days_ago = now - datetime.timedelta(days=2)
 
     alert_groups = AlertGroup.objects.using(get_random_readonly_database_key_if_present_otherwise_default()).filter(


### PR DESCRIPTION
# What this PR does
Exclude the latest alert groups from escalation finished check to give them time for building escalation snapshot

## Which issue(s) this PR fixes
https://github.com/grafana/irm/issues/4910

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
