### PR TITLE
Improve user permissions query

### DIFF
--- a/engine/apps/user_management/models/user.py
+++ b/engine/apps/user_management/models/user.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import re
 import typing
 from urllib.parse import urljoin
 
@@ -32,6 +33,10 @@ if typing.TYPE_CHECKING:
     from apps.user_management.models import Organization, Team
 
 logger = logging.getLogger(__name__)
+
+
+class PermissionsQuery(typing.TypedDict):
+    permissions__contains: typing.Dict
 
 
 class PermissionsRegexQuery(typing.TypedDict):
@@ -387,7 +392,7 @@ class User(models.Model):
     @staticmethod
     def build_permissions_query(
         permission: LegacyAccessControlCompatiblePermission, organization
-    ) -> typing.Union[PermissionsRegexQuery, RoleInQuery]:
+    ) -> typing.Union[PermissionsQuery, PermissionsRegexQuery, RoleInQuery]:
         """
         This method returns a django query filter that is compatible with RBAC
         as well as legacy "basic" role based authorization. If a permission is provided we simply do
@@ -399,7 +404,11 @@ class User(models.Model):
         """
         if organization.is_rbac_permissions_enabled:
             # https://stackoverflow.com/a/50251879
-            return PermissionsRegexQuery(permissions__regex=r".*{0}.*".format(permission.value))
+            if settings.DATABASE_TYPE == settings.DATABASE_TYPES.SQLITE3:
+                # https://docs.djangoproject.com/en/4.2/topics/db/queries/#contains
+                return PermissionsRegexQuery(permissions__regex=re.escape(permission.value))
+            required_permission = {"action": permission.value}
+            return PermissionsQuery(permissions__contains=required_permission)
         return RoleInQuery(role__lte=permission.fallback_role.value)
 
     def get_or_create_notification_policies(self, important=False):

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -120,6 +120,7 @@ DATABASE_DEFAULTS = {
     },
 }
 
+DATABASE_TYPES = DatabaseTypes
 DATABASE_NAME = os.getenv("DATABASE_NAME") or os.getenv("MYSQL_DB_NAME")
 DATABASE_USER = os.getenv("DATABASE_USER") or os.getenv("MYSQL_USER")
 DATABASE_PASSWORD = os.getenv("DATABASE_PASSWORD") or os.getenv("MYSQL_PASSWORD")


### PR DESCRIPTION
The query for checking a user permission (used to get users from a Slack usergroup, for example) is timing out (and generating retries, besides affecting some use cases: [logs](https://ops.grafana-ops.net/explore?panes=%7B%22FCQ%22:%7B%22datasource%22:%22c-R8UWvVk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22amixr-prod%5C%22,%20cluster%3D%5C%22prod-us-central-0%5C%22%7D%20%7C%3D%20%5C%22Timeout%20exceeded%20in%20regular%20expression%20match.%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22c-R8UWvVk%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-6h%22,%22to%22:%22now%22%7D%7D%7D&schemaVersion=1&orgId=1)):

`django.db.utils.OperationalError: (3699, 'Timeout exceeded in regular expression match.')`

Change to a `contains` query except for SQLite (not supported), where a simplified version of the original regex query is used.