### PR TITLE
Fix alert group rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ endpoint currently) @mderynck ([#3189](https://github.com/grafana/oncall/pull/31
 - Remove displaying rotation modal for Terraform/API based schedules
 - Filters polishing ([3183](https://github.com/grafana/oncall/issues/3183))
 - Fixed permissions so User settings reader role included list users @mderynck ([#3419](https://github.com/grafana/oncall/pull/3419))
+- Fixed alert group rendering when some links were broken because of replacing `-` to `_` @Ferril ([#3424](https://github.com/grafana/oncall/pull/3424))
 
 ## v1.3.62 (2023-11-21)
 

--- a/engine/apps/slack/slack_formatter.py
+++ b/engine/apps/slack/slack_formatter.py
@@ -37,6 +37,18 @@ class SlackFormatter(SlackFormatterBase):
 
         return message
 
+    def slack_to_accepted_emoji(self, message):
+        """Overridden original method to fix regex that replaces dashes in links"""
+        message = re.sub(
+            r":([a-zA-Z0-9<>/:])([^ <>/:]+):",  # overridden regex
+            lambda x: ":{}{}:".format(x.group(1), x.group(2).replace("-", "_")),
+            message,
+        )
+
+        # https://github.com/Ranks/emojione/issues/114
+        message = message.replace(":simple_smile:", ":slightly_smiling_face:")
+        return message
+
     def _sub_hyperlink(self, matchobj):
         compound = matchobj.group(0)[1:-1]
         if len(compound.split("|")) == 2:

--- a/engine/apps/slack/tests/test_slack_formatter.py
+++ b/engine/apps/slack/tests/test_slack_formatter.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from apps.slack.slack_formatter import SlackFormatter
+
+
+@pytest.mark.django_db
+def test_slack_to_accepted_emoji():
+    sf = SlackFormatter(MagicMock())
+    test_message = """[:book: Runbook:link:](https://example-test.com/explore?panes=%7B:%7Bname-with-dash%22:%22FE%22:%5B%7B%22another-one%22:namespace-with-dash)
+Test emoji :male-construction-worker:https://another-example.com/test:=%22-dash
+:female-construction-worker:"""
+    expected_result = test_message.replace("-construction-worker", "_construction_worker")
+    result = sf.slack_to_accepted_emoji(test_message)
+    assert result == expected_result


### PR DESCRIPTION
# What this PR does
Fix alert group rendering when some links were broken because of replacing `-` to `_`.

## Which issue(s) this PR fixes
https://github.com/grafana/support-escalations/issues/8119
https://github.com/grafana/support-escalations/issues/8468

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
