### PR TITLE
Fix channel filter endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Add filtering term length check for channel filter endpoints @Ferril ([#3192](https://github.com/grafana/oncall/pull/3192))
+
 ## v1.3.46 (2023-10-23)
 
 ### Added

--- a/engine/apps/alerts/models/channel_filter.py
+++ b/engine/apps/alerts/models/channel_filter.py
@@ -76,7 +76,9 @@ class ChannelFilter(OrderedModel):
     notification_backends = models.JSONField(null=True, default=None)
 
     created_at = models.DateTimeField(auto_now_add=True)
-    filtering_term = models.CharField(max_length=1024, null=True, default=None)
+
+    FILTERING_TERM_MAX_LENGTH = 1024
+    filtering_term = models.CharField(max_length=FILTERING_TERM_MAX_LENGTH, null=True, default=None)
 
     FILTERING_TERM_TYPE_REGEX = 0
     FILTERING_TERM_TYPE_JINJA2 = 1

--- a/engine/apps/api/serializers/channel_filter.py
+++ b/engine/apps/api/serializers/channel_filter.py
@@ -60,6 +60,12 @@ class ChannelFilterSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     def validate(self, data):
         filtering_term = data.get("filtering_term")
         filtering_term_type = data.get("filtering_term_type")
+        if filtering_term is not None:
+            if len(filtering_term) > ChannelFilter.FILTERING_TERM_MAX_LENGTH:
+                raise serializers.ValidationError(
+                    f"Expression is too long. Maximum length: {ChannelFilter.FILTERING_TERM_MAX_LENGTH} characters, "
+                    f"current length: {len(filtering_term)}"
+                )
         if filtering_term_type == ChannelFilter.FILTERING_TERM_TYPE_JINJA2:
             try:
                 valid_jinja_template_for_serializer_method_field({"route_template": filtering_term})
@@ -141,7 +147,6 @@ class ChannelFilterSerializer(EagerLoadingMixin, serializers.ModelSerializer):
 class ChannelFilterCreateSerializer(ChannelFilterSerializer):
     alert_receive_channel = OrganizationFilteredPrimaryKeyRelatedField(queryset=AlertReceiveChannel.objects)
     slack_channel = serializers.CharField(allow_null=True, required=False, source="slack_channel_id")
-    filtering_term = serializers.CharField(required=False, allow_null=True, allow_blank=True)
 
     class Meta:
         model = ChannelFilter

--- a/engine/apps/public_api/serializers/routes.py
+++ b/engine/apps/public_api/serializers/routes.py
@@ -163,8 +163,14 @@ class ChannelFilterSerializer(BaseChannelFilterSerializer):
         return super().create(validated_data)
 
     def validate(self, data):
-        filtering_term = data.get("routing_regex")
-        filtering_term_type = data.get("routing_type")
+        filtering_term = data.get("filtering_term")
+        filtering_term_type = data.get("filtering_term_type")
+        if filtering_term is not None:
+            if len(filtering_term) > ChannelFilter.FILTERING_TERM_MAX_LENGTH:
+                raise serializers.ValidationError(
+                    f"Expression is too long. Maximum length: {ChannelFilter.FILTERING_TERM_MAX_LENGTH} characters, "
+                    f"current length: {len(filtering_term)}"
+                )
         if filtering_term_type == ChannelFilter.FILTERING_TERM_TYPE_JINJA2:
             try:
                 valid_jinja_template_for_serializer_method_field({"route_template": filtering_term})


### PR DESCRIPTION
# What this PR does
Add filtering term length check for channel filter endpoints

## Which issue(s) this PR fixes

Closes https://github.com/grafana/oncall-private/issues/2114

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
