### PR TITLE
remove is_restricted from frontend codebase

### DIFF
--- a/grafana-plugin/src/models/alertgroup/alertgroup.types.ts
+++ b/grafana-plugin/src/models/alertgroup/alertgroup.types.ts
@@ -55,7 +55,6 @@ export interface Alert {
   acknowledged_at: string;
   acknowledged_by_user: User;
   acknowledged_on_source: boolean;
-  is_restricted: boolean;
   channel: Channel;
   slack_permalink?: string;
   permalinks: {

--- a/grafana-plugin/src/pages/incident/Incident.helpers.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.helpers.tsx
@@ -153,7 +153,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const resolveButton = (
     <WithPermissionControlTooltip key="resolve" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading || incident.is_restricted} onClick={onResolve} variant="primary">
+      <Button disabled={incident.loading} onClick={onResolve} variant="primary">
         Resolve
       </Button>
     </WithPermissionControlTooltip>
@@ -161,7 +161,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const unacknowledgeButton = (
     <WithPermissionControlTooltip key="unacknowledge" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading || incident.is_restricted} onClick={onUnacknowledge} variant="secondary">
+      <Button disabled={incident.loading} onClick={onUnacknowledge} variant="secondary">
         Unacknowledge
       </Button>
     </WithPermissionControlTooltip>
@@ -169,7 +169,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const unresolveButton = (
     <WithPermissionControlTooltip key="unacknowledge" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading || incident.is_restricted} onClick={onUnresolve} variant="primary">
+      <Button disabled={incident.loading} onClick={onUnresolve} variant="primary">
         Unresolve
       </Button>
     </WithPermissionControlTooltip>
@@ -177,7 +177,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const acknowledgeButton = (
     <WithPermissionControlTooltip key="acknowledge" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading || incident.is_restricted} onClick={onAcknowledge} variant="secondary">
+      <Button disabled={incident.loading} onClick={onAcknowledge} variant="secondary">
         Acknowledge
       </Button>
     </WithPermissionControlTooltip>
@@ -188,7 +188,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
   if (incident.status === IncidentStatus.Silenced) {
     buttons.push(
       <WithPermissionControlTooltip key="silence" userAction={UserActions.AlertGroupsWrite}>
-        <Button disabled={incident.loading || incident.is_restricted} variant="secondary" onClick={onUnsilence}>
+        <Button disabled={incident.loading} variant="secondary" onClick={onUnsilence}>
           Unsilence
         </Button>
       </WithPermissionControlTooltip>
@@ -198,7 +198,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
       <SilenceButtonCascader
         className={cx('silence-button-inline')}
         key="silence"
-        disabled={incident.loading || incident.is_restricted}
+        disabled={incident.loading}
         onSelect={onSilence}
       />
     );

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -171,7 +171,6 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                     <Incident incident={incident} datetimeReference={this.getIncidentDatetimeReference(incident)} />
                     <GroupedIncidentsList
                       id={incident.pk}
-                      disabled={incident.is_restricted}
                       getIncidentDatetimeReference={this.getIncidentDatetimeReference}
                     />
                     <AttachedIncidentsList id={incident.pk} getUnattachClickHandler={this.getUnattachClickHandler} />
@@ -289,12 +288,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                       {incident.root_alert_group.render_for_web.title}
                     </PluginLink>{' '}
                     <WithPermissionControlTooltip userAction={UserActions.AlertGroupsWrite}>
-                      <Button
-                        variant="secondary"
-                        onClick={() => this.getUnattachClickHandler(incident.pk)}
-                        size="sm"
-                        disabled={incident.is_restricted}
-                      >
+                      <Button variant="secondary" onClick={() => this.getUnattachClickHandler(incident.pk)} size="sm">
                         Unattach
                       </Button>
                     </WithPermissionControlTooltip>
@@ -310,16 +304,10 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                     onClick={this.showAttachIncidentForm}
                     tooltip="Attach to another Alert Group"
                     className={cx('title-icon')}
-                    disabled={incident.is_restricted}
                   />
                 )}
                 <a href={incident.slack_permalink} target="_blank" rel="noreferrer">
-                  <IconButton
-                    name="slack"
-                    tooltip="View in Slack"
-                    className={cx('title-icon')}
-                    disabled={incident.is_restricted}
-                  />
+                  <IconButton name="slack" tooltip="View in Slack" className={cx('title-icon')} />
                 </a>
                 <CopyToClipboard
                   text={window.location.href}
@@ -327,12 +315,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                     openNotification('Link copied');
                   }}
                 >
-                  <IconButton
-                    name="copy"
-                    tooltip="Copy link"
-                    className={cx('title-icon')}
-                    disabled={incident.is_restricted}
-                  />
+                  <IconButton name="copy" tooltip="Copy link" className={cx('title-icon')} />
                 </CopyToClipboard>
               </Text>
             </HorizontalGroup>
