### PR TITLE
Add alert group actions extension point to plugin

### DIFF
--- a/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkDropdown.tsx
+++ b/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkDropdown.tsx
@@ -25,7 +25,7 @@ export function ExtensionLinkDropdown({
   declareIncidentLink,
   grafanaIncidentId,
 }: Props): ReactElement | null {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState(false);
   const context = useExtensionPointContext(incident);
   const extensions = useExtensionLinks(context, extensionPointId);
 

--- a/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkDropdown.tsx
+++ b/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkDropdown.tsx
@@ -1,0 +1,82 @@
+import React, { ReactElement, useMemo, useState } from 'react';
+
+// Note: these imports are available in Grafana>=10.0.
+// @ts-expect-error
+import { PluginExtensionLink } from '@grafana/data';
+// @ts-expect-error
+import { getPluginLinkExtensions } from '@grafana/runtime';
+import { Dropdown, ToolbarButton } from '@grafana/ui';
+import { OnCallPluginExtensionPoints } from 'types';
+
+import { Alert } from 'models/alertgroup/alertgroup.types';
+
+import { ExtensionLinkMenu } from './ExtensionLinkMenu';
+
+interface Props {
+  incident: Alert;
+  extensionPointId: OnCallPluginExtensionPoints;
+  declareIncidentLink?: string;
+  grafanaIncidentId: string | null;
+}
+
+export function ExtensionLinkDropdown({
+  incident,
+  extensionPointId,
+  declareIncidentLink,
+  grafanaIncidentId,
+}: Props): ReactElement | null {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const context = useExtensionPointContext(incident);
+  const extensions = useExtensionLinks(context, extensionPointId);
+
+  if (extensions.length === 0) {
+    return null;
+  }
+
+  const menu = (
+    <ExtensionLinkMenu
+      extensions={extensions}
+      declareIncidentLink={declareIncidentLink}
+      grafanaIncidentId={grafanaIncidentId}
+    />
+  );
+
+  return (
+    <Dropdown onVisibleChange={setIsOpen} placement="bottom-start" overlay={menu}>
+      <ToolbarButton aria-label="Actions" variant="canvas" isOpen={isOpen}>
+        Actions
+      </ToolbarButton>
+    </Dropdown>
+  );
+}
+
+function useExtensionPointContext(incident: Alert): PluginExtensionOnCallAlertGroupContext {
+  return { alertGroup: incident };
+}
+
+function useExtensionLinks<T>(context: T, extensionPointId: OnCallPluginExtensionPoints): PluginExtensionLink[] {
+  return useMemo(() => {
+    // getPuginLinkExtensions is available in Grafana>=10.0,
+    // so will be undefined in earlier versions. Just return an
+    // empty list of extensions in this case.
+    if (getPluginLinkExtensions === undefined) {
+      return [];
+    }
+    const { extensions } = getPluginLinkExtensions({
+      extensionPointId,
+      context,
+      limitPerPlugin: 3,
+    });
+
+    return extensions;
+  }, [context]);
+}
+
+// This is the 'context' that will be passed to plugin extensions when they
+// are created (in `getPluginLinkExtensions`, provided by Grafana).
+//
+// Other plugins should be able to use this context type in the `configure`
+// or `onClick` handler of their extension.
+interface PluginExtensionOnCallAlertGroupContext {
+  alertGroup: Alert;
+}

--- a/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkDropdown.tsx
+++ b/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkDropdown.tsx
@@ -56,7 +56,7 @@ function useExtensionPointContext(incident: Alert): PluginExtensionOnCallAlertGr
 
 function useExtensionLinks<T>(context: T, extensionPointId: OnCallPluginExtensionPoints): PluginExtensionLink[] {
   return useMemo(() => {
-    // getPuginLinkExtensions is available in Grafana>=10.0,
+    // getPluginLinkExtensions is available in Grafana>=10.0,
     // so will be undefined in earlier versions. Just return an
     // empty list of extensions in this case.
     if (getPluginLinkExtensions === undefined) {

--- a/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkMenu.tsx
+++ b/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkMenu.tsx
@@ -6,6 +6,7 @@ import { locationUtil, PluginExtensionLink } from '@grafana/data';
 import { Menu } from '@grafana/ui';
 
 import { PluginBridge, SupportedPlugin } from 'components/PluginBridge/PluginBridge';
+import { truncateTitle } from 'utils/string';
 
 type Props = {
   extensions: PluginExtensionLink[];
@@ -120,12 +121,4 @@ function useExtensionLinksByCategory(extensions: PluginExtensionLink[]): Extensi
       categorised,
     };
   }, [extensions]);
-}
-
-function truncateTitle(title: string, length: number): string {
-  if (title.length < length) {
-    return title;
-  }
-  const part = title.slice(0, length - 3);
-  return `${part.trimEnd()}...`;
 }

--- a/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkMenu.tsx
+++ b/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkMenu.tsx
@@ -49,11 +49,11 @@ function DeclareIncidentMenuItem({ extensions, declareIncidentLink, grafanaIncid
   );
   if (
     // Don't show a custom Declare incident button if the Grafana Incident plugin already configured one.
-    declareIncidentExtensionLink !== undefined ||
+    declareIncidentExtensionLink ||
     // Don't show a custom Declare incident button if there's no valid link.
-    declareIncidentLink === undefined ||
+    !declareIncidentLink ||
     // Don't show the button if an incident has already been declared from this alert group.
-    grafanaIncidentId !== null
+    grafanaIncidentId
   ) {
     return null;
   }

--- a/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkMenu.tsx
+++ b/grafana-plugin/src/components/ExtensionLinkMenu/ExtensionLinkMenu.tsx
@@ -1,0 +1,131 @@
+import React, { ReactElement, useMemo } from 'react';
+
+// Note: `PluginExtensionLink` is available in Grafana>=10.0.
+// @ts-expect-error
+import { locationUtil, PluginExtensionLink } from '@grafana/data';
+import { Menu } from '@grafana/ui';
+
+import { PluginBridge, SupportedPlugin } from 'components/PluginBridge/PluginBridge';
+
+type Props = {
+  extensions: PluginExtensionLink[];
+  // We require this to be passed in so we can continue to
+  // create a custom Declare incident link. Once the Incident plugin
+  // registers its own extension link, we can remove this.
+  declareIncidentLink?: string;
+  grafanaIncidentId?: string;
+};
+
+export function ExtensionLinkMenu({ extensions, declareIncidentLink, grafanaIncidentId }: Props): ReactElement | null {
+  const { categorised, uncategorised } = useExtensionLinksByCategory(extensions);
+  const showDivider = uncategorised.length > 0 && Object.keys(categorised).length > 0;
+
+  return (
+    <Menu>
+      <>
+        <DeclareIncidentMenuItem
+          extensions={extensions}
+          declareIncidentLink={declareIncidentLink}
+          grafanaIncidentId={grafanaIncidentId}
+        />
+        {Object.keys(categorised).map((category) => (
+          <Menu.Group key={category} label={truncateTitle(category, 25)}>
+            {renderItems(categorised[category])}
+          </Menu.Group>
+        ))}
+        {showDivider && <Menu.Divider key="divider" />}
+        {renderItems(uncategorised)}
+      </>
+    </Menu>
+  );
+}
+
+// This menu item is a temporary workaround for the fact that the Incident plugin doesn't
+// register its own extension link.
+// TODO: remove this once Incident is definitely registering its own extension link.
+function DeclareIncidentMenuItem({ extensions, declareIncidentLink, grafanaIncidentId }: Props): ReactElement | null {
+  const declareIncidentExtensionLink = extensions.find(
+    (extension) => extension.pluginId === 'grafana-incident-app' && extension.title === 'Declare incident'
+  );
+  if (
+    // Don't show a custom Declare incident button if the Grafana Incident plugin already configured one.
+    declareIncidentExtensionLink !== undefined ||
+    // Don't show a custom Declare incident button if there's no valid link.
+    declareIncidentLink === undefined ||
+    // Don't show the button if an incident has already been declared from this alert group.
+    grafanaIncidentId !== null
+  ) {
+    return null;
+  }
+  return (
+    <PluginBridge plugin={SupportedPlugin.Incident}>
+      <Menu.Group key={'Declare incident'} label={'Incident'}>
+        {renderItems([
+          {
+            type: 'link',
+            path: declareIncidentLink,
+            icon: 'fire',
+            category: 'Incident',
+            title: 'Declare incident',
+            pluginId: 'grafana-oncall-app',
+          },
+        ])}
+      </Menu.Group>
+    </PluginBridge>
+  );
+}
+
+function renderItems(extensions: PluginExtensionLink[]): JSX.Element[] {
+  return extensions.map((extension) => (
+    <Menu.Item
+      ariaLabel={extension.title}
+      icon={extension?.icon || 'plug'}
+      key={extension.id}
+      label={truncateTitle(extension.title, 25)}
+      onClick={(event) => {
+        if (extension.path) {
+          return void global.open(locationUtil.assureBaseUrl(extension.path), '_blank');
+        }
+        extension.onClick?.(event);
+      }}
+    />
+  ));
+}
+
+type ExtensionLinksResult = {
+  uncategorised: PluginExtensionLink[];
+  categorised: Record<string, PluginExtensionLink[]>;
+};
+
+function useExtensionLinksByCategory(extensions: PluginExtensionLink[]): ExtensionLinksResult {
+  return useMemo(() => {
+    const uncategorised: PluginExtensionLink[] = [];
+    const categorised: Record<string, PluginExtensionLink[]> = {};
+
+    for (const link of extensions) {
+      if (!link.category) {
+        uncategorised.push(link);
+        continue;
+      }
+
+      if (!Array.isArray(categorised[link.category])) {
+        categorised[link.category] = [];
+      }
+      categorised[link.category].push(link);
+      continue;
+    }
+
+    return {
+      uncategorised,
+      categorised,
+    };
+  }, [extensions]);
+}
+
+function truncateTitle(title: string, length: number): string {
+  if (title.length < length) {
+    return title;
+  }
+  const part = title.slice(0, length - 3);
+  return `${part.trimEnd()}...`;
+}

--- a/grafana-plugin/src/pages/incident/Incident.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.tsx
@@ -22,8 +22,10 @@ import CopyToClipboard from 'react-copy-to-clipboard';
 import Emoji from 'react-emoji-render';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import reactStringReplace from 'react-string-replace';
+import { OnCallPluginExtensionPoints } from 'types';
 
 import Collapse from 'components/Collapse/Collapse';
+import { ExtensionLinkDropdown } from 'components/ExtensionLinkMenu/ExtensionLinkDropdown';
 import Block from 'components/GBlock/Block';
 import IntegrationLogo from 'components/IntegrationLogo/IntegrationLogo';
 import PageErrorHandlingWrapper, { PageBaseState } from 'components/PageErrorHandlingWrapper/PageErrorHandlingWrapper';
@@ -435,6 +437,12 @@ class IncidentPage extends React.Component<IncidentPageProps, IncidentPageState>
                   </a>
                 </PluginBridge>
               )}
+              <ExtensionLinkDropdown
+                incident={incident}
+                extensionPointId={OnCallPluginExtensionPoints.AlertGroupAction}
+                declareIncidentLink={incident.declare_incident_link}
+                grafanaIncidentId={incident.grafana_incident_id}
+              />
             </HorizontalGroup>
 
             <Button

--- a/grafana-plugin/src/types.ts
+++ b/grafana-plugin/src/types.ts
@@ -19,6 +19,11 @@ export type AppRootProps = BaseAppRootProps<OnCallPluginMetaJSONData>;
 export type OnCallAppPluginMeta = AppPluginMeta<null | OnCallPluginMetaJSONData>;
 export type OnCallPluginConfigPageProps = PluginConfigPageProps<OnCallAppPluginMeta>;
 
+// Extension points that other plugins can use to hook into the OnCall app.
+export enum OnCallPluginExtensionPoints {
+  AlertGroupAction = 'plugins/grafana-oncall-app/alert-group/action',
+}
+
 declare global {
   export interface Window {
     // https://github.com/grafana/grafana/blob/78bef7a26a799209b5307d6bde8e25fcb4fbde7d/public/views/index-template.html#L251-L258

--- a/grafana-plugin/src/utils/string.ts
+++ b/grafana-plugin/src/utils/string.ts
@@ -1,0 +1,8 @@
+// Truncate a string to a given maximum length, adding ellipsis if it was truncated.
+export function truncateTitle(title: string, length: number): string {
+  if (title.length < length) {
+    return title;
+  }
+  const part = title.slice(0, length - 3);
+  return `${part.trimEnd()}...`;
+}


### PR DESCRIPTION
# What this PR does

This PR adds an [extension point] to the Grafana plugin, allowing other plugins to add menu items to the dropdown independently of this plugin.

It also moves the 'Declare incident' button into the 'Actions' menu representing the extension point, and displays it conditionally; the menu item is shown if all of the following are true:

1. the Grafana Incident plugin is installed (using the `PluginBridge` as before)
2. the alert group has a valid Grafana Incident URL
3. the alert group hasn't already been linked to an Incident
4. the Grafana Incident plugin hasn't _also_ configured an identical extension link to show in the dropdown.

Ideally the Grafana Incident plugin would soon configure an extension using this extension point, at which point we can remove the custom 'Declare incident' button (and the `PluginBridge`) from the OnCall app.

---

The main use case I have for this is to be able to run a Sift investigation from an OnCall alert group, similar to how it can be done from a Grafana alert instance as of [this PR][pr].

I'll try and get the Grafana ML and Incident plugins running in the same Grafana instance as this to test it out more thoroughly!

Note: this is heavily inspired by, and in some case stolen from, the [Explore toolbar extension point in Grafana](https://github.com/grafana/grafana/blob/main/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx).

## Which issue(s) this PR fixes

Part of https://github.com/grafana/machine-learning/issues/3558.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)

[extension point]: https://grafana.com/developers/plugin-tools/ui-extensions/create-an-extension-point
[pr]: https://github.com/grafana/grafana/pull/77900