### PR TITLE
Allow users with user settings read to list users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ endpoint currently) @mderynck ([#3189](https://github.com/grafana/oncall/pull/31
 - User filter doesn't display current value on Alert Groups page ([1714](https://github.com/grafana/oncall/issues/1714))
 - Remove displaying rotation modal for Terraform/API based schedules
 - Filters polishing ([3183](https://github.com/grafana/oncall/issues/3183))
+- Fixed permissions so User settings reader role included list users @mderynck ([#3419](https://github.com/grafana/oncall/pull/3419))
 
 ## v1.3.62 (2023-11-21)
 

--- a/engine/apps/api/tests/test_user.py
+++ b/engine/apps/api/tests/test_user.py
@@ -410,7 +410,7 @@ def test_user_update_other_permissions(
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
         (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
-        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
         (LegacyAccessControlRole.NONE, status.HTTP_403_FORBIDDEN),
     ],
 )

--- a/engine/apps/api/tests/test_user.py
+++ b/engine/apps/api/tests/test_user.py
@@ -1291,14 +1291,14 @@ def test_viewer_cant_update_himself(make_organization_and_user_with_plugin_token
 
 
 @pytest.mark.django_db
-def test_viewer_cant_list_users(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+def test_viewer_can_list_users(make_organization_and_user_with_plugin_token, make_user_auth_headers):
     _, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.VIEWER)
 
     client = APIClient()
     url = reverse("api-internal:user-list")
 
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.django_db

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -159,7 +159,7 @@ class UserView(
         "timezone_options": [RBACPermission.Permissions.USER_SETTINGS_READ],
         "check_availability": [RBACPermission.Permissions.USER_SETTINGS_READ],
         "metadata": [RBACPermission.Permissions.USER_SETTINGS_WRITE],
-        "list": [RBACPermission.Permissions.USER_SETTINGS_WRITE],
+        "list": [RBACPermission.Permissions.USER_SETTINGS_READ],
         "update": [RBACPermission.Permissions.USER_SETTINGS_WRITE],
         "partial_update": [RBACPermission.Permissions.USER_SETTINGS_WRITE],
         "verify_number": [RBACPermission.Permissions.USER_SETTINGS_WRITE],


### PR DESCRIPTION
# What this PR does
Fixed issue where `User Settings Reader` was missing permission to list users.

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
