### PR TITLE
Fix broken openapi schema + add integration test

### DIFF
--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -179,6 +179,7 @@ class AlertGroupSlackRenderingMixin:
 
 
 class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.Model):
+    acknowledged_by_user: typing.Optional["User"]
     alerts: "RelatedManager['Alert']"
     dependent_alert_groups: "RelatedManager['AlertGroup']"
     channel: "AlertReceiveChannel"
@@ -187,7 +188,9 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
     resolution_notes: "RelatedManager['ResolutionNote']"
     resolution_note_slack_messages: "RelatedManager['ResolutionNoteSlackMessage']"
     resolved_by_alert: typing.Optional["Alert"]
+    resolved_by_user: typing.Optional["User"]
     root_alert_group: typing.Optional["AlertGroup"]
+    silenced_by_user: typing.Optional["User"]
     slack_log_message: typing.Optional["SlackMessage"]
     slack_messages: "RelatedManager['SlackMessage']"
     users: "RelatedManager['User']"

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -91,7 +91,7 @@ class ShortAlertGroupSerializer(AlertGroupFieldsCacheSerializerMixin, serializer
             },
         )
     )
-    def get_render_for_web(self, obj):
+    def get_render_for_web(self, obj: "AlertGroup"):
         last_alert = obj.alerts.last()
         if last_alert is None:
             return {}
@@ -103,7 +103,9 @@ class ShortAlertGroupSerializer(AlertGroupFieldsCacheSerializerMixin, serializer
         )
 
 
-class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerializerMixin, serializers.ModelSerializer):
+class AlertGroupListSerializer(
+    EagerLoadingMixin, AlertGroupFieldsCacheSerializerMixin, serializers.ModelSerializer[AlertGroup]
+):
     pk = serializers.CharField(read_only=True, source="public_primary_key")
     alert_receive_channel = FastAlertReceiveChannelSerializer(source="channel")
     status = serializers.ReadOnlyField()
@@ -178,7 +180,7 @@ class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerialize
             },
         )
     )
-    def get_render_for_web(self, obj):
+    def get_render_for_web(self, obj: "AlertGroup"):
         if not obj.last_alert:
             return {}
         return AlertGroupFieldsCacheSerializerMixin.get_or_set_web_template_field(
@@ -189,9 +191,11 @@ class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerialize
         )
 
     @extend_schema_field(UserShortSerializer(many=True))
-    def get_related_users(self, obj):
-        users_ids = set()
-        users = []
+    def get_related_users(self, obj: "AlertGroup"):
+        from apps.user_management.models import User
+
+        users_ids: typing.Set[str] = set()
+        users: typing.List[User] = []
 
         # add resolved and acknowledged by_user explicitly because logs are already prefetched
         # when def acknowledge/resolve are called in view.

--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -1,21 +1,22 @@
 import datetime
 import logging
+import typing
 
 from django.core.cache import cache
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema_field, inline_serializer
 from rest_framework import serializers
 
-from apps.alerts.incident_appearance.renderers.classic_markdown_renderer import AlertGroupClassicMarkdownRenderer
 from apps.alerts.incident_appearance.renderers.web_renderer import AlertGroupWebRenderer
 from apps.alerts.models import AlertGroup
+from apps.alerts.models.alert_group import PagedUser
 from common.api_helpers.custom_fields import TeamPrimaryKeyRelatedField
 from common.api_helpers.mixins import EagerLoadingMixin
 
 from .alert import AlertSerializer
 from .alert_receive_channel import FastAlertReceiveChannelSerializer
 from .alerts_field_cache_buster_mixin import AlertsFieldCacheBusterMixin
-from .user import FastUserSerializer, PagedUserSerializer, UserShortSerializer
+from .user import FastUserSerializer, UserShortSerializer
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -116,7 +117,6 @@ class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerialize
 
     alerts_count = serializers.IntegerField(read_only=True)
     render_for_web = serializers.SerializerMethodField()
