### PR TITLE
Expand users details in filter swaps endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Performance and UX tweaks to integrations page ([#2869](https://github.com/grafana/oncall/pull/2869))
+- Expand users details in filter swaps internal endpoint ([#2921](https://github.com/grafana/oncall/pull/2921))
 
 ## v1.3.29 (2023-08-29)
 

--- a/engine/apps/api/serializers/shift_swap.py
+++ b/engine/apps/api/serializers/shift_swap.py
@@ -12,7 +12,7 @@ if typing.TYPE_CHECKING:
     from apps.user_management.models import User
 
 
-class ShiftSwapRequestListSerializer(EagerLoadingMixin, serializers.ModelSerializer):
+class BaseShiftSwapRequestListSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, source="public_primary_key")
     schedule = OrganizationFilteredPrimaryKeyRelatedField(queryset=OnCallSchedule.objects)
 
@@ -49,6 +49,8 @@ class ShiftSwapRequestListSerializer(EagerLoadingMixin, serializers.ModelSeriali
             "status",
         ]
 
+
+class ShiftSwapRequestListSerializer(BaseShiftSwapRequestListSerializer):
     def get_benefactor(self, obj: ShiftSwapRequest) -> str | None:
         return obj.benefactor.public_primary_key if obj.benefactor else None
 
@@ -94,7 +96,7 @@ class ShiftSwapRequestSerializer(ShiftSwapRequestListSerializer):
         return data
 
 
-class ShiftSwapRequestExpandedUsersSerializer(ShiftSwapRequestListSerializer):
+class ShiftSwapRequestExpandedUsersSerializer(BaseShiftSwapRequestListSerializer):
     beneficiary = serializers.SerializerMethodField(read_only=True)
     benefactor = serializers.SerializerMethodField(read_only=True)
 

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1310,13 +1310,22 @@ def test_filter_swap_requests(
     response = client.get(url, format="json", **make_user_auth_headers(admin, token))
     assert response.status_code == status.HTTP_200_OK
 
+    def _serialized_user(u):
+        if u:
+            return {
+                "display_name": u.username,
+                "email": u.email,
+                "pk": u.public_primary_key,
+                "avatar_full": u.avatar_full_url,
+            }
+
     expected = [
         {
             "pk": swap.public_primary_key,
             "swap_start": serialize_datetime_as_utc_timestamp(swap.swap_start),
             "swap_end": serialize_datetime_as_utc_timestamp(swap.swap_end),
-            "beneficiary": swap.beneficiary.public_primary_key,
-            "benefactor": swap.benefactor.public_primary_key if swap.benefactor else None,
+            "beneficiary": _serialized_user(swap.beneficiary),
+            "benefactor": _serialized_user(swap.benefactor),
         }
         for swap in (swap_a, swap_b)
     ]

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -28,7 +28,7 @@ from apps.api.serializers.schedule_polymorphic import (
     PolymorphicScheduleSerializer,
     PolymorphicScheduleUpdateSerializer,
 )
-from apps.api.serializers.shift_swap import ShiftSwapRequestSerializer
+from apps.api.serializers.shift_swap import ShiftSwapRequestExpandedUsersSerializer
 from apps.api.serializers.user import ScheduleUserSerializer
 from apps.auth_token.auth import PluginAuthentication
 from apps.auth_token.constants import SCHEDULE_EXPORT_TOKEN_NAME
@@ -356,7 +356,7 @@ class ScheduleView(
 
         swap_requests = schedule.filter_swap_requests(datetime_start, datetime_end)
 
-        serialized_swap_requests = ShiftSwapRequestSerializer(swap_requests, many=True)
+        serialized_swap_requests = ShiftSwapRequestExpandedUsersSerializer(swap_requests, many=True)
         result = {"shift_swaps": serialized_swap_requests.data}
 
         return Response(result, status=status.HTTP_200_OK)


### PR DESCRIPTION
Include additional information about beneficiary/benefactor users to avoid extra requests when listing swap requests details.