### PR TITLE
Update slack direct paging default to general team

### DIFF
--- a/engine/apps/slack/scenarios/paging.py
+++ b/engine/apps/slack/scenarios/paging.py
@@ -433,7 +433,7 @@ def render_dialog(
 
     # widgets
     team_select_blocks = _get_team_select_blocks(
-        slack_user_identity, selected_organization, is_team_selected, selected_team, new_input_id_prefix
+        slack_user_identity, selected_organization, selected_team, new_input_id_prefix
     )
     additional_responders_blocks = _get_additional_responders_blocks(
         payload, selected_organization, new_input_id_prefix, is_additional_responders_checked, error_msg
@@ -545,7 +545,6 @@ def _get_selected_org_from_payload(
 def _get_team_select_blocks(
     slack_user_identity: "SlackUserIdentity",
     organization: "Organization",
-    is_selected: bool,
     value: "Team",
     input_id_prefix: str,
 ) -> Block.AnyBlocks:
@@ -594,10 +593,6 @@ def _get_team_select_blocks(
         },
         "dispatch_action": True,
     }
-
-    # No context block if no team selected
-    if not is_selected:
-        return [team_select]
 
     team_select["element"]["initial_option"] = team_options[initial_option_idx]
     return [team_select, _get_team_select_context(organization, value)]

--- a/engine/apps/slack/tests/test_scenario_steps/test_paging.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_paging.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from apps.base.models import UserNotificationPolicy
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleWeb
 from apps.slack.scenarios.paging import (
+    DEFAULT_TEAM_VALUE,
     DIRECT_PAGING_ADDITIONAL_RESPONDERS_INPUT_ID,
     DIRECT_PAGING_MESSAGE_INPUT_ID,
     DIRECT_PAGING_ORG_SELECT_ID,
@@ -99,6 +100,10 @@ def test_initial_state(
     metadata = json.loads(mock_slack_api_call.call_args.kwargs["view"]["private_metadata"])
     assert metadata[DataKey.USERS] == {}
     assert metadata[DataKey.SCHEDULES] == {}
+    initial_blocks = mock_slack_api_call.call_args.kwargs["view"]["blocks"]
+    # title, message, team, ...
+    team_select = initial_blocks[2]
+    assert team_select["element"]["initial_option"]["value"] == DEFAULT_TEAM_VALUE
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Related to https://github.com/grafana/oncall/issues/3021

I think a similar approach could be implemented for the web UI.