### PR TITLE
Disable updates for API/terraform shifts in internal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent additional polling on Incidents if the previous request didn't complete
   ([#3205](https://github.com/grafana/oncall/pull/3205))
 
+### Fixed
+
+- Do not allow to update terraform-based shifts in web UI schedule API ([#3224](https://github.com/grafana/oncall/pull/3224))
+
 ## v1.3.48 (2023-10-30)
 
 ### Added

--- a/engine/apps/api/serializers/on_call_shifts.py
+++ b/engine/apps/api/serializers/on_call_shifts.py
@@ -228,6 +228,9 @@ class OnCallShiftUpdateSerializer(OnCallShiftSerializer):
         read_only_fields = ["schedule", "type"]
 
     def update(self, instance, validated_data):
+        if not instance.schedule:
+            # only web-based schedule events can be updated using UI
+            raise serializers.ValidationError(["This event cannot be updated"])
         validated_data = self._correct_validated_data(instance.type, validated_data)
         change_only_name = True
         create_or_update_last_shift = False


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2246