### PR TITLE
Quickfix for getting alert group from slack message payload

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py
@@ -437,6 +437,8 @@ class AlertGroupSlackRenderer(AlertGroupBaseRenderer):
         data = {
             "organization_id": self.alert_group.channel.organization_id,
             "alert_group_pk": self.alert_group.pk,
+            # eventually replace using alert_group_pk with alert_group_public_pk in slack payload
+            "alert_group_ppk": self.alert_group.public_primary_key,
             **kwargs,
         }
         return json.dumps(data)  # Slack block elements allow to pass value as string only (max 2000 chars)

--- a/engine/apps/slack/scenarios/step_mixins.py
+++ b/engine/apps/slack/scenarios/step_mixins.py
@@ -107,7 +107,7 @@ class AlertGroupActionsMixin:
 
         try:
             alert_group_pk = value["alert_group_pk"]
-            organization_pk = value["organization_pk"]
+            organization_pk = value["organization_id"]
         except (KeyError, TypeError):
             return None
 
@@ -152,7 +152,7 @@ class AlertGroupActionsMixin:
 
             try:
                 alert_group_pk = value["alert_group_pk"]
-                organization_pk = value["organization_pk"]
+                organization_pk = value["organization_id"]
             except (KeyError, TypeError):
                 continue
 

--- a/engine/apps/slack/tests/test_scenario_steps/test_alert_group_actions.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_alert_group_actions.py
@@ -191,7 +191,21 @@ def test_get_alert_group_from_message(
         ],
         "message": {
             "ts": "RANDOM_MESSAGE_TS",
-            "attachments": [{"blocks": [{"elements": [{"value": json.dumps({"alert_group_pk": alert_group.pk})}]}]}],
+            "attachments": [
+                {
+                    "blocks": [
+                        {
+                            "elements": [
+                                {
+                                    "value": json.dumps(
+                                        {"alert_group_pk": alert_group.pk, "organization_id": organization.pk}
+                                    )
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
         },
         "channel": {"id": "RANDOM_CHANNEL_ID"},
     }

--- a/engine/apps/slack/tests/test_scenario_steps/test_manage_responders.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_manage_responders.py
@@ -81,18 +81,16 @@ def manage_responders_setup(
 
 @pytest.mark.django_db
 def test_initial_state(manage_responders_setup):
+    organization, user, slack_team_identity, slack_user_identity = manage_responders_setup
     payload = {
         "trigger_id": TRIGGER_ID,
         "actions": [
             {
                 "type": "button",
-                "value": json.dumps({"organization_id": ORGANIZATION_ID, "alert_group_pk": ALERT_GROUP_ID}),
+                "value": json.dumps({"organization_id": organization.pk, "alert_group_pk": ALERT_GROUP_ID}),
             }
         ],
     }
-
-    organization, user, slack_team_identity, slack_user_identity = manage_responders_setup
-
     step = StartManageResponders(slack_team_identity, organization, user)
     with patch.object(step._slack_client, "views_open") as mock_slack_api_call:
         step.process_scenario(slack_user_identity, slack_team_identity, payload)

--- a/engine/apps/slack/tests/test_slack_renderer.py
+++ b/engine/apps/slack/tests/test_slack_renderer.py
@@ -17,7 +17,11 @@ def test_slack_renderer_acknowledge_button(make_organization, make_alert_receive
 
     button = elements[0]
     assert button["text"]["text"] == "Acknowledge"
-    assert json.loads(button["value"]) == {"organization_id": organization.pk, "alert_group_pk": alert_group.pk}
+    assert json.loads(button["value"]) == {
+        "organization_id": organization.pk,
+        "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
+    }
 
 
 @pytest.mark.django_db
@@ -33,7 +37,11 @@ def test_slack_renderer_unacknowledge_button(
 
     button = elements[0]
     assert button["text"]["text"] == "Unacknowledge"
-    assert json.loads(button["value"]) == {"organization_id": organization.pk, "alert_group_pk": alert_group.pk}
+    assert json.loads(button["value"]) == {
+        "organization_id": organization.pk,
+        "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
+    }
 
 
 @pytest.mark.django_db
@@ -47,7 +55,11 @@ def test_slack_renderer_resolve_button(make_organization, make_alert_receive_cha
 
     button = elements[1]
     assert button["text"]["text"] == "Resolve"
-    assert json.loads(button["value"]) == {"organization_id": organization.pk, "alert_group_pk": alert_group.pk}
+    assert json.loads(button["value"]) == {
+        "organization_id": organization.pk,
+        "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
+    }
 
 
 @pytest.mark.django_db
@@ -61,7 +73,11 @@ def test_slack_renderer_unresolve_button(make_organization, make_alert_receive_c
 
     button = elements[0]
     assert button["text"]["text"] == "Unresolve"
-    assert json.loads(button["value"]) == {"organization_id": organization.pk, "alert_group_pk": alert_group.pk}
+    assert json.loads(button["value"]) == {
+        "organization_id": organization.pk,
+        "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
+    }
 
 
 @pytest.mark.django_db
@@ -133,6 +149,7 @@ def test_slack_renderer_unsilence_button(make_organization, make_alert_receive_c
     assert json.loads(button["value"]) == {
         "organization_id": organization.pk,
         "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
     }
 
 
@@ -150,6 +167,7 @@ def test_slack_renderer_attach_button(make_organization, make_alert_receive_chan
     assert json.loads(button["value"]) == {
         "organization_id": organization.pk,
         "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
     }
 
 
@@ -186,7 +204,11 @@ def test_slack_renderer_format_alert_button(
 
     button = elements[5]
     assert button["text"]["text"] == ":mag: Format Alert"
-    assert json.loads(button["value"]) == {"organization_id": organization.pk, "alert_group_pk": alert_group.pk}
+    assert json.loads(button["value"]) == {
+        "organization_id": organization.pk,
+        "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
+    }
 
 
 @pytest.mark.django_db
@@ -205,5 +227,6 @@ def test_slack_renderer_resolution_notes_button(
     assert json.loads(button["value"]) == {
         "organization_id": organization.pk,
         "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
         "resolution_note_window_action": "edit",
     }

--- a/engine/apps/slack/tests/test_slack_renderer.py
+++ b/engine/apps/slack/tests/test_slack_renderer.py
@@ -112,6 +112,7 @@ def test_slack_renderer_stop_invite_button(
     assert json.loads(action["value"]) == {
         "organization_id": organization.pk,
         "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
         "invitation_id": invitation.pk,
     }
 
@@ -188,6 +189,7 @@ def test_slack_renderer_unattach_button(make_organization, make_alert_receive_ch
     assert json.loads(action["value"]) == {
         "organization_id": organization.pk,
         "alert_group_pk": alert_group.pk,
+        "alert_group_ppk": alert_group.public_primary_key,
     }
 
 

--- a/engine/apps/slack/tests/test_slack_renderer.py
+++ b/engine/apps/slack/tests/test_slack_renderer.py
@@ -131,7 +131,12 @@ def test_slack_renderer_silence_button(make_organization, make_alert_receive_cha
 
     values = [json.loads(option["value"]) for option in button["options"]]
     assert values == [
-        {"organization_id": organization.pk, "alert_group_pk": alert_group.pk, "delay": delay}
+        {
+            "organization_id": organization.pk,
+            "alert_group_pk": alert_group.pk,
+            "alert_group_ppk": alert_group.public_primary_key,
+            "delay": delay,
+        }
         for delay, _ in AlertGroup.SILENCE_DELAY_OPTIONS
     ]
 


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2217

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
