### PR TITLE
Fix monaco editor height

### DIFF
--- a/grafana-plugin/src/assets/style/utils.css
+++ b/grafana-plugin/src/assets/style/utils.css
@@ -64,6 +64,11 @@
   height: 100%;
 }
 
+.u-width-height-100 {
+  width: 100%;
+  height: 100%;
+}
+
 .u-display-block {
   display: block;
 }

--- a/grafana-plugin/src/components/MonacoEditor/MonacoEditor.tsx
+++ b/grafana-plugin/src/components/MonacoEditor/MonacoEditor.tsx
@@ -100,7 +100,7 @@ const MonacoEditor: FC<MonacoEditorProps> = (props) => {
       height={height}
       onEditorDidMount={handleMount}
       getSuggestions={useAutoCompleteList ? autoCompleteList : undefined}
-      containerStyles="u-width-100"
+      containerStyles="u-width-height-100"
     />
   );
 };

--- a/grafana-plugin/src/containers/IntegrationTemplate/IntegrationTemplate.module.scss
+++ b/grafana-plugin/src/containers/IntegrationTemplate/IntegrationTemplate.module.scss
@@ -65,3 +65,7 @@
 .template-block-codeeditor div[aria-label='Code editor container'] {
   border-bottom: none;
 }
+
+.template-editor-block-content {
+  height: calc(100% - 60px);
+}

--- a/grafana-plugin/src/containers/IntegrationTemplate/IntegrationTemplate.tsx
+++ b/grafana-plugin/src/containers/IntegrationTemplate/IntegrationTemplate.tsx
@@ -23,7 +23,6 @@ import { AlertTemplatesDTO } from 'models/alert_templates';
 import { Alert } from 'models/alertgroup/alertgroup.types';
 import { ChannelFilter } from 'models/channel_filter/channel_filter.types';
 import { TemplateOptions } from 'pages/integration/Integration.config';
-import { waitForElement } from 'utils/DOM';
 import LocationHelper from 'utils/LocationHelper';
 import { UserActions } from 'utils/authorization';
 
