### PR TITLE
Remove unused prefetch; prefer indexed query

### DIFF
--- a/engine/apps/api/serializers/webhook.py
+++ b/engine/apps/api/serializers/webhook.py
@@ -194,7 +194,7 @@ class WebhookSerializer(LabelsSerializerMixin, serializers.ModelSerializer):
         return preset
 
     def get_last_response_log(self, obj):
-        return WebhookResponseSerializer(obj.responses.all().last()).data
+        return WebhookResponseSerializer(obj.responses.last()).data
 
     def get_trigger_type_name(self, obj):
         trigger_type_name = ""

--- a/engine/apps/api/views/webhooks.py
+++ b/engine/apps/api/views/webhooks.py
@@ -94,7 +94,7 @@ class WebhooksView(TeamFilteringMixin, PublicPrimaryKeyMixin, ModelViewSet):
     def get_queryset(self, ignore_filtering_by_available_teams=False):
         queryset = Webhook.objects.filter(
             organization=self.request.auth.organization,
-        ).prefetch_related("responses")
+        )
         if not ignore_filtering_by_available_teams:
             queryset = queryset.filter(*self.available_teams_lookup_args).distinct()
 


### PR DESCRIPTION
This should help with slowness in webhooks listing page (do not fetch *all* responses for webhooks, which besides were not used in the serializer).