### PR TITLE
[WIP] Add base image with installed pip wheels

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -293,6 +293,7 @@ steps:
 trigger:
   ref:
     include:
+      - refs/heads/iskhakov/add-base-image
       - refs/heads/main
       - refs/heads/dev
       - refs/tags/v*.*.*

--- a/.drone.yml
+++ b/.drone.yml
@@ -279,28 +279,26 @@ steps:
       # Ignore lines that start with #.
       - grep -v '^#' ./engine/base-image-version > .tags
 
-  - name: build and push oncall base docker image for arm64
-    image: plugins/docker
+  - name: build and push oncall base docker image
+    image: thegeeklab/drone-docker-buildx:24.1.0
+    # From the docs (https://drone-plugin-index.geekdocs.de/plugins/drone-docker-buildx/) regarding privileged=true:
+    #
+    # Be aware that the this plugin requires privileged capabilities, otherwise the integrated
+    # Docker daemon is not able to start.
+    privileged: true
     settings:
       repo: grafana/oncall-base
-      platform: linux/arm64
+      tags: latest,${DRONE_TAG}
+      platforms: linux/arm64/v8,linux/amd64
       dockerfile: engine/Dockerfile.base
       context: engine/
       password:
         from_secret: docker_password
       username:
         from_secret: docker_username
-  - name: build and push oncall base docker image for amd64
-    image: plugins/docker
-    settings:
-      repo: grafana/oncall-base
-      platform: linux/amd64
-      dockerfile: engine/Dockerfile.base
-      context: engine/
-      password:
-        from_secret: docker_password
-      username:
-        from_secret: docker_username
+    depends_on:
+      - set oncall base image version
+
 trigger:
   ref:
     include:

--- a/.drone.yml
+++ b/.drone.yml
@@ -279,11 +279,22 @@ steps:
       # Ignore lines that start with #.
       - grep -v '^#' ./engine/base-image-version > .tags
 
-  - name: build and push oncall base docker image
+  - name: build and push oncall base docker image for arm64
     image: plugins/docker
     settings:
       repo: grafana/oncall-base
-      platform: linux/arm64/v8,linux/amd64
+      platform: linux/arm64
+      dockerfile: engine/Dockerfile.base
+      context: engine/
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+  - name: build and push oncall base docker image for amd64
+    image: plugins/docker
+    settings:
+      repo: grafana/oncall-base
+      platform: linux/amd64
       dockerfile: engine/Dockerfile.base
       context: engine/
       password:

--- a/.drone.yml
+++ b/.drone.yml
@@ -288,7 +288,6 @@ steps:
     privileged: true
     settings:
       repo: grafana/oncall-base
-      tags: latest,${DRONE_TAG}
       platforms: linux/arm64/v8,linux/amd64
       dockerfile: engine/Dockerfile.base
       context: engine/

--- a/.drone.yml
+++ b/.drone.yml
@@ -277,7 +277,7 @@ steps:
     commands:
       # Tag image with the version located in the base-image-version file.
       # Ignore lines that start with #.
-      - grep -v '^#' base-image-version > .tags
+      - grep -v '^#' ./engine/base-image-version > .tags
 
   - name: build and push oncall base docker image
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -283,7 +283,6 @@ steps:
     image: plugins/docker
     settings:
       repo: grafana/oncall-base
-      tags: latest
       platform: linux/arm64/v8,linux/amd64
       dockerfile: engine/Dockerfile.base
       context: engine/

--- a/.drone.yml
+++ b/.drone.yml
@@ -267,6 +267,38 @@ trigger:
     - refs/tags/v*.*.*
 
 ---
+kind: pipeline
+type: docker
+name: OSS engine base image release
+
+steps:
+  - name: set oncall base image version
+    image: alpine
+    commands:
+      # Tag image with the version located in the base-image-version file.
+      # Ignore lines that start with #.
+      - grep -v '^#' base-image-version > .tags
+
+  - name: build and push oncall base docker image
+    image: plugins/docker
+    settings:
+      repo: grafana/oncall-base
+      tags: latest
+      platform: linux/arm64/v8,linux/amd64
+      dockerfile: engine/Dockerfile.base
+      context: engine/
+      password:
+        from_secret: docker_password
+      username:
+        from_secret: docker_username
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/heads/dev
+      - refs/tags/v*.*.*
+
+---
 # Secret for pulling docker images.
 kind: secret
 name: dockerconfigjson

--- a/engine/Dockerfile.base
+++ b/engine/Dockerfile.base
@@ -1,0 +1,17 @@
+FROM python:3.11.4-alpine3.18 AS base
+
+RUN apk add \
+            python3-dev \
+            build-base \
+            linux-headers \
+            pcre-dev \
+            libffi-dev \
+            mariadb-connector-c-dev \
+            git \
+            postgresql-dev 
+
+COPY ./requirements-base.txt ./
+RUN pip install --upgrade pip setuptools wheel
+RUN pip install --no-cache-dir -r requirements-base.txt \
+  # Clean up
+  && rm requirements-base.txt

--- a/engine/base-image-version
+++ b/engine/base-image-version
@@ -1,0 +1,2 @@
+# This is the version of the base image grafana/oncall-base 
+python3.11.4-alpine3.18-1

--- a/engine/base-image-version
+++ b/engine/base-image-version
@@ -1,2 +1,3 @@
 # This is the version of the base image grafana/oncall-base 
+# The image is pushed to dockerhub by CI in ./.drone.yml
 python3.11.4-alpine3.18-1

--- a/engine/requirements-base.txt
+++ b/engine/requirements-base.txt
@@ -1,0 +1,17 @@
+# These dependencies are pre-installed into base image to increase build speed for different platforms
+cffi==1.15.1
+django-mirage-field==1.3.0
+django-redis-cache @ git+https://github.com/grafana/django-redis-cache.git@37fd75814b34775c657598fcb2309caafbcc4c59
+django-sns-view==0.1.2
+emoji==2.4.0
+fcm-django @ https://github.com/grafana/fcm-django/archive/refs/tags/v1.0.12r1.tar.gz#sha256=7ec7cd9d353fc9edf19a4acd4fa14090a31d83d02ac986c5e5e081dea29f564f
+grpcio==1.57.0
+grpcio-status==1.57.0
+hiredis==1.0.0
+humanize==0.5.1
+psutil==5.9.4
+psycopg2==2.9.3
+recurring-ical-events==0.1.16b0
+regex==2021.11.2
+slack-export-viewer==1.1.4
+twilio==6.37.0


### PR DESCRIPTION
# What this PR does

Instead of using custom image as a base it is better to [use similar approach](https://lipanski.com/posts/speed-up-your-docker-builds-with-cache-from)
```
docker pull grafana/oncall

DOCKER_BUILDKIT=1 docker build --cache-from grafana/oncall:latest --cache-from docker.io/library/python:3.11.4-alpine3.18 --tag grafana/oncall:latest --build-arg BUILDKIT_INLINE_CACHE=1  .
```


## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
