### PR TITLE
Check if organization was deleted for heartbeat integration

### DIFF
--- a/engine/apps/heartbeat/tasks.py
+++ b/engine/apps/heartbeat/tasks.py
@@ -45,8 +45,14 @@ def check_heartbeats() -> str:
         # * is enabled,
         # * is not already expired,
         # * last check in was before the timeout period start
-        expired_heartbeats = enabled_heartbeats.select_for_update().filter(
-            last_heartbeat_time__lte=F("period_start"), previous_alerted_state_was_life=True
+        expired_heartbeats = (
+            enabled_heartbeats.select_for_update()
+            .filter(
+                last_heartbeat_time__lte=F("period_start"),
+                previous_alerted_state_was_life=True,
+                alert_receive_channel__organization__deleted_at__isnull=True,
+            )
+            .select_related("alert_receive_channel")
         )
         # Schedule alert creation for each expired heartbeat after transaction commit
         for heartbeat in expired_heartbeats:

--- a/engine/apps/heartbeat/tests/test_integration_heartbeat.py
+++ b/engine/apps/heartbeat/tests/test_integration_heartbeat.py
@@ -25,10 +25,10 @@ def test_check_heartbeats(
     assert mock_create_alert_apply_async.call_count == 0
 
     # Prepare heartbeat
-    team, _ = make_organization_and_user()
+    organization, _ = make_organization_and_user()
     timeout = 60
     last_heartbeat_time = timezone.now()
-    alert_receive_channel = make_alert_receive_channel(team, integration=integration)
+    alert_receive_channel = make_alert_receive_channel(organization, integration=integration)
     integration_heartbeat = make_integration_heartbeat(
         alert_receive_channel, timeout, last_heartbeat_time=last_heartbeat_time, previous_alerted_state_was_life=True
     )
@@ -73,6 +73,17 @@ def test_check_heartbeats(
     integration_heartbeat.last_heartbeat_time = timezone.now()
     integration_heartbeat.save()
     integration_heartbeat.refresh_from_db()
+    with patch.object(create_alert, "apply_async") as mock_create_alert_apply_async:
+        with django_capture_on_commit_callbacks(execute=True):
+            result = check_heartbeats()
+    assert result == "Found 0 expired and 0 restored heartbeats"
+    assert mock_create_alert_apply_async.call_count == 0
+
+    # Hearbeat expires, but organization was deleted, don't send an alert
+    integration_heartbeat.refresh_from_db()
+    integration_heartbeat.last_heartbeat_time = timezone.now() - timezone.timedelta(seconds=timeout * 10)
+    integration_heartbeat.save()
+    organization.delete()
     with patch.object(create_alert, "apply_async") as mock_create_alert_apply_async:
         with django_capture_on_commit_callbacks(execute=True):
             result = check_heartbeats()


### PR DESCRIPTION
# What this PR does
Exclude deleted organizations before sending heartbeat alerts

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
