### PR TITLE
AmazonSNS integration exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix AmazonSNS integration to handle exceptions the same as other integrations @mderynck ([#3315](https://github.com/grafana/oncall/pull/3315))
+
 ## v1.3.55 (2023-11-07)
 
 ### Changed

--- a/engine/apps/integrations/views.py
+++ b/engine/apps/integrations/views.py
@@ -21,6 +21,7 @@ from apps.integrations.mixins import (
     is_ratelimit_ignored,
 )
 from apps.integrations.tasks import create_alert, create_alertmanager_alerts
+from apps.user_management.exceptions import OrganizationDeletedException, OrganizationMovedException
 from common.api_helpers.utils import create_engine_url
 
 logger = logging.getLogger(__name__)
@@ -31,8 +32,10 @@ class AmazonSNS(BrowsableInstructionMixin, AlertChannelDefiningMixin, Integratio
     def dispatch(self, *args, **kwargs):
         try:
             return super().dispatch(*args, **kwargs)
+        except (OrganizationMovedException, OrganizationDeletedException, PermissionDenied) as oe:
+            raise oe
         except Exception as e:
-            print(e)
+            logger.error(f"AmazonSNS - Bad Request (400) {str(e)}")
             return JsonResponse(status=400, data={})
 
     def handle_message(self, message, payload):


### PR DESCRIPTION
# What this PR does
Handle OrganizationMoved, OrganizationDeleted and PermissionDenied exceptions same as other integration API views instead of converting to BadRequest.

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
