### PR TITLE
Update `STEP_NOTIFY_IF_TIME` step description

### DIFF
--- a/engine/apps/alerts/models/escalation_policy.py
+++ b/engine/apps/alerts/models/escalation_policy.py
@@ -130,7 +130,7 @@ class EscalationPolicy(OrderedModel):
         STEP_NOTIFY_USERS_QUEUE: ("Round robin notification for {{users}}", "Notify users one by one (round-robin)"),
         STEP_NOTIFY_IF_TIME: (
             "Continue escalation if current UTC time is in {{timerange}}",
-            "Continue escalation if current time is in range",
+            "Continue escalation if current UTC time is in range",
         ),
         STEP_NOTIFY_IF_NUM_ALERTS_IN_TIME_WINDOW: (
             "Continue escalation if >{{num_alerts_in_window}} alerts per {{num_minutes_in_window}} minutes",


### PR DESCRIPTION
# What this PR does

Make descriptions consistent for the `STEP_NOTIFY_IF_TIME` escalation step (my [initial assumption](https://github.com/grafana/oncall/pull/2729#discussion_r1281929984) seems to be wrong and this can confuse users).

## Which issue(s) this PR fixes

https://github.com/grafana/support-escalations/issues/7164

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
