### PR TITLE
Update ical schedule creation/update to trigger final schedule refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Update ical schedule creation/update to trigger final schedule refresh ([#3156](https://github.com/grafana/oncall/pull/3156))
+
 ## v1.3.44 (2023-10-16)
 
 ### Added


### PR DESCRIPTION
Otherwise iCal schedules only refresh their cached final representation once a day (via periodic task).
Related to https://github.com/grafana/oncall/issues/3154