### PR TITLE
Switch to django-redis, update redis deps

### DIFF
--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -5,7 +5,7 @@ whitenoise==5.3.0
 twilio~=6.37.0
 phonenumbers==8.10.0
 celery[amqp,redis]==5.3.1
-redis==4.6.0
+redis==5.0.1
 humanize==0.5.1
 uwsgi==2.0.21
 django-cors-headers==3.7.0
@@ -13,13 +13,8 @@ django-debug-toolbar==4.1
 django-sns-view==0.1.2
 python-telegram-bot==13.13
 django-silk==5.0.3
-# we need to use our own fork of django-redis-cache
-# reason being is that the "regular" repo (https://github.com/sebleier/django-redis-cache/)
-# has `redis` pinned @ <4.0
-# celery==5.3.1 complains about this
-# celery[amqp,redis] 5.3.1 depends on redis!=4.5.5 and >=4.5.2; extra == "redis"
-git+https://github.com/grafana/django-redis-cache.git@bump-redis-version-to-v4.6
-hiredis==1.0.0
+django-redis==5.4.0
+hiredis==2.2.3
 django-ratelimit==2.0.0
 django-filter==2.4.0
 icalendar==5.0.10

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -219,7 +219,7 @@ if REDIS_USE_SSL:
 # Cache
 CACHES = {
     "default": {
-        "BACKEND": "redis_cache.RedisCache",
+        "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URI,
         "OPTIONS": {
             "DB": REDIS_DATABASE,

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -223,7 +223,7 @@ CACHES = {
         "LOCATION": REDIS_URI,
         "OPTIONS": {
             "DB": REDIS_DATABASE,
-            "PARSER_CLASS": "redis.connection.HiredisParser",
+            "PARSER_CLASS": "redis.connection._HiredisParser",
             "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
             "CONNECTION_POOL_CLASS_KWARGS": REDIS_SSL_CONFIG
             | {


### PR DESCRIPTION
Moving to django-redis and updating related deps.
django-redis has better support for [sentinel setup](https://github.com/jazzband/django-redis#use-the-sentinel-connection-factory), besides improved cache helpers (and being actively maintained).