### PR TITLE
Remove apps.mobile_app.tasks.notify_user_async celery task

### DIFF
--- a/engine/apps/mobile_app/tasks/__init__.py
+++ b/engine/apps/mobile_app/tasks/__init__.py
@@ -2,7 +2,7 @@ from .going_oncall_notification import (  # noqa:F401
     conditionally_send_going_oncall_push_notifications_for_all_schedules,
     conditionally_send_going_oncall_push_notifications_for_schedule,
 )
-from .new_alert_group import notify_user_about_new_alert_group, notify_user_async  # noqa:F401
+from .new_alert_group import notify_user_about_new_alert_group  # noqa:F401
 from .new_shift_swap_request import (  # noqa:F401
     notify_shift_swap_request,
     notify_shift_swap_requests,

--- a/engine/apps/mobile_app/tasks/new_alert_group.py
+++ b/engine/apps/mobile_app/tasks/new_alert_group.py
@@ -137,9 +137,3 @@ def notify_user_about_new_alert_group(user_pk, alert_group_pk, notification_poli
 
     message = _get_fcm_message(alert_group, user, device_to_notify, critical)
     send_push_notification(device_to_notify, message, _create_error_log_record)
-
-
-# TODO: remove this in a future release
-@shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True, max_retries=MAX_RETRIES)
-def notify_user_async(user_pk, alert_group_pk, notification_policy_pk, critical):
-    notify_user_about_new_alert_group(user_pk, alert_group_pk, notification_policy_pk, critical)

--- a/engine/common/tests/test_task_queue_assignment.py
+++ b/engine/common/tests/test_task_queue_assignment.py
@@ -9,7 +9,6 @@ we should avoid @shared_dedicated_queue_retry_task or @shared_task and
 remove entirely if it is not needed.
 """
 COMMON_IGNORED_TASKS = {
-    "apps.mobile_app.tasks.new_alert_group.notify_user_async",
     "apps.alerts.tasks.create_contact_points_for_datasource.schedule_create_contact_points_for_datasource",
     "common.oncall_gateway.tasks.create_slack_connector_async_v2",
 }

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -100,8 +100,6 @@ CELERY_TASK_ROUTES = {
     "apps.integrations.tasks.create_alert": {"queue": "critical"},
     "apps.integrations.tasks.create_alertmanager_alerts": {"queue": "critical"},
     "apps.integrations.tasks.start_notify_about_integration_ratelimit": {"queue": "critical"},
-    # TODO: remove apps.mobile_app.tasks.notify_user_async in a future release
-    "apps.mobile_app.tasks.notify_user_async": {"queue": "critical"},
     "apps.mobile_app.tasks.new_alert_group.notify_user_about_new_alert_group": {"queue": "critical"},
     "apps.mobile_app.tasks.going_oncall_notification.conditionally_send_going_oncall_push_notifications_for_schedule": {
         "queue": "critical"


### PR DESCRIPTION
# What this PR does

This task was renamed in a v1.3.30. It is no longer referenced and there are no pending tasks in production queues:
![Screenshot 2023-09-01 at 09 35 45](https://github.com/grafana/oncall/assets/9406895/0f7149bd-efe3-401e-ac94-a664af67472a)



## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
