### PR TITLE
Add render_for_web information to alert group incident API

### DIFF
--- a/engine/apps/api_for_grafana_incident/serializers.py
+++ b/engine/apps/api_for_grafana_incident/serializers.py
@@ -2,7 +2,9 @@ import logging
 
 from rest_framework import serializers
 
+from apps.alerts.incident_appearance.renderers.web_renderer import AlertGroupWebRenderer
 from apps.alerts.models import Alert, AlertGroup
+from apps.api.serializers.alert_group import AlertGroupFieldsCacheSerializerMixin
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +28,21 @@ class AlertGroupSerializer(serializers.ModelSerializer):
     title = serializers.CharField(read_only=True, source="long_verbose_name_without_formatting")
     alerts = AlertSerializer(many=True, read_only=True)
 
+    render_for_web = serializers.SerializerMethodField()
+
     def get_status(self, obj):
         return next(filter(lambda status: status[0] == obj.status, AlertGroup.STATUS_CHOICES))[1].lower()
+
+    def get_render_for_web(self, obj):
+        last_alert = obj.alerts.last()
+        if last_alert is None:
+            return {}
+        return AlertGroupFieldsCacheSerializerMixin.get_or_set_web_template_field(
+            obj,
+            last_alert,
+            AlertGroupFieldsCacheSerializerMixin.RENDER_FOR_WEB_FIELD_NAME,
+            AlertGroupWebRenderer,
+        )
 
     class Meta:
         model = AlertGroup
@@ -37,4 +52,5 @@ class AlertGroupSerializer(serializers.ModelSerializer):
             "status",
             "alerts",
             "title",
+            "render_for_web",
         ]

--- a/engine/apps/api_for_grafana_incident/tests/test_views.py
+++ b/engine/apps/api_for_grafana_incident/tests/test_views.py
@@ -1,0 +1,50 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_alert_group_details(
+    make_organization,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_alert,
+    settings,
+):
+    settings.GRAFANA_INCIDENT_STATIC_API_KEY = "test-key"
+    headers = {"HTTP_AUTHORIZATION": "test-key"}
+    organization = make_organization()
+    alert_receive_channel = make_alert_receive_channel(
+        organization,
+        slack_title_template=None,
+        web_title_template="title: {{ payload.field2 }}",
+        web_message_template="Something {{ payload.field1 }} + {{ payload.field3 }}",
+        web_image_url_template="http://{{ payload.field1 }}",
+    )
+    alert_group = make_alert_group(alert_receive_channel)
+    alert_payload = {"field1": "foo", "field2": "bar", "field3": "baz"}
+    alert = make_alert(alert_group, alert_payload)
+
+    client = APIClient()
+
+    url = reverse("api-gi:alert-groups-detail", kwargs={"public_primary_key": alert_group.public_primary_key})
+    response = client.get(url, format="json", **headers)
+    expected = {
+        "id": alert_group.public_primary_key,
+        "link": alert_group.web_link,
+        "status": "new",
+        "title": alert_group.long_verbose_name_without_formatting,
+        "alerts": [
+            {
+                "id_oncall": alert.public_primary_key,
+                "payload": alert_payload,
+            }
+        ],
+        "render_for_web": {
+            "title": "title: bar",
+            "message": "<p>Something foo + baz</p>",
+            "image_url": "http://foo",
+            "source_link": None,
+        },
+    }
+    assert response.json() == expected


### PR DESCRIPTION
Include alert group render_for_web details in the API response.

Related to https://github.com/grafana/oncall-private/issues/2159