### PR TITLE
Allow deletion for removed presets

### DIFF
--- a/engine/apps/webhooks/presets/preset_options.py
+++ b/engine/apps/webhooks/presets/preset_options.py
@@ -20,7 +20,7 @@ class WebhookPresetOptions:
 
 @receiver(pre_save, sender=Webhook)
 def listen_for_webhook_save(sender: Webhook, instance: Webhook, raw: bool, *args, **kwargs) -> None:
-    if instance.preset:
+    if instance.preset and not instance.deleted_at:
         if instance.preset in WebhookPresetOptions.WEBHOOK_PRESETS:
             WebhookPresetOptions.WEBHOOK_PRESETS[instance.preset].override_parameters_before_save(instance)
         else:


### PR DESCRIPTION
If a webhook preset is removed from configuration while there are still existing webhooks referencing it they will have the following behavior:

- Webhook can be viewed
- Webhook can be deleted
- Webhook cannot be modified
- Webhook will not execute

Removing a preset from configuration effectively disables all existing webhooks referencing it while retaining their data.