### PR TITLE
Fix dayOption NPE, add top boundary for rotation modal

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -422,7 +422,12 @@ const RotationForm = observer((props: RotationFormProps) => {
         width="430px"
         onDismiss={onHide}
         contentElement={(props, children) => (
-          <Draggable handle=".drag-handler" defaultClassName={cx('draggable')} positionOffset={{ x: 0, y: offsetTop }}>
+          <Draggable
+            handle=".drag-handler"
+            defaultClassName={cx('draggable')}
+            positionOffset={{ x: 0, y: offsetTop }}
+            bounds={{ top: 0 }}
+          >
             <div {...props}>{children}</div>
           </Draggable>
         )}

--- a/grafana-plugin/src/models/schedule/schedule.ts
+++ b/grafana-plugin/src/models/schedule/schedule.ts
@@ -82,7 +82,7 @@ export class ScheduleStore extends BaseStore {
   } = {};
 
   @observable
-  byDayOptions: SelectOption[];
+  byDayOptions: SelectOption[] = [];
 
   @observable
   scheduleId: Schedule['id'];


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR fixes

Fix:

- Schedule race condition
- No obvious way to close Rotation modal

https://github.com/grafana/oncall/issues/2802
https://github.com/grafana/oncall/issues/2880

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
