### PR TITLE
Add test to ensure integrations work when cache is down

### DIFF
--- a/engine/apps/integrations/tests/test_views.py
+++ b/engine/apps/integrations/tests/test_views.py
@@ -1,10 +1,12 @@
-from unittest.mock import call, patch
+from unittest.mock import DEFAULT, call, patch
 
 import pytest
+from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db import OperationalError
 from django.urls import reverse
 from pytest_django.plugin import _DatabaseBlocker
+from redis.exceptions import ConnectionError as RedisConnectionError
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -283,6 +285,100 @@ def test_integration_grafana_endpoint_without_db_has_alerts(
 
     # disable DB access
     with DatabaseBlocker().block():
+        response = client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    mock_create_alertmanager_alerts.apply_async.assert_has_calls(
+        [
+            call((alert_receive_channel.pk, data["alerts"][0])),
+            call((alert_receive_channel.pk, data["alerts"][1])),
+        ]
+    )
+
+
+@patch("apps.integrations.views.create_alert")
+@pytest.mark.parametrize(
+    "integration_type",
+    [
+        arc_type
+        for arc_type in AlertReceiveChannel.INTEGRATION_TYPES
+        if arc_type not in ["amazon_sns", "grafana", "alertmanager", "grafana_alerting", "maintenance"]
+    ],
+)
+@pytest.mark.django_db
+def test_integration_universal_endpoint_works_without_cache(
+    mock_create_alert, make_organization_and_user, make_alert_receive_channel, integration_type
+):
+    organization, user = make_organization_and_user()
+    alert_receive_channel = make_alert_receive_channel(
+        organization=organization,
+        author=user,
+        integration=integration_type,
+    )
+
+    client = APIClient()
+    url = reverse(
+        "integrations:universal",
+        kwargs={"integration_type": integration_type, "alert_channel_key": alert_receive_channel.token},
+    )
+
+    # disable cache access
+    with patch.multiple(cache, set=DEFAULT, get=DEFAULT, add=DEFAULT, incr=DEFAULT) as mocks:
+        for mock in mocks.values():
+            mock.side_effect = RedisConnectionError
+        data = {"foo": "bar"}
+        response = client.post(url, data, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+
+    mock_create_alert.apply_async.assert_called_once_with(
+        [],
+        {
+            "title": None,
+            "message": None,
+            "image_url": None,
+            "link_to_upstream_details": None,
+            "alert_receive_channel_pk": alert_receive_channel.pk,
+            "integration_unique_data": None,
+            "raw_request_data": data,
+        },
+    )
+
+
+@patch("apps.integrations.views.create_alertmanager_alerts")
+@pytest.mark.django_db
+def test_integration_grafana_endpoint_without_cache_has_alerts(
+    mock_create_alertmanager_alerts, settings, make_organization_and_user, make_alert_receive_channel
+):
+    settings.DEBUG = False
+
+    integration_type = "grafana"
+    organization, user = make_organization_and_user()
+    alert_receive_channel = make_alert_receive_channel(
+        organization=organization,
+        author=user,
+        integration=integration_type,
+    )
+
+    client = APIClient()
+    url = reverse("integrations:grafana", kwargs={"alert_channel_key": alert_receive_channel.token})
+
+    data = {
+        "alerts": [
+            {
+                "foo": 123,
+            },
+            {
+                "foo": 456,
+            },
+        ]
+    }
+
+    # disable cache access
+    with patch.multiple(cache, set=DEFAULT, get=DEFAULT, add=DEFAULT, incr=DEFAULT) as mocks:
+        for mock in mocks.values():
+            mock.side_effect = RedisConnectionError
         response = client.post(url, data, format="json")
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Complements https://github.com/grafana/oncall/pull/3414/