### PR TITLE
Trigger distribute task after alert is committed

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -144,7 +144,9 @@ class Alert(models.Model):
         if settings.DEBUG:
             tasks.distribute_alert(alert.pk)
         else:
-            tasks.distribute_alert.apply_async((alert.pk,), countdown=TASK_DELAY_SECONDS)
+            transaction.on_commit(
+                partial(tasks.distribute_alert.apply_async, (alert.pk,), countdown=TASK_DELAY_SECONDS)
+            )
 
         if group_created:
             # all code below related to maintenance mode


### PR DESCRIPTION
Fix issue triggering task retries because alert is not yet committed to the DB.
Similar to https://github.com/grafana/oncall/pull/3001.