### PR TITLE
Copy change for Schedules

### DIFF
--- a/grafana-plugin/src/pages/escalation-chains/EscalationChains.tsx
+++ b/grafana-plugin/src/pages/escalation-chains/EscalationChains.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, HorizontalGroup, Icon, IconButton, LoadingPlaceholder, Tooltip, VerticalGroup } from '@grafana/ui';
+import { Button, HorizontalGroup, Icon, IconButton, Tooltip, VerticalGroup } from '@grafana/ui';
 import cn from 'classnames/bind';
 import { observer } from 'mobx-react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -176,7 +176,11 @@ class EscalationChainsPage extends React.Component<EscalationChainsPageProps, Es
                           {(item) => <EscalationChainCard id={item.id} />}
                         </GList>
                       ) : (
-                        <LoadingPlaceholder className={cx('loading')} text="Loading..." />
+                        <VerticalGroup>
+                          <Text type="primary" className={cx('loading')}>
+                            Loading...
+                          </Text>
+                        </VerticalGroup>
                       )}
                     </div>
                   </div>

--- a/grafana-plugin/src/pages/schedules/Schedules.tsx
+++ b/grafana-plugin/src/pages/schedules/Schedules.tsx
@@ -125,7 +125,7 @@ class SchedulesPage extends React.Component<SchedulesPageProps, SchedulesPageSta
           </div>
 
           {results === undefined ? (
-            <LoadingPlaceholder text="Loading Schedules..." />
+            <LoadingPlaceholder text="Loading..." />
           ) : (
             <Table
               columns={this.getTableColumns()}

--- a/grafana-plugin/src/pages/schedules/Schedules.tsx
+++ b/grafana-plugin/src/pages/schedules/Schedules.tsx
@@ -124,28 +124,24 @@ class SchedulesPage extends React.Component<SchedulesPageProps, SchedulesPageSta
             />
           </div>
 
-          {results === undefined ? (
-            <LoadingPlaceholder text="Loading..." />
-          ) : (
-            <Table
-              columns={this.getTableColumns()}
-              data={results}
-              loading={!results}
-              pagination={{
-                page,
-                total: Math.ceil((count || 0) / (page_size || PAGE_SIZE_DEFAULT)),
-                onChange: this.handlePageChange,
-              }}
-              rowKey="id"
-              expandable={{
-                expandedRowKeys: expandedRowKeys,
-                onExpand: this.handleExpandRow,
-                expandedRowRender: this.renderSchedule,
-                expandRowByClick: true,
-              }}
-              emptyText={this.renderNotFound()}
-            />
-          )}
+          <Table
+            columns={this.getTableColumns()}
+            data={results}
+            loading={!results}
+            pagination={{
+              page,
+              total: Math.ceil((count || 0) / (page_size || PAGE_SIZE_DEFAULT)),
+              onChange: this.handlePageChange,
+            }}
+            rowKey="id"
+            expandable={{
+              expandedRowKeys: expandedRowKeys,
+              onExpand: this.handleExpandRow,
+              expandedRowRender: this.renderSchedule,
+              expandRowByClick: true,
+            }}
+            emptyText={results === undefined ? 'Loading...' : this.renderNotFound()}
+          />
         </div>
 
         {showNewScheduleSelector && (


### PR DESCRIPTION
# What this PR does

- Replaced `LoadingPlaceholder` with normal `Text` on the Escalations page
- Changed the copy for the loading indicator on Schedules

Both changes have been done to be consistent with the style used on the other pages.