@@ -358,7 +341,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                     query={{ page: 'integrations', id: incident.alert_receive_channel.id }}
                   >
                     <Button
-                      disabled={incident.alert_receive_channel.deleted || incident.is_restricted}
+                      disabled={incident.alert_receive_channel.deleted}
                       variant="secondary"
                       fill="outline"
                       size="sm"
@@ -395,7 +378,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                         variant="secondary"
                         fill="outline"
                         size="sm"
-                        disabled={incident.render_for_web.source_link === null || incident.is_restricted}
+                        disabled={incident.render_for_web.source_link === null}
                         className={cx('label-button')}
                         icon="external-link-alt"
                       >
@@ -419,7 +402,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
               })}
               <PluginBridge plugin={SupportedPlugin.Incident}>
                 <a href={incident.declare_incident_link} target="_blank" rel="noreferrer">
-                  <Button variant="secondary" size="md" icon="fire" disabled={incident.is_restricted}>
+                  <Button variant="secondary" size="md" icon="fire">
                     Declare incident
                   </Button>
                 </a>
@@ -427,7 +410,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
             </HorizontalGroup>
 
             <Button
-              disabled={incident.alert_receive_channel.deleted || incident.is_restricted}
+              disabled={incident.alert_receive_channel.deleted}
               variant="secondary"
               icon="edit"
               onClick={this.showIntegrationSettings}
@@ -532,7 +515,6 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
         >
           <TextArea
             value={resolutionNoteText}
-            disabled={incident.is_restricted}
             onChange={(e: any) => this.setState({ resolutionNoteText: e.target.value })}
           />
         </Field>
@@ -541,7 +523,7 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
             icon="plus"
             variant="primary"
             onClick={this.handleCreateResolutionNote}
-            disabled={isResolutionNoteTextEmpty || incident.is_restricted}
+            disabled={isResolutionNoteTextEmpty}
           >
             Add resolution note
           </ToolbarButton>
@@ -663,10 +645,8 @@ function Incident({ incident }: { incident: Alert; datetimeReference: string }) 
 function GroupedIncidentsList({
   id,
   getIncidentDatetimeReference,
-  disabled,
 }: {
   id: string;
-  disabled: boolean;
   getIncidentDatetimeReference: (incident: GroupedAlert) => string;
 }) {
   const store = useStore();
@@ -695,26 +675,13 @@ function GroupedIncidentsList({
       contentClassName={cx('incidents-content')}
     >
       {alerts.map((alert) => (
-        <GroupedIncident
-          key={alert.id}
-          incident={alert}
-          disabled={disabled}
-          datetimeReference={getIncidentDatetimeReference(alert)}
-        />
+        <GroupedIncident key={alert.id} incident={alert} datetimeReference={getIncidentDatetimeReference(alert)} />
       ))}
     </Collapse>
   );
 }
 
-function GroupedIncident({
-  incident,
-  datetimeReference,
-  disabled,
-}: {
-  incident: GroupedAlert;
-  datetimeReference: string;
-  disabled: boolean;
-}) {
+function GroupedIncident({ incident, datetimeReference }: { incident: GroupedAlert; datetimeReference: string }) {
   const store = useStore();
   const [incidentRawResponse, setIncidentRawResponse] = useState<{ id: string; raw_request_data: any }>(undefined);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -762,7 +729,7 @@ function GroupedIncident({
           <div className={cx('incident-row-right')}>
             <HorizontalGroup wrap={false} justify={'flex-end'}>
               <Tooltip placement="top" content="Alert Payload">
-                <IconButton name="arrow" onClick={() => openIncidentResponse(incident)} disabled={disabled} />
+                <IconButton name="arrow" onClick={() => openIncidentResponse(incident)} />
               </Tooltip>
             </HorizontalGroup>
           </div>
@@ -818,12 +785,7 @@ function AttachedIncidentsList({
               #{incident.inside_organization_number} {incident.render_for_web.title}
             </PluginLink>
             <WithPermissionControlTooltip userAction={UserActions.AlertGroupsWrite}>
-              <Button
-                size="sm"
-                onClick={() => getUnattachClickHandler(incident.pk)}
-                variant="secondary"
-                disabled={incident.is_restricted}
-              >
+              <Button size="sm" onClick={() => getUnattachClickHandler(incident.pk)} variant="secondary">
                 Unattach
               </Button>
             </WithPermissionControlTooltip>


### PR DESCRIPTION
# What this PR does

The concept of `AlertGroup.is_restricted` is deprecated and no longer used. In a future release I will remove all references to `is_restricted` from the backend (doing it in separate releases to avoid any potential issues where the frontend still references it shortly after release of it being removed from the API response)

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
