### PR TITLE
Trigger alert group signal after transaction commit

### DIFF
--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -3,6 +3,7 @@ import logging
 import typing
 import urllib
 from collections import namedtuple
+from functools import partial
 from urllib.parse import urljoin
 
 from celery import uuid as celery_uuid
@@ -1215,7 +1216,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
             alert_group.start_ack_reminder_if_needed()
 
             log_record = alert_group.log_records.create(type=AlertGroupLogRecord.TYPE_ACK, author=user)
-            send_alert_group_signal.apply_async((log_record.pk,))
+            transaction.on_commit(partial(send_alert_group_signal.delay, log_record.pk))
 
     @staticmethod
     def bulk_acknowledge(user: User, alert_groups: "QuerySet[AlertGroup]") -> None:
@@ -1287,7 +1288,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
                 state=AlertGroupState.RESOLVED,
             )
             log_record = alert_group.log_records.create(type=AlertGroupLogRecord.TYPE_RESOLVED, author=user)
-            send_alert_group_signal.apply_async((log_record.pk,))
+            transaction.on_commit(partial(send_alert_group_signal.delay, log_record.pk))
 
     @staticmethod
     def bulk_resolve(user: User, alert_groups: "QuerySet[AlertGroup]") -> None:
@@ -1360,7 +1361,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
             if alert_group.is_root_alert_group:
                 alert_group.start_escalation_if_needed()
 
-            send_alert_group_signal.apply_async((log_record.pk,))
+            transaction.on_commit(partial(send_alert_group_signal.delay, log_record.pk))
 
     @staticmethod
     def _bulk_restart_unresolve(user: User, alert_groups_to_restart_unresolve: "QuerySet[AlertGroup]") -> None:
@@ -1403,7 +1404,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
             if alert_group.is_root_alert_group:
                 alert_group.start_escalation_if_needed()
 
-            send_alert_group_signal.apply_async((log_record.pk,))
+            transaction.on_commit(partial(send_alert_group_signal.delay, log_record.pk))
 
     @staticmethod
     def _bulk_restart_unsilence(user: User, alert_groups_to_restart_unsilence: "QuerySet[AlertGroup]") -> None:
@@ -1442,7 +1443,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
             )
             alert_group.start_escalation_if_needed()
 
-            send_alert_group_signal.apply_async((log_record.pk,))
+            transaction.on_commit(partial(send_alert_group_signal.delay, log_record.pk))
 
     @staticmethod
     def bulk_restart(user: User, alert_groups: "QuerySet[AlertGroup]") -> None:
@@ -1578,7 +1579,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
                 reason="Bulk action silence",
             )
 
-            send_alert_group_signal.apply_async((log_record.pk,))
+            transaction.on_commit(partial(send_alert_group_signal.delay, log_record.pk))
             if silence_for_period and alert_group.is_root_alert_group:
                 alert_group.start_unsilence_task(countdown=silence_delay)
 

--- a/engine/apps/alerts/models/invitation.py
+++ b/engine/apps/alerts/models/invitation.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+from functools import partial
 
 from django.db import models, transaction
 
@@ -92,8 +93,8 @@ class Invitation(models.Model):
             f"log record {log_record.pk} with type '{log_record.get_type_display()}'"
         )
 
-        tasks.send_alert_group_signal.apply_async((log_record.pk,))
-        tasks.invite_user_to_join_incident.apply_async((invitation.pk,))
+        transaction.on_commit(partial(tasks.send_alert_group_signal.delay, log_record.pk))
+        transaction.on_commit(partial(tasks.invite_user_to_join_incident.delay, invitation.pk))
 
     @staticmethod
     def stop_invitation(invitation_pk, user):
@@ -119,4 +120,4 @@ class Invitation(models.Model):
             f"call send_alert_group_signal for alert_group {invitation.alert_group.pk}, "
             f"log record {log_record.pk} with type '{log_record.get_type_display()}'"
         )
-        tasks.send_alert_group_signal.apply_async((log_record.pk,))
+        transaction.on_commit(partial(tasks.send_alert_group_signal.delay, log_record.pk))


### PR DESCRIPTION
See https://docs.djangoproject.com/en/4.2/topics/db/transactions/#performing-actions-after-commit

Related to https://github.com/grafana/oncall-private/issues/2015