### PR TITLE
Fix build escalation snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix for Cloud plugin install not refreshing page after completion ([2974](https://github.com/grafana/oncall/issues/2874))
+- Fix escalation snapshot building if user was deleted @Ferril ([#2954](https://github.com/grafana/oncall/pull/2954))
 
 ## v1.3.30 (2023-08-31)
 

--- a/engine/apps/alerts/escalation_snapshot/serializers/escalation_policy_snapshot.py
+++ b/engine/apps/alerts/escalation_snapshot/serializers/escalation_policy_snapshot.py
@@ -64,6 +64,7 @@ class EscalationPolicySnapshotSerializer(serializers.ModelSerializer):
     num_alerts_in_window = serializers.IntegerField(allow_null=True, default=None)
     num_minutes_in_window = serializers.IntegerField(allow_null=True, default=None)
     pause_escalation = serializers.BooleanField(default=False)
+    last_notified_user = PrimaryKeyRelatedFieldWithNoneValue(allow_null=True, queryset=User.objects)
 
     class Meta:
         model = EscalationPolicy

--- a/engine/apps/api/tests/test_escalation_policy.py
+++ b/engine/apps/api/tests/test_escalation_policy.py
@@ -846,6 +846,9 @@ def test_escalation_policy_filter_by_user(
 
     assert response.status_code == status.HTTP_200_OK
 
+    result = response.json()
+    assert set(result[1]["notify_to_users_queue"]) == {user.public_primary_key, second_user.public_primary_key}
+    expected_payload[1]["notify_to_users_queue"] = result[1]["notify_to_users_queue"]
     assert response.json() == expected_payload
 
 


### PR DESCRIPTION
# What this PR does
Fix escalation snapshot building if last notified user in escalation step "Notify users one by one (round-robin)" was deleted
 
## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2148

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
