### PR TITLE
Enable email notification step by default on Helm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Enable email notification step by default on Helm by @vadimkerr ([#2975](https://github.com/grafana/oncall/pull/2975))
+
 ## v1.3.35 (2023-09-05)
 
 ### Fixed

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -198,7 +198,7 @@ oncall:
     # The key in the secret containing Telegram token
     tokenKey: ""
   smtp:
-    enabled: false
+    enabled: true
     host: ~
     port: ~
     username: ~


### PR DESCRIPTION
# What this PR does

Set `oncall.smtp.enabled` to `true` by default to enable email notifications on Helm deployments.
Email notifications are enabled by default on docker-compose deployments already: see [this feature flag](https://github.com/grafana/oncall/blob/df6f6183ecc9e541d07317590db9d3affb7097ab/engine/settings/base.py#L63).

## Which issue(s) this PR fixes

https://github.com/grafana/oncall/issues/2917

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