-    render_for_classic_markdown = serializers.SerializerMethodField()
 
     labels = AlertGroupLabelSerializer(many=True, read_only=True)
 
@@ -158,7 +158,6 @@ class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerialize
             "silenced_until",
             "related_users",
             "render_for_web",
-            "render_for_classic_markdown",
             "dependent_alert_groups",
             "root_alert_group",
             "status",
@@ -187,17 +186,6 @@ class AlertGroupListSerializer(EagerLoadingMixin, AlertGroupFieldsCacheSerialize
             obj.last_alert,
             AlertGroupFieldsCacheSerializerMixin.RENDER_FOR_WEB_FIELD_NAME,
             AlertGroupWebRenderer,
-        )
-
-    def get_render_for_classic_markdown(self, obj):
-        """Deprecated. TODO: remove"""
-        if not obj.last_alert:
-            return {}
-        return AlertGroupFieldsCacheSerializerMixin.get_or_set_web_template_field(
-            obj,
-            obj.last_alert,
-            AlertGroupFieldsCacheSerializerMixin.RENDER_FOR_CLASSIC_MARKDOWN_FIELD_NAME,
-            AlertGroupClassicMarkdownRenderer,
         )
 
     @extend_schema_field(UserShortSerializer(many=True))
@@ -241,7 +229,7 @@ class AlertGroupSerializer(AlertGroupListSerializer):
             "paged_users",
         ]
 
-    def get_last_alert_at(self, obj) -> datetime.datetime:
+    def get_last_alert_at(self, obj: "AlertGroup") -> datetime.datetime:
         last_alert = obj.alerts.last()
 
         if not last_alert:
@@ -250,7 +238,7 @@ class AlertGroupSerializer(AlertGroupListSerializer):
         return last_alert.created_at
 
     @extend_schema_field(AlertSerializer(many=True))
