### PR TITLE
Change section title "Advanced Usage".

### DIFF
--- a/docs/sources/integrations/servicenow/index.md
+++ b/docs/sources/integrations/servicenow/index.md
@@ -135,7 +135,7 @@ Use the following JSON template as webhook data:
 
 >**Note**: Values for fields `state` and `close_code` may be different for your ServiceNow instance, please check and update the values accordingly.
 
-## Advanced usage
+## More Information on Outgoing Webhook syntax  (Or something similar).
 
 The examples above describe how to create outgoing webhooks in Grafana OnCall that will allow to automatically create, assign and resolve incidents in ServiceNow.
 


### PR DESCRIPTION
This section title is a bit miss leading at it doesn't offer an advanced examples and links to the basic outgoing webhook documentation.  Also, in the outgoing webhook documentation there is a section labeled Advanced Examples that leads back to the ServiceNow documentation.  This could be even more confusing for the customer.  Because of this I think we should change the name of this section to be something like "Outgoing Webhook syntax" or "Outgoing Webhook basics".  This way there isn't a circle of links marked Advanced usage/examples leading to each other.

Outgoing Webhook doc: https://grafana.com/docs/oncall/latest/outgoing-webhooks/#advanced-examples

# What this PR does
Renames "Advanced usage" section to prevent circular links leading back to eachother.

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
