### PR TITLE
Order alert groups by -started_at in internal API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent additional polling on Incidents if the previous request didn't complete
   ([#3205](https://github.com/grafana/oncall/pull/3205))
 - Order results from `GET /teams` internal API endpoint by ascending name by @joeyorlando ([#3220](https://github.com/grafana/oncall/pull/3220))
+- Order alert groups internal API endpoint by descending started_at by @mderynck ([#3240](https://github.com/grafana/oncall/pull/3240))
 
 ### Fixed
 

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -200,7 +200,7 @@ class AlertGroupFilter(DateRangeFilterMixin, ByTeamModelFieldFilterMixin, ModelF
         # so we limit the number of alert groups to filter by the last 1000 for the given user(s)
         alert_group_notified_users_ids = list(
             UserNotificationPolicyLogRecord.objects.filter(author__in=users)
-            .order_by("-started_at")
+            .order_by("-alert_group_id")
             .values_list("alert_group_id", flat=True)
             .distinct()[: self.FILTER_BY_INVOLVED_USERS_ALERT_GROUPS_CUTOFF]
         )

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -200,7 +200,7 @@ class AlertGroupFilter(DateRangeFilterMixin, ByTeamModelFieldFilterMixin, ModelF
         # so we limit the number of alert groups to filter by the last 1000 for the given user(s)
         alert_group_notified_users_ids = list(
             UserNotificationPolicyLogRecord.objects.filter(author__in=users)
-            .order_by("-alert_group_id")
+            .order_by("-started_at")
             .values_list("alert_group_id", flat=True)
             .distinct()[: self.FILTER_BY_INVOLVED_USERS_ALERT_GROUPS_CUTOFF]
         )
@@ -423,7 +423,7 @@ class AlertGroupView(
 
         # enrich alert groups with select_related and prefetch_related
         alert_group_pks = [alert_group.pk for alert_group in alert_groups]
-        queryset = AlertGroup.objects.filter(pk__in=alert_group_pks).order_by("-pk")
+        queryset = AlertGroup.objects.filter(pk__in=alert_group_pks).order_by("-started_at")
 
         queryset = self.get_serializer_class().setup_eager_loading(queryset)
         alert_groups = list(queryset)


### PR DESCRIPTION
# What this PR does
Order alert groups in API by -started_at instead of -pk.  This should result in no visible change for most installations.  In the case where alert groups are being moved/restored between installations this allows for the display order to be as expected without relying on insertion order.

Note: Public API is already using -started_at instead of pk and it is already indexed.

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
