### PR TITLE
unskip sms verification e2e test

### DIFF
--- a/grafana-plugin/e2e-tests/alerts/sms.test.ts
+++ b/grafana-plugin/e2e-tests/alerts/sms.test.ts
@@ -5,8 +5,7 @@ import { createIntegrationAndSendDemoAlert } from '../utils/integrations';
 import { waitForSms } from '../utils/phone';
 import { configureUserNotificationSettings, verifyUserPhoneNumber } from '../utils/userSettings';
 
-// TODO: enable once we've signed up for a MailSlurp account to receieve SMSes
-test.skip('we can verify our phone number + receive an SMS alert @expensive', async ({ adminRolePage }) => {
+test('we can verify our phone number + receive an SMS alert @expensive', async ({ adminRolePage }) => {
   const { page, userName } = adminRolePage;
   const escalationChainName = generateRandomValue();
   const integrationName = generateRandomValue();


### PR DESCRIPTION
# What this PR does

Since we now have a Mailslurp account we can start running this test. At the moment it is only run 1x daily on a GitHub Actions cron (to avoid incurring costs; [it is skipped](https://github.com/grafana/oncall/blob/dev/.github/workflows/linting-and-tests.yml#L317) via a Playwright "[test annotation filter](https://github.com/grafana/oncall/blob/dev/grafana-plugin/package.json#L14-L15)").

`MAILSLURP_API_KEY` repo secret has already been updated.

Closes #2693