### PR TITLE
[Docs] add details inbound email integration setup

### DIFF
--- a/docs/sources/integrations/inbound-email/index.md
+++ b/docs/sources/integrations/inbound-email/index.md
@@ -16,6 +16,10 @@ weight: 500
 
 Inbound Email integration will consume emails from dedicated email address and make alert groups from them.
 
+## Configure required environment variables
+
+See [Inbound Email Setup]({{< relref "../../open-source/_index.md#inbound-email-setup" >}}) for details.
+
 ## Configure Inbound Email integration for Grafana OnCall
 
 You must have an Admin role to create integrations in Grafana OnCall.

--- a/docs/sources/open-source/_index.md
+++ b/docs/sources/open-source/_index.md
@@ -262,7 +262,7 @@ To configure Inbound Email integration for Grafana OnCall OSS populate env varia
 
 - `INBOUND_EMAIL_ESP` - Inbound email ESP name. Available options: `amazon_ses`, `mailgun`, `mailjet`, `mandrill`, `postal`, `postmark`, `sendgrid`, `sparkpost`
 - `INBOUND_EMAIL_DOMAIN` - Inbound email domain
-- `INBOUND_EMAIL_WEBHOOK_SECRET` - Inbound email webhook secret.
+- `INBOUND_EMAIL_WEBHOOK_SECRET` - Inbound email webhook secret
 
 Required secret syntax: `part1ofsecret:part2ofsecret` (The colon `:` is a mandatory delimiter separating both parts of your secret.)
 

--- a/docs/sources/open-source/_index.md
+++ b/docs/sources/open-source/_index.md
@@ -262,9 +262,11 @@ To configure Inbound Email integration for Grafana OnCall OSS populate env varia
 
 - `INBOUND_EMAIL_ESP` - Inbound email ESP name. Available options: `amazon_ses`, `mailgun`, `mailjet`, `mandrill`, `postal`, `postmark`, `sendgrid`, `sparkpost`
 - `INBOUND_EMAIL_DOMAIN` - Inbound email domain
-- `INBOUND_EMAIL_WEBHOOK_SECRET` - Inbound email webhook secret
+- `INBOUND_EMAIL_WEBHOOK_SECRET` - Inbound email webhook secret.
 
-You will also need to configure your ESP to forward messages to the following URL: `<ONCALL_ENGINE_PUBLIC_URL>/integrations/v1/inbound_email_webhook`.
+Required secret syntax: `part1ofsecret:part2ofsecret` (The colon `:` is a mandatory delimiter separating both parts of your secret.)
+
+You will also need to configure your ESP to forward messages to the following URL: `scheme://<INBOUND_EMAIL_WEBHOOK_SECRET>@<ONCALL_ENGINE_PUBLIC_URL>/integrations/v1/inbound_email_webhook`.
 
 ## Limits
 


### PR DESCRIPTION
# What this PR does

This PR adds some more depth to the documentation regarding the setup of the "Inbound Email" integration.
In particular it references the setup requirement in the integration documentation and also outlines the requirements for the secret syntax and usage in the process.

## Which issue(s) this PR fixes

https://github.com/grafana/oncall/issues/3015

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
