### PR TITLE
fix RBAC authz issue for Slack Alert Group actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Data type changed from `DateField` to `DateTimeField` on the `final_shifts` API endpoint. Endpoint now accepts either
-a date or a datetime ([#3103](https://github.com/grafana/oncall/pull/3103))
+  a date or a datetime ([#3103](https://github.com/grafana/oncall/pull/3103))
 
 ### Changed
 
 - Simplify Direct Paging workflow. Now when using Direct Paging you either simply specify a team, or one or more users
   to page by @joeyorlando ([#3128](https://github.com/grafana/oncall/pull/3128))
+
+### Fixed
+
+- Fix RBAC authorization bugs related to interacting with Alert Group Slack messages by @joeyorlando ([#3213](https://github.com/grafana/oncall/pull/3213))
 
 ## v1.3.47 (2023-10-25)
 

--- a/engine/apps/slack/scenarios/distribute_alerts.py
+++ b/engine/apps/slack/scenarios/distribute_alerts.py
@@ -230,7 +230,7 @@ class InviteOtherPersonToIncident(AlertGroupActionsMixin, scenario_step.Scenario
     Check out apps/slack/scenarios/manage_responders.py for the new version that uses direct paging.
     """
 
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -266,7 +266,7 @@ class InviteOtherPersonToIncident(AlertGroupActionsMixin, scenario_step.Scenario
 
 
 class SilenceGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -293,7 +293,7 @@ class SilenceGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class UnSilenceGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -313,7 +313,7 @@ class UnSilenceGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class SelectAttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -509,7 +509,7 @@ class AttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class UnAttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -534,7 +534,7 @@ class StopInvitationProcess(AlertGroupActionsMixin, scenario_step.ScenarioStep):
     Check out apps/slack/scenarios/manage_responders.py for the new version that uses direct paging.
     """
 
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -561,7 +561,7 @@ class StopInvitationProcess(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class CustomButtonProcessStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -624,7 +624,7 @@ class CustomButtonProcessStep(AlertGroupActionsMixin, scenario_step.ScenarioStep
 
 
 class ResolveGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -665,7 +665,7 @@ class ResolveGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class UnResolveGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -685,7 +685,7 @@ class UnResolveGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class AcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,
@@ -705,7 +705,7 @@ class AcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
 
 class UnAcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
-    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.CHATOPS_WRITE]
+    REQUIRED_PERMISSIONS = [RBACPermission.Permissions.ALERT_GROUPS_WRITE]
 
     def process_scenario(
         self,


### PR DESCRIPTION
Was able to reproduce locally with OnCall RBAC enabled and as a user with Viewer role:
<img width="701" alt="Screenshot 2023-10-30 at 09 30 52" src="https://github.com/grafana/oncall/assets/9406895/0050c2b1-2765-4aba-a73e-985f364691ad">

Fixed with the changes introduced in this PR:
<img width="963" alt="Screenshot 2023-10-30 at 09 30 16" src="https://github.com/grafana/oncall/assets/9406895/02b62f39-01e5-4a13-baaf-db30181eb16a">
<img width="967" alt="Screenshot 2023-10-30 at 09 30 11" src="https://github.com/grafana/oncall/assets/9406895/c606f6db-8e99-4df4-a3e9-5c9da8feb051">



## Which issue(s) this PR fixes

Closes #3212 

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