-    def get_limited_alerts(self, obj):
+    def get_limited_alerts(self, obj: "AlertGroup"):
         """
         Overriding default alerts because there are alert_groups with thousands of them.
         It's just too slow, we need to cut here.
@@ -258,6 +246,5 @@ class AlertGroupSerializer(AlertGroupListSerializer):
         alerts = obj.alerts.order_by("-pk")[:100]
         return AlertSerializer(alerts, many=True).data
 
-    @extend_schema_field(PagedUserSerializer(many=True))
-    def get_paged_users(self, obj):
+    def get_paged_users(self, obj: "AlertGroup") -> typing.List[PagedUser]:
         return obj.get_paged_users()

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -245,14 +245,17 @@ class FastAlertReceiveChannelSerializer(serializers.ModelSerializer[AlertReceive
 
 
 class FilterAlertReceiveChannelSerializer(serializers.ModelSerializer[AlertReceiveChannel]):
-    value = serializers.SerializerMethodField()
+    # don't use get_value as the method name, otherwise this will override the get_value method on
+    # serializers.ModelSerializer, which may cause unexpected behavior (+ this violates the "Lisov substition
+    # principle" which mypy complains about)
+    value = serializers.SerializerMethodField(method_name="_get_value")
     display_name = serializers.SerializerMethodField()
 
     class Meta:
         model = AlertReceiveChannel
         fields = ["value", "display_name", "integration_url"]
 
-    def get_value(self, obj: "AlertReceiveChannel"):
+    def _get_value(self, obj: "AlertReceiveChannel"):
         return obj.public_primary_key
 
     def get_display_name(self, obj: "AlertReceiveChannel"):

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -1,3 +1,4 @@
+import typing
 from collections import OrderedDict
 
 from django.conf import settings
@@ -39,7 +40,9 @@ class IntegrationAlertGroupLabelsSerializer(serializers.Serializer):
     inheritable = serializers.DictField(child=serializers.BooleanField())
 
 
-class AlertReceiveChannelSerializer(EagerLoadingMixin, LabelsSerializerMixin, serializers.ModelSerializer):
+class AlertReceiveChannelSerializer(
+    EagerLoadingMixin, LabelsSerializerMixin, serializers.ModelSerializer[AlertReceiveChannel]
+):
     id = serializers.CharField(read_only=True, source="public_primary_key")
     integration_url = serializers.ReadOnlyField()
     alert_count = serializers.SerializerMethodField()
@@ -163,12 +166,12 @@ class AlertReceiveChannelSerializer(EagerLoadingMixin, LabelsSerializerMixin, se
         except AlertReceiveChannel.DuplicateDirectPagingError:
             raise BadRequest(detail=AlertReceiveChannel.DuplicateDirectPagingError.DETAIL)
 
-    def get_instructions(self, obj):
+    def get_instructions(self, obj: "AlertReceiveChannel"):
         # Deprecated, kept for api-backward compatibility
         return ""
 
     # MethodFields are used instead of relevant properties because of properties hit db on each instance in queryset
-    def get_default_channel_filter(self, obj):
+    def get_default_channel_filter(self, obj: "AlertReceiveChannel"):
         for filter in obj.channel_filters.all():
             if filter.is_default:
                 return filter.public_primary_key
@@ -192,29 +195,29 @@ class AlertReceiveChannelSerializer(EagerLoadingMixin, LabelsSerializerMixin, se
         else:
             raise serializers.ValidationError(detail="Integration with this name already exists")
 
-    def get_heartbeat(self, obj):
+    def get_heartbeat(self, obj: "AlertReceiveChannel"):
         try:
             heartbeat = obj.integration_heartbeat
         except ObjectDoesNotExist:
             return None
         return IntegrationHeartBeatSerializer(heartbeat).data
 
-    def get_allow_delete(self, obj):
+    def get_allow_delete(self, obj: "AlertReceiveChannel"):
         return True
 
-    def get_alert_count(self, obj):
+    def get_alert_count(self, obj: "AlertReceiveChannel"):
         return 0
 
-    def get_alert_groups_count(self, obj):
+    def get_alert_groups_count(self, obj: "AlertReceiveChannel"):
         return 0
 
-    def get_routes_count(self, obj) -> int:
+    def get_routes_count(self, obj: "AlertReceiveChannel") -> int:
         return obj.channel_filters.count()
 
-    def get_is_legacy(self, obj) -> bool:
+    def get_is_legacy(self, obj: "AlertReceiveChannel") -> bool:
         return has_legacy_prefix(obj.integration)
 
-    def get_connected_escalations_chains_count(self, obj) -> int:
+    def get_connected_escalations_chains_count(self, obj: "AlertReceiveChannel") -> int:
         return (
             ChannelFilter.objects.filter(alert_receive_channel=obj, escalation_chain__isnull=False)
             .values("escalation_chain")
@@ -228,7 +231,7 @@ class AlertReceiveChannelUpdateSerializer(AlertReceiveChannelSerializer):
         read_only_fields = [*AlertReceiveChannelSerializer.Meta.read_only_fields, "integration"]
 
 
-class FastAlertReceiveChannelSerializer(serializers.ModelSerializer):
+class FastAlertReceiveChannelSerializer(serializers.ModelSerializer[AlertReceiveChannel]):
     id = serializers.CharField(read_only=True, source="public_primary_key")
     integration = serializers.CharField(read_only=True)
     deleted = serializers.SerializerMethodField()
@@ -237,11 +240,11 @@ class FastAlertReceiveChannelSerializer(serializers.ModelSerializer):
         model = AlertReceiveChannel
         fields = ["id", "integration", "verbal_name", "deleted"]
 
-    def get_deleted(self, obj) -> bool:
+    def get_deleted(self, obj: "AlertReceiveChannel") -> bool:
         return obj.deleted_at is not None
 
 
-class FilterAlertReceiveChannelSerializer(serializers.ModelSerializer):
+class FilterAlertReceiveChannelSerializer(serializers.ModelSerializer[AlertReceiveChannel]):
     value = serializers.SerializerMethodField()
     display_name = serializers.SerializerMethodField()
 
@@ -249,15 +252,15 @@ class FilterAlertReceiveChannelSerializer(serializers.ModelSerializer):
         model = AlertReceiveChannel
         fields = ["value", "display_name", "integration_url"]
 
-    def get_value(self, obj):
+    def get_value(self, obj: "AlertReceiveChannel"):
         return obj.public_primary_key
 
-    def get_display_name(self, obj):
+    def get_display_name(self, obj: "AlertReceiveChannel"):
         display_name = obj.verbal_name or AlertReceiveChannel.INTEGRATION_CHOICES[obj.integration][1]
         return display_name
 
 
-class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.ModelSerializer):
+class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.ModelSerializer[AlertReceiveChannel]):
     id = serializers.CharField(read_only=True, source="public_primary_key")
 
     payload_example = SerializerMethodField()
@@ -273,7 +276,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
         ]
         extra_kwargs = {"integration": {"required": True}}
 
-    def get_payload_example(self, obj):
+    def get_payload_example(self, obj: "AlertReceiveChannel"):
         from apps.alerts.models import AlertGroup
 
         if "alert_group_id" in self.context["request"].query_params:
@@ -290,7 +293,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
             except AttributeError:
                 return None
 
-    def get_is_based_on_alertmanager(self, obj):
+    def get_is_based_on_alertmanager(self, obj: "AlertReceiveChannel"):
         return obj.based_on_alertmanager
 
     # Override method to pass field_name directly in set_value to handle None values for WritableSerializerField
@@ -366,7 +369,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
                 set_value(ret, [field_name], value)
         return errors
 
-    def to_representation(self, obj):
+    def to_representation(self, obj: "AlertReceiveChannel"):
         ret = super().to_representation(obj)
 
         core_templates = self._get_core_templates(obj)
@@ -378,7 +381,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
 
         return ret
 
-    def _get_messaging_backend_templates(self, obj):
+    def _get_messaging_backend_templates(self, obj: "AlertReceiveChannel"):
         """Return additional messaging backend templates if any."""
         templates = {}
         for backend_id, backend in get_messaging_backends():
@@ -397,7 +400,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
                 templates[f"{field_name}_is_default"] = is_default
         return templates
 
-    def _get_core_templates(self, obj):
+    def _get_core_templates(self, obj: "AlertReceiveChannel"):
         core_templates = {}
 
         for template_name in self.core_templates_names:
@@ -410,10 +413,9 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
         return core_templates
 
     @property
-    def core_templates_names(self):
+    def core_templates_names(self) -> typing.List[str]:
         """
