### PR TITLE
Forward headers for Amazon SNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Forward headers for Amazon SNS when organizations are moved @mderynck ([#3326](https://github.com/grafana/oncall/pull/3326))
+
 ## v1.3.57 (2023-11-10)
 
 ### Fixed

--- a/engine/apps/user_management/middlewares.py
+++ b/engine/apps/user_management/middlewares.py
@@ -32,6 +32,11 @@ class OrganizationMovedMiddleware(MiddlewareMixin):
             if (v := request.META.get("HTTP_AUTHORIZATION", None)) is not None:
                 headers["Authorization"] = v
 
+            if "amazon_sns" in request.path:
+                for k, v in request.META.items():
+                    if k.startswith("x-amz-sns-"):
+                        headers[k] = v
+
             response = self.make_request(request.method, url, headers, request.body)
             return HttpResponse(response.content, status=response.status_code)
 


### PR DESCRIPTION
# What this PR does
Forward headers for Amazon SNS when forwarding requests for moved organizations. Previous [PR](https://github.com/grafana/oncall/pull/3315) missed this since the test did not check mocked make_request for headers.

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
