### PR TITLE
Make telegram on_alert_group_action_triggered asynchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ endpoint currently) @mderynck ([#3189](https://github.com/grafana/oncall/pull/31
 - Filters polishing ([3183](https://github.com/grafana/oncall/issues/3183))
 - Fixed permissions so User settings reader role included list users @mderynck ([#3419](https://github.com/grafana/oncall/pull/3419))
 - Fixed alert group rendering when some links were broken because of replacing `-` to `_` @Ferril ([#3424](https://github.com/grafana/oncall/pull/3424))
+- Make telegram on_alert_group_action_triggered asynchronous([#3471](https://github.com/grafana/oncall/pull/3471))
 
 ## v1.3.62 (2023-11-21)
 

--- a/engine/apps/telegram/alert_group_representative.py
+++ b/engine/apps/telegram/alert_group_representative.py
@@ -80,7 +80,7 @@ class AlertGroupTelegramRepresentative(AlertGroupAbstractRepresentative):
         from apps.alerts.models import AlertGroupLogRecord
 
         log_record = kwargs["log_record"]
-        if not isinstance(log_record, AlertGroupLogRecord):
+        if isinstance(log_record, AlertGroupLogRecord):
             log_record_id = log_record.pk
         else:
             log_record_id = log_record

--- a/engine/apps/telegram/alert_group_representative.py
+++ b/engine/apps/telegram/alert_group_representative.py
@@ -3,9 +3,11 @@ import logging
 from apps.alerts.models import AlertGroup
 from apps.alerts.representative import AlertGroupAbstractRepresentative
 from apps.telegram.models import TelegramMessage
-from apps.telegram.tasks import edit_message, on_create_alert_telegram_representative_async
-
-from .tasks import on_alert_group_action_triggered_async
+from apps.telegram.tasks import (
+    edit_message,
+    on_alert_group_action_triggered_async,
+    on_create_alert_telegram_representative_async,
+)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/engine/apps/telegram/tasks.py
+++ b/engine/apps/telegram/tasks.py
@@ -19,8 +19,6 @@ from apps.telegram.models import TelegramMessage, TelegramToOrganizationConnecto
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 from common.utils import OkToRetry
 
-from .alert_group_representative import AlertGroupTelegramRepresentative
-
 logger = get_task_logger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -224,6 +222,8 @@ def on_create_alert_telegram_representative_async(self, alert_pk):
 )
 def on_alert_group_action_triggered_async(log_record_id):
     from apps.alerts.models import AlertGroupLogRecord
+
+    from .alert_group_representative import AlertGroupTelegramRepresentative
 
     logger.info(f"AlertGroupTelegramRepresentative ACTION SIGNAL, log record {log_record_id}")
 

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -159,6 +159,7 @@ CELERY_TASK_ROUTES = {
     "apps.telegram.tasks.register_telegram_webhook": {"queue": "telegram"},
     "apps.telegram.tasks.send_link_to_channel_message_or_fallback_to_full_alert_group": {"queue": "telegram"},
     "apps.telegram.tasks.send_log_and_actions_message": {"queue": "telegram"},
+    "apps.telegram.alert_group_representative.on_alert_group_action_triggered_async": {"queue": "telegram"},
     # WEBHOOK
     "apps.alerts.tasks.custom_button_result.custom_button_result": {"queue": "webhook"},
     "apps.alerts.tasks.custom_webhook_result.custom_webhook_result": {"queue": "webhook"},

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -159,7 +159,7 @@ CELERY_TASK_ROUTES = {
     "apps.telegram.tasks.register_telegram_webhook": {"queue": "telegram"},
     "apps.telegram.tasks.send_link_to_channel_message_or_fallback_to_full_alert_group": {"queue": "telegram"},
     "apps.telegram.tasks.send_log_and_actions_message": {"queue": "telegram"},
-    "apps.telegram.alert_group_representative.on_alert_group_action_triggered_async": {"queue": "telegram"},
+    "apps.telegram.tasks.on_alert_group_action_triggered_async": {"queue": "telegram"},
     # WEBHOOK
     "apps.alerts.tasks.custom_button_result.custom_button_result": {"queue": "webhook"},
     "apps.alerts.tasks.custom_webhook_result.custom_webhook_result": {"queue": "webhook"},


### PR DESCRIPTION
# What this PR does

[send_alert_group_signal](https://github.com/grafana/oncall/blob/dev/engine/apps/alerts/tasks/send_alert_group_signal.py#L12) task is not idempotent. It launches [on_alert_group_action_triggered_async](https://github.com/grafana/oncall/blob/a2851d3f813c04768ce825c8af99e26912d80b4e/engine/apps/slack/representatives/alert_group_representative.py#L158) for slack and then might fail on [on_alert_group_action_triggered](https://github.com/grafana/oncall/blob/b2f4ffb98a940b894042df9161e209dc8a781dc1/engine/apps/telegram/alert_group_representative.py#L79) (not async) due to database DoesNotExist exception.

This PR makes telegram representative asyncronous

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