-        core_templates_names returns names of templates introduced before messaging backends system with respect to
-        enabled integrations.
+        returns names of templates introduced before messaging backends system with respect to enabled integrations.
         """
         core_templates = [
             "web_title_template",
@@ -427,21 +429,16 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
             "acknowledge_condition_template",
         ]
 
-        slack_integration_required_templates = [
-            "slack_title_template",
-            "slack_message_template",
-            "slack_image_url_template",
-        ]
-        telegram_integration_required_templates = [
-            "telegram_title_template",
-            "telegram_message_template",
-            "telegram_image_url_template",
-        ]
-
-        apppend = []
-
         if settings.FEATURE_SLACK_INTEGRATION_ENABLED:
-            core_templates += slack_integration_required_templates
+            core_templates += [
+                "slack_title_template",
+                "slack_message_template",
+                "slack_image_url_template",
+            ]
         if settings.FEATURE_TELEGRAM_INTEGRATION_ENABLED:
-            core_templates += telegram_integration_required_templates
-        return apppend + core_templates
+            core_templates += [
+                "telegram_title_template",
+                "telegram_message_template",
+                "telegram_image_url_template",
+            ]
+        return core_templates

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -237,7 +237,7 @@ class FastAlertReceiveChannelSerializer(serializers.ModelSerializer):
         model = AlertReceiveChannel
         fields = ["id", "integration", "verbal_name", "deleted"]
 
-    def get_deleted(self, obj):
+    def get_deleted(self, obj) -> bool:
         return obj.deleted_at is not None
 
 

--- a/engine/apps/api/serializers/alerts_field_cache_buster_mixin.py
+++ b/engine/apps/api/serializers/alerts_field_cache_buster_mixin.py
@@ -5,8 +5,7 @@ from django.core.cache import cache
 
 class AlertsFieldCacheBusterMixin:
     RENDER_FOR_WEB_FIELD_NAME = "render_for_web"
-    RENDER_FOR_CLASSIC_MARKDOWN_FIELD_NAME = "render_for_classic_markdown"
-    ALL_FIELD_NAMES = [RENDER_FOR_WEB_FIELD_NAME, RENDER_FOR_CLASSIC_MARKDOWN_FIELD_NAME]
+    ALL_FIELD_NAMES = [RENDER_FOR_WEB_FIELD_NAME]
 
     @classmethod
     def calculate_cache_key(cls, field_name: str, obj: typing.Any) -> str:

--- a/engine/apps/api/tests/test_openapi_schema.py
+++ b/engine/apps/api/tests/test_openapi_schema.py
@@ -1,0 +1,14 @@
+import pytest
+import yaml
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+def test_fetching_the_openapi_schema_works(settings):
+    client = APIClient()
+    response = client.get(reverse("schema"))
+
+    assert response.status_code == status.HTTP_200_OK
+    assert yaml.safe_load(response.content)["info"]["title"] == settings.SPECTACULAR_SETTINGS["TITLE"]

--- a/engine/apps/api/tests/test_openapi_schema.py
+++ b/engine/apps/api/tests/test_openapi_schema.py
@@ -6,7 +6,10 @@ from rest_framework.test import APIClient
 
 
 @pytest.mark.django_db
-def test_fetching_the_openapi_schema_works(settings):
+def test_fetching_the_openapi_schema_works(settings, reload_urls):
+    settings.DRF_SPECTACULAR_ENABLED = True
+    reload_urls()
+
     client = APIClient()
     response = client.get(reverse("schema"))
 

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -57,5 +57,5 @@ urllib3==1.26.18
 prometheus_client==0.16.0
 lxml==4.9.2
 babel==2.12.1
-drf-spectacular==0.26.2
+drf-spectacular==0.26.5
 grpcio==1.57.0

--- a/engine/settings/ci-test.py
+++ b/engine/settings/ci-test.py
@@ -40,6 +40,3 @@ TWILIO_ACCOUNT_SID = "dummy_twilio_account_sid"
 TWILIO_AUTH_TOKEN = "dummy_twilio_auth_token"
 
 EXTRA_MESSAGING_BACKENDS = [("apps.base.tests.messaging_backend.TestOnlyBackend", 42)]
-
-# needed to test that the openapi schema is valid and doesn't return HTTP 500
-DRF_SPECTACULAR_ENABLED = True

--- a/engine/settings/ci-test.py
+++ b/engine/settings/ci-test.py
@@ -40,3 +40,6 @@ TWILIO_ACCOUNT_SID = "dummy_twilio_account_sid"
 TWILIO_AUTH_TOKEN = "dummy_twilio_auth_token"
 
 EXTRA_MESSAGING_BACKENDS = [("apps.base.tests.messaging_backend.TestOnlyBackend", 42)]
+
+# needed to test that the openapi schema is valid and doesn't return HTTP 500
+DRF_SPECTACULAR_ENABLED = True


### PR DESCRIPTION
# Which issue(s) this PR fixes

- Fix issue that was causing our openapi schema to return HTTP 500 + add an integration test which fetches the `.yaml` schema and validates that the endpoint returns HTTP 200 (should hopefully prevent this from happening again).
- add a few more type hints along the way

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
