### PR TITLE
few add responders patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## v1.3.48 (2023-10-30)
+
 ### Added
 
 - Data type changed from `DateField` to `DateTimeField` on the `final_shifts` API endpoint. Endpoint now accepts either

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve slow `GET /users` + `GET /teams` internal API endpoints by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
 - Fix search issue when searching for teams in the add responders popup window by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
 - CSS changes to add responders dropdown to fix long search results list by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
-
-### Fixed
-
 - Do not allow to update terraform-based shifts in web UI schedule API ([#3224](https://github.com/grafana/oncall/pull/3224))
 
 ## v1.3.48 (2023-10-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Order results from `GET /teams` internal API endpoint by ascending name by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
+
+### Fixed
+
+- Improve slow `GET /users` + `GET /teams` internal API endpoints by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
+- Fix search issue when searching for teams in the add responders popup window by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
+- CSS changes to add responders dropdown to fix long search results list by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
+
 ## v1.3.48 (2023-10-30)
 
 ### Added

--- a/engine/apps/api/serializers/team.py
+++ b/engine/apps/api/serializers/team.py
@@ -19,27 +19,35 @@ class FastTeamSerializer(serializers.ModelSerializer):
 
 
 class TeamSerializer(serializers.ModelSerializer):
-    context: TeamSerializerContext
-
     id = serializers.CharField(read_only=True, source="public_primary_key")
-    number_of_users_currently_oncall = serializers.SerializerMethodField()
 
     class Meta:
         model = Team
-        fields = (
+        fields = [
             "id",
             "name",
             "email",
             "avatar_url",
             "is_sharing_resources_to_all",
             "number_of_users_currently_oncall",
-        )
+        ]
 
         read_only_fields = [
             "id",
             "name",
             "email",
             "avatar_url",
+        ]
+
+
+class TeamLongSerializer(TeamSerializer):
+    context: TeamSerializerContext
+
+    number_of_users_currently_oncall = serializers.SerializerMethodField()
+
+    class Meta(TeamSerializer.Meta):
+        fields = TeamSerializer.Meta.fields + [
+            "number_of_users_currently_oncall",
         ]
 
     def get_number_of_users_currently_oncall(self, obj: Team) -> int:

--- a/engine/apps/api/serializers/team.py
+++ b/engine/apps/api/serializers/team.py
@@ -29,7 +29,6 @@ class TeamSerializer(serializers.ModelSerializer):
             "email",
             "avatar_url",
             "is_sharing_resources_to_all",
-            "number_of_users_currently_oncall",
         ]
 
         read_only_fields = [

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -14,7 +14,7 @@ from apps.user_management.models import Team
 GENERAL_TEAM = Team(public_primary_key="null", name="No team", email=None, avatar_url=None)
 
 
-def get_payload_from_team(team, short=True):
+def get_payload_from_team(team, long=False):
     payload = {
         "id": team.public_primary_key,
         "name": team.name,
@@ -23,7 +23,7 @@ def get_payload_from_team(team, short=True):
         "is_sharing_resources_to_all": team.is_sharing_resources_to_all,
     }
 
-    if short:
+    if long:
         payload.update({"number_of_users_currently_oncall": 0})
     return payload
 
@@ -46,9 +46,9 @@ def test_list_teams(
     auth_headers = make_user_auth_headers(user, token)
 
     general_team_payload = get_payload_from_team(GENERAL_TEAM)
-    general_team_long_payload = get_payload_from_team(GENERAL_TEAM, short=False)
+    general_team_long_payload = get_payload_from_team(GENERAL_TEAM, long=True)
     team_payload = get_payload_from_team(team)
-    team_long_payload = get_payload_from_team(team, short=False)
+    team_long_payload = get_payload_from_team(team, long=True)
 
     client = APIClient()
     url = reverse("api-internal:team-list")
@@ -163,7 +163,7 @@ def test_teams_number_of_users_currently_oncall_attribute_works_properly(
     _make_schedule(team=team3, oncall_users=[])
 
     client = APIClient()
-    url = reverse("api-internal:team-list")
+    url = f"{reverse('api-internal:team-list')}?short=false"
 
     response = client.get(url, format="json", **make_user_auth_headers(user1, token))
 

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -240,18 +240,18 @@ class UserView(
     def _is_currently_oncall_request(self) -> bool:
         return self._get_is_currently_oncall_query_param() in ["true", "false"]
 
-    def _is_short_oncall_request(self) -> bool:
+    def _is_long_request(self) -> bool:
         return self.request.query_params.get("short", "true").lower() == "false"
 
-    def _is_currently_oncall_or_short_request(self) -> bool:
-        return self._is_currently_oncall_request() or self._is_short_oncall_request()
+    def _is_currently_oncall_or_long_request(self) -> bool:
+        return self._is_currently_oncall_request() or self._is_long_request()
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
         context.update(
             {
                 "schedules_with_oncall_users": self.schedules_with_oncall_users
-                if self._is_currently_oncall_or_short_request()
+                if self._is_currently_oncall_or_long_request()
                 else {}
             }
         )
@@ -268,7 +268,7 @@ class UserView(
 
         if is_list_request and is_filters_request:
             return self.get_filter_serializer_class()
-        elif is_list_request and self._is_currently_oncall_or_short_request():
+        elif is_list_request and self._is_currently_oncall_or_long_request():
             return UserLongSerializer
 
         is_users_own_data = kwargs.get("pk") is not None and kwargs.get("pk") == user.public_primary_key

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -234,9 +234,27 @@ class UserView(
         """
         return get_oncall_users_for_multiple_schedules(self.request.user.organization.oncall_schedules.all())
 
+    def _get_is_currently_oncall_query_param(self) -> str:
+        return self.request.query_params.get("is_currently_oncall", "").lower()
+
+    def _is_currently_oncall_request(self) -> bool:
+        return self._get_is_currently_oncall_query_param() in ["true", "false"]
+
+    def _is_short_oncall_request(self) -> bool:
+        return self.request.query_params.get("short", "true").lower() == "false"
+
+    def _is_currently_oncall_or_short_request(self) -> bool:
+        return self._is_currently_oncall_request() or self._is_short_oncall_request()
+
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        context.update({"schedules_with_oncall_users": self.schedules_with_oncall_users})
+        context.update(
+            {
+                "schedules_with_oncall_users": self.schedules_with_oncall_users
+                if self._is_currently_oncall_or_short_request()
+                else {}
+            }
+        )
         return context
 
     def get_serializer_class(self):
@@ -247,12 +265,10 @@ class UserView(
 
         is_list_request = self.action in ["list"]
         is_filters_request = query_params.get("filters", "false") == "true"
-        is_short_request = query_params.get("short", "true") == "false"
-        is_currently_oncall_request = query_params.get("is_currently_oncall", "").lower() in ["true", "false"]
 
         if is_list_request and is_filters_request:
             return self.get_filter_serializer_class()
-        elif is_list_request and (is_short_request or is_currently_oncall_request):
+        elif is_list_request and self._is_currently_oncall_or_short_request():
             return UserLongSerializer
 
         is_users_own_data = kwargs.get("pk") is not None and kwargs.get("pk") == user.public_primary_key
@@ -277,11 +293,10 @@ class UserView(
     def list(self, request, *args, **kwargs) -> Response:
         queryset = self.filter_queryset(self.get_queryset())
 
-        is_currently_oncall_query_param = request.query_params.get("is_currently_oncall", "").lower()
-
         def _get_oncall_user_ids():
             return {user.pk for _, users in self.schedules_with_oncall_users.items() for user in users}
 
+        is_currently_oncall_query_param = self._get_is_currently_oncall_query_param()
         if is_currently_oncall_query_param == "true":
             # client explicitly wants to filter out users that are on-call
             queryset = queryset.filter(pk__in=_get_oncall_user_ids())

--- a/grafana-plugin/src/containers/AddResponders/parts/AddRespondersPopup/AddRespondersPopup.module.scss
+++ b/grafana-plugin/src/containers/AddResponders/parts/AddRespondersPopup/AddRespondersPopup.module.scss
@@ -31,6 +31,7 @@
 }
 
 .table {
+  max-height: 150px;
   overflow: auto;
   padding: 4px 0px;
 

--- a/grafana-plugin/src/containers/AddResponders/parts/AddRespondersPopup/AddRespondersPopup.tsx
+++ b/grafana-plugin/src/containers/AddResponders/parts/AddRespondersPopup/AddRespondersPopup.tsx
@@ -115,7 +115,7 @@ const AddRespondersPopup = observer(
 
     const handleSearchTermChange = useDebouncedCallback(() => {
       if (isCreateMode && activeOption === TabOptions.Teams) {
-        grafanaTeamStore.updateItems(searchTerm, false, true);
+        grafanaTeamStore.updateItems(searchTerm, false, true, false);
       } else {
         userStore.updateItems({ searchTerm, short: 'false' });
       }

--- a/grafana-plugin/src/models/grafana_team/grafana_team.ts
+++ b/grafana-plugin/src/models/grafana_team/grafana_team.ts
@@ -5,12 +5,14 @@ import { GrafanaTeam } from 'models/grafana_team/grafana_team.types';
 import { makeRequest } from 'network';
 import { RootStore } from 'state';
 
+type TeamItems = { [id: string]: GrafanaTeam };
+
 export class GrafanaTeamStore extends BaseStore {
   @observable
-  searchResult: { [key: string]: Array<GrafanaTeam['id']> } = {};
+  searchResult: Array<GrafanaTeam['id']> = [];
 
   @observable.shallow
-  items: { [id: string]: GrafanaTeam } = {};
+  items: TeamItems = {};
 
   constructor(rootStore: RootStore) {
     super(rootStore);
@@ -29,10 +31,11 @@ export class GrafanaTeamStore extends BaseStore {
   }
 
   @action
-  async updateItems(query = '', includeNoTeam = true, onlyIncludeNotifiableTeams = false) {
-    const result = await makeRequest(`${this.path}`, {
+  async updateItems(query = '', includeNoTeam = true, onlyIncludeNotifiableTeams = false, short = true) {
+    const result = await makeRequest<GrafanaTeam[]>(`${this.path}`, {
       params: {
         search: query,
+        short: short ? 'true' : 'false',
         include_no_team: includeNoTeam ? 'true' : 'false',
         only_include_notifiable_teams: onlyIncludeNotifiableTeams ? 'true' : 'false',
       },
@@ -40,8 +43,8 @@ export class GrafanaTeamStore extends BaseStore {
 
     this.items = {
       ...this.items,
-      ...result.reduce(
-        (acc: { [key: number]: GrafanaTeam }, item: GrafanaTeam) => ({
+      ...result.reduce<TeamItems>(
+        (acc, item) => ({
           ...acc,
           [item.id]: item,
         }),
@@ -49,17 +52,11 @@ export class GrafanaTeamStore extends BaseStore {
       ),
     };
 
-    this.searchResult = {
-      ...this.searchResult,
-      [query]: result.map((item: GrafanaTeam) => item.id),
-    };
+    this.searchResult = result.map((item: GrafanaTeam) => item.id);
   }
 
-  getSearchResult(query = '') {
-    if (!this.searchResult[query]) {
-      return [];
-    }
-
-    return this.searchResult[query].map((teamId: GrafanaTeam['id']) => this.items[teamId]);
+  getSearchResult() {
+    console.log('yoooo');
+    return this.searchResult.map((teamId: GrafanaTeam['id']) => this.items[teamId]);
   }
 }

--- a/grafana-plugin/src/models/grafana_team/grafana_team.ts
+++ b/grafana-plugin/src/models/grafana_team/grafana_team.ts
@@ -56,7 +56,6 @@ export class GrafanaTeamStore extends BaseStore {
   }
 
   getSearchResult() {
-    console.log('yoooo');
     return this.searchResult.map((teamId: GrafanaTeam['id']) => this.items[teamId]);
   }
 }

--- a/grafana-plugin/src/models/grafana_team/grafana_team.types.ts
+++ b/grafana-plugin/src/models/grafana_team/grafana_team.types.ts
@@ -4,5 +4,5 @@ export interface GrafanaTeam {
   email: string;
   avatar_url: string;
   is_sharing_resources_to_all: boolean;
-  number_of_users_currently_oncall: number;
+  number_of_users_currently_oncall?: number;
 }

--- a/grafana-plugin/src/models/user/user.types.ts
+++ b/grafana-plugin/src/models/user/user.types.ts
@@ -43,6 +43,6 @@ export interface User {
   hidden_fields?: boolean;
   timezone: Timezone;
   working_hours: { [key: string]: [] };
-  is_currently_oncall: boolean;
-  teams: GrafanaTeam[];
+  is_currently_oncall?: boolean;
+  teams?: GrafanaTeam[];
 }


### PR DESCRIPTION
# Which issue(s) this PR fixes

Closes https://github.com/grafana/support-escalations/issues/8143

Fix a few minor issues introduced in #3128:

- Fix slow `GET /users` internal API endpoint related to [this change](https://github.com/grafana/oncall/blob/dev/engine/apps/api/views/user.py#L239)
- Fix slow `GET /teams` internal API endpoint. Introduced a `short` query parameter that only invokes `apps.schedules.ical_utils.get_oncall_users_for_multiple_schedules` when `short=false`.
- Order results from `GET /teams` internal API endpoint by name (ascending)
- Fix search issue when searching for teams in the add responders popup window (this was strictly a frontend issue)
- CSS changes to add responders dropdown to fix lonnnggg results list:
  **Before**
  <img width="377" alt="Screenshot 2023-10-31 at 10 06 20" src="https://github.com/grafana/oncall/assets/9406895/246c7c3b-7bea-44a1-afec-a38144c2c2d1">
  **After**
  <img width="444" alt="Screenshot 2023-10-31 at 10 48 12" src="https://github.com/grafana/oncall/assets/9406895/b5602a22-c691-4dc7-bd3d-e4d6b76d04a0">



## Still todo

The `apps.schedules.ical_utils.get_oncall_users_for_multiple_schedules` method is still very slow when an instance has a lot of users (ex. `ops`). Ideally we should refactor this method to be more efficient because we still need to call this method under some circumstances. Ex. to populate this dropdown when Direct Paging a user (note that it didn't finish loading here on `ops`):
<img width="1037" alt="Screenshot 2023-10-30 at 18 14 59" src="https://github.com/grafana/oncall/assets/9406895/9d91a57c-5db8-4ff9-862a-cd3755f52690">



## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
