### PR TITLE
Add missing referenced local_image.yml for local helm setup

### DIFF
--- a/helm/local_image.yml
+++ b/helm/local_image.yml
@@ -1,0 +1,6 @@
+image:
+  repository: oncall/engine
+  tag: latest
+  pullPolicy: IfNotPresent
+oncall:
+  devMode: true


### PR DESCRIPTION
Forgot to add the `local_image.yml` file referenced [here](https://github.com/grafana/oncall/pull/3204/files#diff-ba66b531f5db27e2cb364be1b4cda073681f7447f088ac98139ca96c1609dc16R30).