### PR TITLE
Update wording for mobile push notifications timing choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Change wording for push notifications timing choices @Ferril ([#3253](https://github.com/grafana/oncall/pull/3253))
+
 ## v1.3.51 (2023-11-02)
 
 ### Fixed

--- a/engine/apps/mobile_app/models.py
+++ b/engine/apps/mobile_app/models.py
@@ -171,11 +171,11 @@ class MobileAppUserSettings(models.Model):
     ONE_DAY_IN_SECONDS = TWELVE_HOURS_IN_SECONDS * 2
 
     NOTIFICATION_TIMING_CHOICES = (
-        (FIFTEEN_MINUTES_IN_SECONDS, "fifteen minutes before"),
-        (ONE_HOUR_IN_SECONDS, "one hour before"),
-        (SIX_HOURS_IN_SECONDS, "six hours before"),
-        (TWELVE_HOURS_IN_SECONDS, "twelve hours before"),
-        (ONE_DAY_IN_SECONDS, "one day before"),
+        (FIFTEEN_MINUTES_IN_SECONDS, "15 minutes before"),
+        (ONE_HOUR_IN_SECONDS, "1 hour before"),
+        (SIX_HOURS_IN_SECONDS, "6 hours before"),
+        (TWELVE_HOURS_IN_SECONDS, "12 hours before"),
+        (ONE_DAY_IN_SECONDS, "1 day before"),
     )
     going_oncall_notification_timing = JSONField(default=default_notification_timing_options)
 


### PR DESCRIPTION
# What this PR does
Update wording for mobile push notifications timing choices

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
