### PR TITLE
fix(2989) Return users field data for web overriden shifts via public…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed recurrency limit issue in the Rotation Modal ([#3358](https://github.com/grafana/oncall/pull/3358))
 - Added dragging boundary constraints for Rotation Modal and show scroll for the users list ([#3365](https://github.com/grafana/oncall/pull/3365))
+### Added
+- Populate `users` field of the public Shift GET API with `rolling_users` from the type override created from web UI([#3303](https://github.com/grafana/oncall/pull/3303))
 
 ## v1.3.58 (2023-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed recurrency limit issue in the Rotation Modal ([#3358](https://github.com/grafana/oncall/pull/3358))
 - Added dragging boundary constraints for Rotation Modal and show scroll for the users list ([#3365](https://github.com/grafana/oncall/pull/3365))
 ### Added
+
 - Populate `users` field of the public Shift GET API with `rolling_users` from the type override created from web UI([#3303](https://github.com/grafana/oncall/pull/3303))
 
 ## v1.3.58 (2023-11-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed recurrency limit issue in the Rotation Modal ([#3358](https://github.com/grafana/oncall/pull/3358))
 - Added dragging boundary constraints for Rotation Modal and show scroll for the users list ([#3365](https://github.com/grafana/oncall/pull/3365))
+
 ### Added
 
 - Populate `users` field of the public Shift GET API with `rolling_users` from the type override created from web UI([#3303](https://github.com/grafana/oncall/pull/3303))

--- a/engine/apps/public_api/serializers/on_call_shifts.py
+++ b/engine/apps/public_api/serializers/on_call_shifts.py
@@ -256,6 +256,16 @@ class CustomOnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer
         result["rotation_start"] = instance.rotation_start.strftime("%Y-%m-%dT%H:%M:%S")
         if instance.until is not None:
             result["until"] = instance.until.strftime("%Y-%m-%dT%H:%M:%S")
+
+        # Populate "users" field using "rolling_users" field for web overrides
+        # To support the behavior of the web UI, which creates overrides populating the rolling_users field
+        if (
+            result["type"] == CustomOnCallShift.PUBLIC_TYPE_CHOICES_MAP[CustomOnCallShift.TYPE_OVERRIDE]
+            and instance.source == CustomOnCallShift.SOURCE_WEB
+            and result["rolling_users"] is not None
+        ):
+            result["users"] += [u for r in result["rolling_users"] for u in r]
+            result["users"] = list(set(result["users"]))  # return unique users
         result = self._get_fields_to_represent(instance, result)
         return result
 

--- a/engine/apps/public_api/serializers/on_call_shifts.py
+++ b/engine/apps/public_api/serializers/on_call_shifts.py
@@ -264,8 +264,7 @@ class CustomOnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer
             and instance.source == CustomOnCallShift.SOURCE_WEB
             and result["rolling_users"] is not None
         ):
-            result["users"] += [u for r in result["rolling_users"] for u in r]
-            result["users"] = list(set(result["users"]))  # return unique users
+            result["users"] = list({u for r in result["rolling_users"] for u in r})
         result = self._get_fields_to_represent(instance, result)
         return result
 

--- a/engine/apps/public_api/tests/test_on_call_shifts.py
+++ b/engine/apps/public_api/tests/test_on_call_shifts.py
@@ -166,6 +166,53 @@ def test_get_override_on_call_shift(make_organization_and_user_with_token, make_
 
 
 @pytest.mark.django_db
+def test_get_web_override_shift(
+    make_organization_and_user_with_token, make_user_for_organization, make_on_call_shift, make_schedule
+):
+    organization, user, token = make_organization_and_user_with_token()
+    other_user = make_user_for_organization(organization)
+    client = APIClient()
+
+    start_data = timezone.now().replace(microsecond=0)
+    schedule = make_schedule(organization, schedule_class=OnCallScheduleCalendar)
+    data = {
+        "name": "override shift",
+        "start": start_data,
+        "rotation_start": start_data,
+        "duration": timezone.timedelta(hours=9),
+        "schedule": schedule,
+    }
+    on_call_shift = make_on_call_shift(
+        organization=organization,
+        source=CustomOnCallShift.SOURCE_WEB,
+        shift_type=CustomOnCallShift.TYPE_OVERRIDE,
+        **data,
+    )
+    on_call_shift.add_rolling_users([[other_user]])
+    on_call_shift.users.add(user)
+
+    url = reverse("api-public:on_call_shifts-detail", kwargs={"pk": on_call_shift.public_primary_key})
+
+    response = client.get(url, format="json", HTTP_AUTHORIZATION=f"{token}")
+
+    result = {
+        "id": on_call_shift.public_primary_key,
+        "team_id": None,
+        "schedule": schedule.public_primary_key,
+        "name": on_call_shift.name,
+        "type": "override",
+        "time_zone": None,
+        "start": on_call_shift.start.strftime("%Y-%m-%dT%H:%M:%S"),
+        "rotation_start": on_call_shift.start.strftime("%Y-%m-%dT%H:%M:%S"),
+        "duration": int(on_call_shift.duration.total_seconds()),
+        "users": list(set([user.public_primary_key, other_user.public_primary_key])),
+    }
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == result
+
+
+@pytest.mark.django_db
 def test_create_on_call_shift(make_organization_and_user_with_token):
     _, user, token = make_organization_and_user_with_token()
     client = APIClient()

--- a/engine/apps/public_api/tests/test_on_call_shifts.py
+++ b/engine/apps/public_api/tests/test_on_call_shifts.py
@@ -188,8 +188,7 @@ def test_get_web_override_shift(
         shift_type=CustomOnCallShift.TYPE_OVERRIDE,
         **data,
     )
-    on_call_shift.add_rolling_users([[other_user]])
-    on_call_shift.users.add(user)
+    on_call_shift.add_rolling_users([[other_user], [user]])
 
     url = reverse("api-public:on_call_shifts-detail", kwargs={"pk": on_call_shift.public_primary_key})
 
@@ -205,7 +204,7 @@ def test_get_web_override_shift(
         "start": on_call_shift.start.strftime("%Y-%m-%dT%H:%M:%S"),
         "rotation_start": on_call_shift.start.strftime("%Y-%m-%dT%H:%M:%S"),
         "duration": int(on_call_shift.duration.total_seconds()),
-        "users": list(set([user.public_primary_key, other_user.public_primary_key])),
+        "users": list({user.public_primary_key, other_user.public_primary_key}),
     }
 
     assert response.status_code == status.HTTP_200_OK

--- a/engine/apps/public_api/tests/test_on_call_shifts.py
+++ b/engine/apps/public_api/tests/test_on_call_shifts.py
@@ -170,7 +170,6 @@ def test_get_web_override_shift(
     make_organization_and_user_with_token, make_user_for_organization, make_on_call_shift, make_schedule
 ):
     organization, user, token = make_organization_and_user_with_token()
-    other_user = make_user_for_organization(organization)
     client = APIClient()
 
     start_data = timezone.now().replace(microsecond=0)
@@ -188,7 +187,7 @@ def test_get_web_override_shift(
         shift_type=CustomOnCallShift.TYPE_OVERRIDE,
         **data,
     )
-    on_call_shift.add_rolling_users([[other_user], [user]])
+    on_call_shift.add_rolling_users([[user]])
 
     url = reverse("api-public:on_call_shifts-detail", kwargs={"pk": on_call_shift.public_primary_key})
 
@@ -204,7 +203,7 @@ def test_get_web_override_shift(
         "start": on_call_shift.start.strftime("%Y-%m-%dT%H:%M:%S"),
         "rotation_start": on_call_shift.start.strftime("%Y-%m-%dT%H:%M:%S"),
         "duration": int(on_call_shift.duration.total_seconds()),
-        "users": list({user.public_primary_key, other_user.public_primary_key}),
+        "users": list({user.public_primary_key}),
     }
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
# What this PR does 
The `rolling_users` field for the shift of type override created from web UI is populated in the `users` field of the public GET Shift API
## Which issue(s) this PR fixes
  #2989
## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
