### PR TITLE
Pass correct params when using retryFailingPromises

### DIFF
--- a/grafana-plugin/src/state/rootBaseStore/index.ts
+++ b/grafana-plugin/src/state/rootBaseStore/index.ts
@@ -125,10 +125,10 @@ export class RootBaseStore {
     };
 
     await retryFailingPromises([
-      this.userStore.loadCurrentUser,
-      this.organizationStore.loadCurrentOrganization,
-      this.grafanaTeamStore.updateItems,
-      updateFeatures,
+      () => this.userStore.loadCurrentUser(),
+      () => this.organizationStore.loadCurrentOrganization(),
+      () => this.grafanaTeamStore.updateItems(),
+      () => updateFeatures(),
     ]);
     this.isBasicDataLoaded = true;
   }

--- a/grafana-plugin/src/utils/async.test.ts
+++ b/grafana-plugin/src/utils/async.test.ts
@@ -8,7 +8,10 @@ describe('retryFailingPromises', () => {
     let attempts1 = 0;
     let attempts2 = 0;
     let attempts3 = 0;
-    const fetch1 = async () => Promise.resolve(++attempts1);
+    const fetch1 = (param = 'param') => {
+      ++attempts1;
+      return Promise.resolve(param);
+    };
     const fetch2 = async () => Promise.reject(++attempts2);
     const fetch3 = async () =>
       new Promise((resolve, reject) => {
@@ -19,13 +22,16 @@ describe('retryFailingPromises', () => {
         reject(attempts3);
       });
 
-    const result = await retryFailingPromises([fetch1, fetch2, fetch3], { maxAttempts: MAX_ATTEMPTS, delayInMs: 50 });
+    const result = await retryFailingPromises([() => fetch1(), fetch2, fetch3], {
+      maxAttempts: MAX_ATTEMPTS,
+      delayInMs: 50,
+    });
 
     expect(attempts1).toBe(1);
     expect(attempts2).toBe(MAX_ATTEMPTS);
     expect(attempts3).toBe(2);
     expect(result).toEqual([
-      { status: 'fulfilled', value: 1 },
+      { status: 'fulfilled', value: 'param' },
       { status: 'rejected', reason: 5 },
       { status: 'fulfilled', value: 2 },
     ]);

--- a/grafana-plugin/src/utils/async.ts
+++ b/grafana-plugin/src/utils/async.ts
@@ -1,7 +1,7 @@
-import { retry } from '@lifeomic/attempt';
+import { AttemptContext, retry } from '@lifeomic/attempt';
 
 export const retryFailingPromises = async (
-  asyncActions: Array<() => Promise<unknown>>,
+  asyncActions: Array<(ctx?: AttemptContext) => Promise<unknown>>,
   { maxAttempts = 3, delayInMs = 500 }: { maxAttempts?: number; delayInMs?: number } = {}
 ) =>
   maxAttempts === 0


### PR DESCRIPTION
# What this PR does
Pass correct params to functions when using retryFailingPromises

## Which issue(s) this PR fixes
https://github.com/grafana/oncall/issues/3479

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
