### PR TITLE
Fix escalation policy importance going back to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix escalation policy importance going back to default by @vadimkerr ([#3282](https://github.com/grafana/oncall/pull/3282))
+
 ## v1.3.53 (2023-11-03)
 
 ### Fixed

--- a/grafana-plugin/e2e-tests/escalationChains/escalationPolicy.test.ts
+++ b/grafana-plugin/e2e-tests/escalationChains/escalationPolicy.test.ts
@@ -1,0 +1,19 @@
+import {expect, test} from "../fixtures";
+import {generateRandomValue} from "../utils/forms";
+import {createEscalationChain, EscalationStep, selectEscalationStepValue} from "../utils/escalationChain";
+
+test('escalation policy does not go back to "Default" after adding users to notify', async ({ adminRolePage }) => {
+  const { page, userName } = adminRolePage;
+  const escalationChainName = generateRandomValue();
+
+  // create important escalation step
+  await createEscalationChain(page, escalationChainName, EscalationStep.NotifyUsers, null, true);
+  // add user to notify
+  await selectEscalationStepValue(page, EscalationStep.NotifyUsers, userName);
+
+  // reload and check if important is still selected
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+
+  expect(await page.locator('text=Important').isVisible()).toBe(true);
+});

--- a/grafana-plugin/e2e-tests/utils/escalationChain.ts
+++ b/grafana-plugin/e2e-tests/utils/escalationChain.ts
@@ -17,7 +17,8 @@ export const createEscalationChain = async (
   page: Page,
   escalationChainName: string,
   escalationStep?: EscalationStep,
-  escalationStepValue?: string
+  escalationStepValue?: string,
+  important?: boolean
 ): Promise<void> => {
   // go to the escalation chains page
   await goToOnCallPage(page, 'escalations');
@@ -40,18 +41,32 @@ export const createEscalationChain = async (
   await clickButton({ page, buttonText: 'Create' });
   await expect(page.getByTestId('escalation-chain-name')).toHaveText(escalationChainName);
 
-  if (!escalationStep || !escalationStepValue) {
-    return;
+  if (escalationStep) {
+    // add an escalation step
+    await selectDropdownValue({
+      page, selectType: 'grafanaSelect', placeholderText: 'Add escalation step...', value: escalationStep,
+    });
+
+    // toggle important
+    if (important) {
+      await selectDropdownValue({
+        page,
+        selectType: 'grafanaSelect',
+        placeholderText: "Default",
+        value: "Important",
+      });
+    }
+
+    // select the escalation step value (e.g. user or schedule)
+    if (escalationStepValue) {await selectEscalationStepValue(page, escalationStep, escalationStepValue);}
   }
+};
 
-  // add an escalation step
-  await selectDropdownValue({
-    page,
-    selectType: 'grafanaSelect',
-    placeholderText: 'Add escalation step...',
-    value: escalationStep,
-  });
-
+export const selectEscalationStepValue = async (
+  page: Page,
+  escalationStep: EscalationStep,
+  escalationStepValue: string
+): Promise<void> => {
   await selectDropdownValue({
     page,
     selectType: 'grafanaSelect',

--- a/grafana-plugin/src/models/escalation_policy/escalation_policy.helpers.ts
+++ b/grafana-plugin/src/models/escalation_policy/escalation_policy.helpers.ts
@@ -3,5 +3,5 @@ import { pick } from 'lodash-es';
 import { EscalationPolicy } from './escalation_policy.types';
 
 export function prepareEscalationPolicy(value: EscalationPolicy) {
-  return pick(value, ['step']);
+  return pick(value, ['step', 'important']);
 }


### PR DESCRIPTION
# What this PR does

Fix escalation policy importance going back to default after changing users to notify + simple e2e test for this scenario

## Which issue(s) this PR fixes

https://github.com/grafana/support-escalations/issues/7920
https://github.com/grafana/oncall/issues/1196

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
