### PR TITLE
Move new alert group metric creation into async task

### DIFF
--- a/engine/apps/alerts/tasks/notify_user.py
+++ b/engine/apps/alerts/tasks/notify_user.py
@@ -8,7 +8,7 @@ from kombu.utils.uuid import uuid as celery_uuid
 from apps.alerts.constants import NEXT_ESCALATION_DELAY
 from apps.alerts.signals import user_notification_action_triggered_signal
 from apps.base.messaging import get_messaging_backend_from_id
-from apps.metrics_exporter.helpers import metrics_update_user_cache
+from apps.metrics_exporter.tasks import update_metrics_for_user
 from apps.phone_notifications.phone_backend import PhoneBackend
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 
@@ -187,7 +187,7 @@ def notify_user_task(
                     alert_group_id=alert_group_pk,
                 ).exists()
             ):
-                metrics_update_user_cache(user)
+                update_metrics_for_user.apply_async((user.id,))
 
             log_record.save()
             if notify_user_task.request.retries == 0:

--- a/engine/apps/metrics_exporter/apps.py
+++ b/engine/apps/metrics_exporter/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class MetricsExporterConfig(AppConfig):
+    name = "apps.metrics_exporter"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/engine/apps/metrics_exporter/metrics_cache_manager.py
+++ b/engine/apps/metrics_exporter/metrics_cache_manager.py
@@ -43,10 +43,10 @@ class MetricsCacheManager:
     def update_integration_states_diff(metrics_dict, integration_id, previous_state=None, new_state=None):
         metrics_dict.setdefault(integration_id, MetricsCacheManager.get_default_states_diff_dict())
         if previous_state:
-            state_value = previous_state.value
+            state_value = previous_state
             metrics_dict[integration_id]["previous_states"][state_value] += 1
         if new_state:
-            state_value = new_state.value
+            state_value = new_state
             metrics_dict[integration_id]["new_states"][state_value] += 1
         return metrics_dict
 

--- a/engine/apps/metrics_exporter/signals.py
+++ b/engine/apps/metrics_exporter/signals.py
@@ -1,0 +1,10 @@
+from apps.alerts.signals import alert_group_created_signal
+
+from .tasks import update_metrics_for_new_alert_group
+
+
+def on_alert_group_created(**kwargs):
+    update_metrics_for_new_alert_group.apply_async((kwargs["alert_group"].id,))
+
+
+alert_group_created_signal.connect(on_alert_group_created)

--- a/engine/apps/metrics_exporter/signals.py
+++ b/engine/apps/metrics_exporter/signals.py
@@ -1,10 +1,14 @@
+from apps.alerts.constants import AlertGroupState
 from apps.alerts.signals import alert_group_created_signal
-
-from .tasks import update_metrics_for_new_alert_group
 
 
 def on_alert_group_created(**kwargs):
-    update_metrics_for_new_alert_group.apply_async((kwargs["alert_group"].id,))
+    alert_group = kwargs["alert_group"]
+    if alert_group.is_maintenance_incident is True:
+        return
+    alert_group._update_metrics(
+        organization_id=alert_group.channel.organization_id, previous_state=None, state=AlertGroupState.FIRING
+    )
 
 
 alert_group_created_signal.connect(on_alert_group_created)

--- a/engine/apps/metrics_exporter/tests/test_calculation_metrics.py
+++ b/engine/apps/metrics_exporter/tests/test_calculation_metrics.py
@@ -11,7 +11,7 @@ from apps.metrics_exporter.helpers import (
 from apps.metrics_exporter.tasks import calculate_and_cache_metrics, calculate_and_cache_user_was_notified_metric
 
 
-@patch("apps.alerts.models.alert_group.MetricsCacheManager.metrics_update_state_cache_for_alert_group")
+@patch("apps.alerts.models.alert_group.update_metrics_for_alert_group.apply_async")
 @pytest.mark.django_db
 def test_calculate_and_cache_metrics_task(
     mocked_update_state_cache,
@@ -114,7 +114,7 @@ def test_calculate_and_cache_metrics_task(
         assert metric_alert_groups_response_time_values[1] == expected_result_metric_alert_groups_response_time
 
 
-@patch("apps.alerts.models.alert_group.MetricsCacheManager.metrics_update_state_cache_for_alert_group")
+@patch("apps.alerts.models.alert_group.update_metrics_for_alert_group.apply_async")
 @pytest.mark.django_db
 def test_calculate_and_cache_user_was_notified_metric_task(
     mocked_update_state_cache,

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -16,6 +16,8 @@ CELERY_TASK_ROUTES = {
     "apps.labels.tasks.update_labels_cache": {"queue": "default"},
     "apps.labels.tasks.update_instances_labels_cache": {"queue": "default"},
     "apps.metrics_exporter.tasks.start_calculate_and_cache_metrics": {"queue": "default"},
+    "apps.metrics_exporter.tasks.update_metrics_for_alert_group": {"queue": "default"},
+    "apps.metrics_exporter.tasks.update_metrics_for_user": {"queue": "default"},
     "apps.metrics_exporter.tasks.start_recalculation_for_new_metric": {"queue": "default"},
     "apps.metrics_exporter.tasks.save_organizations_ids_in_cache": {"queue": "default"},
     "apps.mobile_app.tasks.new_shift_swap_request.notify_shift_swap_requests": {"queue": "default"},


### PR DESCRIPTION
# What this PR does

Moving metrics creation into separate task to make alert ingestion more robust

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
