### PR TITLE
Update plugin role permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Update plugin OnCaller role permissions ([#3145](https://github.com/grafana/oncall/pull/3145))
+
 ## v1.3.43 (2023-10-05)
 
 ### Added

--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -317,12 +317,13 @@
     {
       "role": {
         "name": "OnCaller",
-        "description": "Grants read access to everything in OnCall. In addition, grants edit access to Alert Groups and Schedules",
+        "description": "Grants read access to everything in OnCall. In addition, grants edit access to Alert Groups, Schedules and own settings",
         "permissions": [
           { "action": "plugins.app:access", "scope": "plugins:id:grafana-oncall-app" },
 
           { "action": "grafana-oncall-app.alert-groups:read" },
           { "action": "grafana-oncall-app.alert-groups:write" },
+          { "action": "grafana-oncall-app.alert-groups:direct-paging" },
 
           { "action": "grafana-oncall-app.integrations:read" },
           { "action": "grafana-oncall-app.escalation-chains:read" },
@@ -336,6 +337,7 @@
           { "action": "grafana-oncall-app.notifications:read" },
           { "action": "grafana-oncall-app.notification-settings:read" },
           { "action": "grafana-oncall-app.user-settings:read" },
+          { "action": "grafana-oncall-app.user-settings:write" },
           { "action": "grafana-oncall-app.other-settings:read" }
         ]
       },


### PR DESCRIPTION
When the direct paging role was [introduced](https://github.com/grafana/oncall/pull/3107), the OnCaller role didn't keep the permission to use this feature.
Also, being an OnCaller, makes sense user can update their own notification settings.

Related https://github.com/grafana/support-escalations/issues/7840.