### PR TITLE
Exclude dark css vars when light theme is turned on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-- Fix styling when light theme is turned on via system preferences by excluding dark theme css vars in this case ([#3336](https://github.com/grafana/oncall/pull/3336))
-
 ### Added
 
 - Added user timezone field to the users public API response ([#3311](https://github.com/grafana/oncall/pull/3311))
@@ -22,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Forward headers for Amazon SNS when organizations are moved @mderynck ([#3326](https://github.com/grafana/oncall/pull/3326))
+- Fix styling when light theme is turned on via system preferences
+  by excluding dark theme css vars in this case ([#3336](https://github.com/grafana/oncall/pull/3336))
 
 ## v1.3.57 (2023-11-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix styling when light theme is turned on via system preferences by excluding dark theme css vars in this case ([#3336](https://github.com/grafana/oncall/pull/3336))
+
 ### Added
 
 - Added user timezone field to the users public API response ([#3311](https://github.com/grafana/oncall/pull/3311))

--- a/grafana-plugin/src/assets/style/vars.css
+++ b/grafana-plugin/src/assets/style/vars.css
@@ -71,7 +71,7 @@
   --working-hours-shades-color-light: rgba(17, 18, 23, 0.04);
 }
 
-.theme-dark {
+.theme-dark:not(.theme-light) {
   --cards-background: var(--gray-9);
   --highlighted-row-bg: var(--gray-9);
   --disabled-button-color: hsla(0, 0%, 100%, 0.08);


### PR DESCRIPTION
# What this PR does
Fix styling when light theme is turned on via system preferences by excluding dark theme css vars in this case

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/3188

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
