### PR TITLE
Make usernames unique in tests

### DIFF
--- a/engine/apps/user_management/tests/factories.py
+++ b/engine/apps/user_management/tests/factories.py
@@ -14,7 +14,7 @@ class OrganizationFactory(factory.DjangoModelFactory):
 
 
 class UserFactory(factory.DjangoModelFactory):
-    username = factory.Faker("user_name")
+    username = UniqueFaker("user_name")
     email = factory.Faker("email")
     user_id = UniqueFaker("pyint")
     avatar_url = factory.Faker("url")


### PR DESCRIPTION
Some tests (particularly when there are schedules and shifts involved) depend on generated usernames being unique (we randomly get [CI errors](https://github.com/grafana/oncall/actions/runs/6812435056/job/18524768961#step:5:676) because of this). Although username field is not required to be unique, I think it makes sense for testing purposes to enable this (and when a duplicated username is needed in a test, make that explicit).