### PR TITLE
fix(3093) Return timezone field of the user via public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.3.56 (2023-11-10)
+
+### Fixed
+
+- Added user timezone field to the users public API response  ([#3311](https://github.com/grafana/oncall/pull/3311))
+
 ## v1.3.55 (2023-11-07)
 
 ### Changed

--- a/docs/sources/oncall-api-reference/users.md
+++ b/docs/sources/oncall-api-reference/users.md
@@ -28,7 +28,8 @@ The above command returns JSON structured in the following way:
     }
   ],
   "username": "alex",
-  "role": "admin"
+  "role": "admin",
+  "timezone": "UTC"
 }
 ```
 
@@ -45,6 +46,7 @@ Use `{{API_URL}}/api/v1/users/current` to retrieve the current user.
 | `slack`    | Yes/org | List of user IDs from connected Slack. User linking key is e-mail. |
 | `username` | Yes/org | User username                                                      |
 | `role`     |   No    | One of: `user`, `observer`, `admin`.                               |
+| `timezone` |   No    | timezone of the user one of [time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).                               |
 
 # List Users
 
@@ -73,7 +75,8 @@ The above command returns JSON structured in the following way:
         }
       ],
       "username": "alex",
-      "role": "admin"
+      "role": "admin",
+      "timezone": "UTC"
     }
   ],
   "current_page_number": 1,

--- a/engine/apps/public_api/serializers/users.py
+++ b/engine/apps/public_api/serializers/users.py
@@ -53,7 +53,8 @@ class UserSerializer(serializers.ModelSerializer, EagerLoadingMixin):
 
     class Meta:
         model = User
-        fields = ["id", "email", "slack", "username", "role", "is_phone_number_verified"]
+        fields = ["id", "email", "slack", "username", "role", "is_phone_number_verified", "timezone"]
+        read_only_fields = ["timezone"]
 
     @staticmethod
     def get_role(obj):

--- a/engine/apps/public_api/tests/test_users.py
+++ b/engine/apps/public_api/tests/test_users.py
@@ -34,6 +34,7 @@ def test_get_user(
         "username": user.username,
         "role": "admin",
         "is_phone_number_verified": False,
+        "timezone": user.timezone,
     }
 
     assert response.status_code == status.HTTP_200_OK
@@ -72,6 +73,7 @@ def test_get_users_list(
                 "username": user_1.username,
                 "role": "admin",
                 "is_phone_number_verified": False,
+                "timezone": user_1.timezone,
             },
             {
                 "id": user_2.public_primary_key,
@@ -80,6 +82,7 @@ def test_get_users_list(
                 "username": user_2.username,
                 "role": "admin",
                 "is_phone_number_verified": False,
+                "timezone": user_2.timezone,
             },
         ],
         "current_page_number": 1,


### PR DESCRIPTION
# What this PR does
Return the `timezone` field for the users GET API call
## Which issue(s) this PR fixes

Closes #3093 

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