@@ -179,7 +178,7 @@ const IntegrationTemplate = observer((props: IntegrationTemplateProps) => {
       width={'95%'}
     >
       <div className={cx('container-wrapper')}>
-        <div className={cx('container')} id={'content-container-id'}>
+        <div className={cx('container')}>
           <TemplatesAlertGroupsList
             templatePage={TEMPLATE_PAGE.Integrations}
             alertReceiveChannelId={id}

--- a/grafana-plugin/src/containers/IntegrationTemplate/IntegrationTemplate.tsx
+++ b/grafana-plugin/src/containers/IntegrationTemplate/IntegrationTemplate.tsx
@@ -50,7 +50,6 @@ const IntegrationTemplate = observer((props: IntegrationTemplateProps) => {
   const [alertGroupPayload, setAlertGroupPayload] = useState<JSON>(undefined);
   const [changedTemplateBody, setChangedTemplateBody] = useState<string>(templateBody);
   const [resultError, setResultError] = useState<string>(undefined);
-  const [editorHeight, setEditorHeight] = useState<string>(undefined);
   const [isRecentAlertGroupExisting, setIsRecentAlertGroupExisting] = useState<boolean>(false);
 
   useEffect(() => {
@@ -61,14 +60,6 @@ const IntegrationTemplate = observer((props: IntegrationTemplateProps) => {
       }
       LocationHelper.update(locationParams, 'partial');
     }
-  }, []);
-
-  useEffect(() => {
-    waitForElement('#content-container-id').then(() => {
-      const mainDiv = document.getElementById('content-container-id');
-      const height = mainDiv?.getBoundingClientRect().height - 59;
-      setEditorHeight(`${height}px`);
-    });
   }, []);
 
   const onShowCheatSheet = useCallback(() => {
@@ -241,7 +232,7 @@ const IntegrationTemplate = observer((props: IntegrationTemplateProps) => {
               value={changedTemplateBody}
               data={templates}
               showLineNumbers={true}
-              height={editorHeight}
+              height="100%"
               onChange={getChangeHandler()}
             />
           </div>

--- a/grafana-plugin/src/containers/TemplatesAlertGroupsList/TemplatesAlertGroupsList.module.css
+++ b/grafana-plugin/src/containers/TemplatesAlertGroupsList/TemplatesAlertGroupsList.module.css
@@ -40,9 +40,17 @@
   background-color: var(--background-secondary);
 }
 
+.alert-groups-editor {
+  height: calc(100% - 60px);
+}
+
 .alert-groups-editor div[aria-label='Code editor container'] {
   border-bottom: none;
   border-right: none;
+}
+
+.alert-groups-editor-withBadge {
+  height: calc(100% - 60px);
 }
 
 .alert-groups-editor-withBadge div[aria-label='Code editor container'] {

--- a/grafana-plugin/src/containers/TemplatesAlertGroupsList/TemplatesAlertGroupsList.tsx
+++ b/grafana-plugin/src/containers/TemplatesAlertGroupsList/TemplatesAlertGroupsList.tsx
@@ -17,8 +17,6 @@ import { useStore } from 'state/useStore';
 import styles from './TemplatesAlertGroupsList.module.css';
 
 const cx = cn.bind(styles);
-const HEADER_OF_CONTAINER_HEIGHT = 59;
-const BADGE_WITH_PADDINGS_HEIGHT = 42;
 
 export enum TEMPLATE_PAGE {
   Integrations,
@@ -70,18 +68,6 @@ const TemplatesAlertGroupsList = (props: TemplatesAlertGroupsListProps) => {
       });
     }
   }, []);
-
-  const getCodeEditorHeight = () => {
-    const mainDiv = document.getElementById('alerts-content-container-id');
-    const height = mainDiv?.getBoundingClientRect().height - HEADER_OF_CONTAINER_HEIGHT;
-    return `${height}px`;
-  };
-
-  const getCodeEditorHeightWithBadge = () => {
-    const mainDiv = document.getElementById('alerts-content-container-id');
-    const height = mainDiv?.getBoundingClientRect().height - HEADER_OF_CONTAINER_HEIGHT - BADGE_WITH_PADDINGS_HEIGHT;
-    return `${height}px`;
-  };
 
   const getChangeHandler = () => {
     return debounce((value: string) => {
@@ -158,7 +144,7 @@ const TemplatesAlertGroupsList = (props: TemplatesAlertGroupsListProps) => {
                 ...MONACO_EDITABLE_CONFIG,
                 readOnly: false,
               }}
-              height={getCodeEditorHeight()}
+              height="100%"
               onChange={getChangeHandler()}
             />
           </div>
@@ -271,7 +257,7 @@ const TemplatesAlertGroupsList = (props: TemplatesAlertGroupsListProps) => {
           <MonacoEditor
             value={JSON.stringify(selectedPayload, null, 4)}
             data={templates}
-            height={getCodeEditorHeight()}
+            height="100%"
             onChange={getChangeHandler()}
             showLineNumbers
             useAutoCompleteList={false}
@@ -310,7 +296,7 @@ const TemplatesAlertGroupsList = (props: TemplatesAlertGroupsListProps) => {
               value={JSON.stringify(selectedPayload, null, 4)}
               data={undefined}
               disabled
-              height={getCodeEditorHeightWithBadge()}
+              height="100%"
               onChange={getChangeHandler()}
               useAutoCompleteList={false}
               language={MONACO_LANGUAGE.json}

--- a/grafana-plugin/src/containers/WebhooksTemplateEditor/WebhooksTemplateEditor.tsx
+++ b/grafana-plugin/src/containers/WebhooksTemplateEditor/WebhooksTemplateEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { Button, Drawer, HorizontalGroup, VerticalGroup } from '@grafana/ui';
 import cn from 'classnames/bind';
@@ -13,7 +13,6 @@ import TemplateResult from 'containers/TemplateResult/TemplateResult';
 import TemplatesAlertGroupsList, { TEMPLATE_PAGE } from 'containers/TemplatesAlertGroupsList/TemplatesAlertGroupsList';
 import { WithPermissionControlTooltip } from 'containers/WithPermissionControl/WithPermissionControlTooltip';
 import { OutgoingWebhook } from 'models/outgoing_webhook/outgoing_webhook.types';
-import { waitForElement } from 'utils/DOM';
 import { UserActions } from 'utils/authorization';
 
 const cx = cn.bind(styles);
@@ -35,17 +34,8 @@ interface WebhooksTemplateEditorProps {
 const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ template, id, onHide, handleSubmit }) => {
   const [isCheatSheetVisible, setIsCheatSheetVisible] = useState<boolean>(false);
   const [changedTemplateBody, setChangedTemplateBody] = useState<string>(template.value);
-  const [editorHeight, setEditorHeight] = useState<string>(undefined);
   const [selectedPayload, setSelectedPayload] = useState(undefined);
   const [resultError, setResultError] = useState<string>(undefined);
-
-  useEffect(() => {
-    waitForElement('#content-container-id').then(() => {
-      const mainDiv = document.getElementById('content-container-id');
-      const height = mainDiv?.getBoundingClientRect().height - 59;
-      setEditorHeight(`${height}px`);
-    });
-  }, []);
 
   const getChangeHandler = () => {
     return debounce((value: string) => {
@@ -110,7 +100,7 @@ const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ templat
       width="95%"
     >
       <div className={cx('container-wrapper')}>
-        <div className={cx('container')} id={'content-container-id'}>
+        <div className={cx('container')}>
           <TemplatesAlertGroupsList
             heading="Last events"
             templatePage={TEMPLATE_PAGE.Webhooks}
@@ -148,7 +138,7 @@ const WebhooksTemplateEditor: React.FC<WebhooksTemplateEditorProps> = ({ templat
                     value={template.value}
                     data={{ payload_example: selectedPayload }}
                     showLineNumbers={true}
-                    height={editorHeight}
+                    height="100%"
                     onChange={getChangeHandler()}
                     suggestionPrefix=""
                   />


### PR DESCRIPTION
# What this PR does
Use css height: 100% instead of manually calculating height of monaco editor

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2351

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
