### PR TITLE
Enable filtering users by public primary key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added user timezone field to the users public API response ([#3311](https://github.com/grafana/oncall/pull/3311))
+- Allow filtering users by public primary key in internal API ([#3339](https://github.com/grafana/oncall/pull/3339))
 
 ### Changed
 

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -222,6 +222,7 @@ class UserView(
         "^slack_user_identity__cached_slack_login",
         "^slack_user_identity__cached_name",
         "^teams__name",
+        "=public_primary_key",
     )
 
     filterset_class = UserFilter


### PR DESCRIPTION
Related to https://github.com/grafana/oncall/issues/3164

This will allow the following request to check if a user is currently on-call:
`GET /api/internal/v1/users/?search=UCGEIXI1MR1NZ&is_currently_oncall=true`