### PR TITLE
Fix action/webhook API not accepting empty/null user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Accept empty and null user when updating webhook via API @mderynck ([#3093](https://github.com/grafana/oncall/pull/3093)))
+
 ## v1.3.40 (2023-08-28)
 
 ### Added

--- a/engine/apps/public_api/serializers/action.py
+++ b/engine/apps/public_api/serializers/action.py
@@ -48,7 +48,7 @@ class ActionCreateSerializer(WebhookCreateSerializer):
 
 
 class ActionUpdateSerializer(ActionCreateSerializer):
-    user = serializers.CharField(required=False, source="username")
+    user = serializers.CharField(required=False, source="username", allow_null=True, allow_blank=True)
     trigger_type = WebhookTriggerTypeField(required=False)
     forward_whole_payload = serializers.BooleanField(required=False, source="forward_all")
 

--- a/engine/apps/public_api/serializers/action.py
+++ b/engine/apps/public_api/serializers/action.py
@@ -63,7 +63,6 @@ class ActionUpdateSerializer(ActionCreateSerializer):
             "headers": {"required": False, "allow_null": True, "allow_blank": True},
             "url": {"required": False, "allow_null": False, "allow_blank": False},
             "data": {"required": False, "allow_null": True, "allow_blank": True},
-            "forward_whole_payload": {"required": False, "allow_null": False},
             "http_method": {"required": False, "allow_null": False, "allow_blank": False},
             "integration_filter": {"required": False, "allow_null": True},
         }

--- a/engine/apps/public_api/tests/test_custom_actions.py
+++ b/engine/apps/public_api/tests/test_custom_actions.py
@@ -366,7 +366,7 @@ def test_create_custom_action_valid_after_render_use_all_data(make_organization_
         ),
         (
             {
-                "name": "RENAMED",
+                "name": "RENAMED 1",
                 "url": "https://example.com",
                 "user": None,
                 "password": None,
@@ -377,7 +377,7 @@ def test_create_custom_action_valid_after_render_use_all_data(make_organization_
         ),
         (
             {
-                "name": "RENAMED",
+                "name": "RENAMED 2",
                 "url": "https://example.com",
                 "user": "",
                 "password": "",
@@ -402,21 +402,18 @@ def test_update_custom_action(
     assert custom_action.name != data["name"]
 
     response = client.put(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
+    custom_action.refresh_from_db()
 
     expected_result = {
         "id": custom_action.public_primary_key,
-        "name": data["name"],
+        "name": custom_action.name,
         "team_id": None,
-        "url": data["url"],
-        "data": data["data"] if "data" in data else custom_action.data,
-        "user": data["username"] if "username" in data else custom_action.username,
-        "password": data["password"] if "password" in data else custom_action.password,
-        "authorization_header": data["authorization_header"]
-        if "authorization_header" in data
-        else custom_action.authorization_header,
-        "forward_whole_payload": data["forward_whole_payload"]
-        if "forward_whole_payload" in data
-        else custom_action.forward_whole_payload,
+        "url": custom_action.url,
+        "data": custom_action.data,
+        "user": custom_action.username,
+        "password": custom_action.password,
+        "authorization_header": custom_action.authorization_header,
+        "forward_whole_payload": custom_action.forward_all,
         "is_webhook_enabled": custom_action.is_webhook_enabled,
         "trigger_template": custom_action.trigger_template,
         "headers": custom_action.headers,
@@ -426,8 +423,6 @@ def test_update_custom_action(
     }
 
     assert response.status_code == status.HTTP_200_OK
-    custom_action.refresh_from_db()
-    assert custom_action.name == expected_result["name"]
     assert response.data == expected_result
 
 

--- a/engine/apps/public_api/views/action.py
+++ b/engine/apps/public_api/views/action.py
@@ -2,7 +2,6 @@ from django_filters import rest_framework as filters
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ModelViewSet
 
-from apps.api.serializers.webhook import WebhookSerializer
 from apps.auth_token.auth import ApiTokenAuthentication
 from apps.public_api.serializers.action import ActionCreateSerializer, ActionUpdateSerializer
 from apps.public_api.throttlers.user_throttle import UserThrottle
@@ -19,7 +18,7 @@ class ActionView(RateLimitHeadersMixin, PublicPrimaryKeyMixin, UpdateSerializerM
     pagination_class = FiftyPageSizePaginator
     throttle_classes = [UserThrottle]
 
-    model = WebhookSerializer
+    model = Webhook
     serializer_class = ActionCreateSerializer
     update_serializer_class = ActionUpdateSerializer
 


### PR DESCRIPTION
# What this PR does
Fix update calls made by terraform when user field is empty or not present.
Should have been part of: https://github.com/grafana/oncall/pull/3053

## Which issue(s) this PR fixes
https://github.com/grafana/terraform-provider-grafana/issues/1025

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
