### PR TITLE
Handle Amazon SNS headers for moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixes forwarding of Amazon SNS headers @mderynck ([#3371](https://github.com/grafana/oncall/pull/3371))
+
 ## v1.3.59 (2023-11-16)
 
 ### Added
@@ -21,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed recurrency limit issue in the Rotation Modal ([#3358](https://github.com/grafana/oncall/pull/3358))
 - Added dragging boundary constraints for Rotation Modal and show scroll for the users list ([#3365](https://github.com/grafana/oncall/pull/3365))
 - Delete direct paging integration on team delete by @vadimkerr ([#3367](https://github.com/grafana/oncall/pull/3367))
-- Fixes forwarding of Amazon SNS headers @mderynck ([#3371](https://github.com/grafana/oncall/pull/3371))
 
 ## v1.3.58 (2023-11-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed recurrency limit issue in the Rotation Modal ([#3358](https://github.com/grafana/oncall/pull/3358))
 - Added dragging boundary constraints for Rotation Modal and show scroll for the users list ([#3365](https://github.com/grafana/oncall/pull/3365))
 - Delete direct paging integration on team delete by @vadimkerr ([#3367](https://github.com/grafana/oncall/pull/3367))
+- Fixes forwarding of Amazon SNS headers @mderynck ([#3371](https://github.com/grafana/oncall/pull/3371))
 
 ## v1.3.58 (2023-11-14)
 

--- a/engine/apps/user_management/middlewares.py
+++ b/engine/apps/user_management/middlewares.py
@@ -11,6 +11,13 @@ from .exceptions import OrganizationDeletedException, OrganizationMovedException
 
 logger = logging.getLogger(__name__)
 
+AMAZON_SNS_HEADERS = [
+    "x-amz-sns-subscription-arn",
+    "x-amz-sns-topic-arn",
+    "x-amz-sns-message-id",
+    "x-amz-sns-message-type",
+]
+
 
 class OrganizationMovedMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
@@ -33,9 +40,8 @@ class OrganizationMovedMiddleware(MiddlewareMixin):
                 headers["Authorization"] = v
 
             if "amazon_sns" in request.path:
-                for k, v in request.META.items():
-                    if k.startswith("x-amz-sns-"):
-                        headers[k] = v
+                for k in AMAZON_SNS_HEADERS:
+                    headers[k] = request.headers.get(k)
 
             response = self.make_request(request.method, url, headers, request.body)
             return HttpResponse(response.content, status=response.status_code)


### PR DESCRIPTION
# What this PR does
Previous PR #3326 test and forwarding code was not representative of actual request.  This fixes forwarding of Amazon SNS headers.

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
