### PR TITLE
Handle scientific notation org/stack ids coming from plugin

### DIFF
--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -89,6 +89,12 @@ class BasePluginAuthentication(BaseAuthentication):
             raise exceptions.AuthenticationFailed("Invalid instance context.")
 
         try:
+            context["stack_id"] = int(float(context["stack_id"]))
+            context["org_id"] = int(float(context["org_id"]))
+        except ValueError:
+            raise exceptions.AuthenticationFailed("Invalid instance context.")
+
+        try:
             auth_token = check_token(token_string, context=context)
             if not auth_token.organization:
                 raise exceptions.AuthenticationFailed("No organization associated with token.")


### PR DESCRIPTION
Sample [log](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22I_o%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22amixr-prod%5C%22,%20cluster%3D%5C%22prod-eu-west-0%5C%22%7D%20%7C%3D%20%5C%22google_trace_id%3De1f3208eac578a3c102bbc64318a98a0%2F982423997271289103%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-24h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)

This requires a better fix in [frontend](https://github.com/grafana/oncall/blob/7aa78f5f73f9403cbd554600d52ebfb72b6c4abd/grafana-plugin/src/plugin.json#L103)