### PR TITLE
Change service account auth to use instance id instead

### DIFF
--- a/engine/apps/auth_token/tests/test_grafana_auth.py
+++ b/engine/apps/auth_token/tests/test_grafana_auth.py
@@ -5,12 +5,7 @@ import pytest
 from rest_framework import exceptions
 from rest_framework.test import APIRequestFactory
 
-from apps.auth_token.auth import (
-    GRAFANA_SA_PREFIX,
-    X_GRAFANA_INSTANCE_SLUG,
-    X_GRAFANA_ORG_SLUG,
-    GrafanaServiceAccountAuthentication,
-)
+from apps.auth_token.auth import GRAFANA_SA_PREFIX, X_GRAFANA_INSTANCE_ID, GrafanaServiceAccountAuthentication
 from settings.base import CLOUD_LICENSE_NAME, OPEN_SOURCE_LICENSE_NAME, SELF_HOSTED_SETTINGS
 
 
@@ -24,7 +19,10 @@ def test_grafana_authentication_oss_inputs(make_organization, settings):
 
     headers, token = check_common_inputs()
     organization = make_organization(
-        stack_slug=SELF_HOSTED_SETTINGS["STACK_SLUG"], org_slug=SELF_HOSTED_SETTINGS["ORG_SLUG"]
+        stack_id=SELF_HOSTED_SETTINGS["STACK_ID"],
+        org_id=SELF_HOSTED_SETTINGS["ORG_ID"],
+        stack_slug=SELF_HOSTED_SETTINGS["STACK_SLUG"],
+        org_slug=SELF_HOSTED_SETTINGS["ORG_SLUG"],
     )
     request = APIRequestFactory().get("/", **headers)
     with patch(
@@ -40,15 +38,13 @@ def test_grafana_authentication_cloud_inputs(make_organization, settings):
     settings.LICENSE = CLOUD_LICENSE_NAME
     headers, token = check_common_inputs()
 
-    test_org_slug = "test_org_123"
-    test_stack_slug = "test_stack_123"
-    headers[f"HTTP_{X_GRAFANA_ORG_SLUG}"] = test_org_slug
-    headers[f"HTTP_{X_GRAFANA_INSTANCE_SLUG}"] = test_stack_slug
+    test_instance_id = "123"
+    headers[f"HTTP_{X_GRAFANA_INSTANCE_ID}"] = test_instance_id
     request = APIRequestFactory().get("/", **headers)
     with pytest.raises(exceptions.AuthenticationFailed):
         GrafanaServiceAccountAuthentication().authenticate(request)
 
-    organization = make_organization(stack_slug=test_stack_slug, org_slug=test_org_slug)
+    organization = make_organization(stack_id=test_instance_id)
     with patch(
         "apps.auth_token.auth.GrafanaServiceAccountAuthentication.authenticate_credentials",
         wraps=fake_authenticate_credentials,


### PR DESCRIPTION
# What this PR does
Change GrafanaServiceAccountAuth to use instance ID header in cloud instead of slugs.

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
