### PR TITLE
Use started_at for alert group order in paginator

### DIFF
--- a/engine/common/api_helpers/paginators.py
+++ b/engine/common/api_helpers/paginators.py
@@ -82,4 +82,4 @@ class FifteenPageSizePaginator(PathPrefixedPagePagination):
 
 class TwentyFiveCursorPaginator(PathPrefixedCursorPagination):
     page_size = 25
-    ordering = "-pk"
+    ordering = "-started_at"


### PR DESCRIPTION
# What this PR does
Fix inconsistency in alert group ordering introduced by #3240

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
