### PR TITLE
Fix silence for paused escalations or alert groups with empty escalation chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix issue with helm chart when specifying `broker.type=rabbitmq` where Redis environment variables
   were not longer being injected @joeyorlando ([#2927](https://github.com/grafana/oncall/pull/2927))
+- Fix silence for alert groups with empty escalation chain @Ferril ([#2929](https://github.com/grafana/oncall/pull/2929))
 
 ## v1.3.29 (2023-08-29)
 

--- a/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/escalation_snapshot/escalation_snapshot_mixin.py
@@ -231,6 +231,9 @@ class EscalationSnapshotMixin:
             return None
 
         raw_next_step_eta = self.raw_escalation_snapshot.get("next_step_eta")
+        if not raw_next_step_eta:  # empty escalation chain or paused escalations
+            return self.raw_escalation_snapshot
+
         next_step_eta = parse(raw_next_step_eta).replace(tzinfo=pytz.UTC)
         updated_next_step_eta = next_step_eta + increase_by_timedelta
         self.raw_escalation_snapshot["next_step_eta"] = updated_next_step_eta.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/engine/apps/alerts/tests/test_escalation_snapshot_mixin.py
+++ b/engine/apps/alerts/tests/test_escalation_snapshot_mixin.py
@@ -684,3 +684,24 @@ def test_update_next_step_eta(
     alert_group.refresh_from_db()
 
     assert alert_group.raw_escalation_snapshot["next_step_eta"] == updated_raw_next_step_eta
+
+
+@pytest.mark.django_db
+def test_update_next_step_eta_none(
+    make_organization_and_user,
+    make_alert_receive_channel,
+    make_alert_group,
+):
+    increase_by_timedelta = datetime.timedelta(minutes=120)
+
+    organization, _ = make_organization_and_user()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+    alert_group.raw_escalation_snapshot = alert_group.build_raw_escalation_snapshot()
+
+    assert alert_group.raw_escalation_snapshot is not None
+    assert alert_group.raw_escalation_snapshot.get("next_step_eta") is None
+
+    updated_snapshot = alert_group.update_next_step_eta(increase_by_timedelta)
+    assert updated_snapshot == alert_group.build_raw_escalation_snapshot()
+    assert updated_snapshot.get("next_step_eta") is None


### PR DESCRIPTION
# What this PR does
Fix silence for paused escalations or alert groups with empty escalation chain

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/2912

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
