### PR TITLE
Refactor gcom api calls when syncing org

### DIFF
--- a/engine/apps/grafana_plugin/helpers/client.py
+++ b/engine/apps/grafana_plugin/helpers/client.py
@@ -371,11 +371,7 @@ class GcomAPIClient(APIClient):
             or feature_enabled_via_enable_key_comma_delimited
         )
 
-    def is_rbac_enabled_for_stack(self, stack_id: str) -> bool:
-        """
-        NOTE: must use an "Admin" GCOM token when calling this method
-        """
-        instance_info = self.get_instance_info(stack_id, True)
+    def is_rbac_enabled_for_instance(self, instance_info: GCOMInstanceInfo = None) -> bool:
         if not instance_info:
             return False
         return self._feature_toggle_is_enabled(instance_info, "accessControlOnCall")

--- a/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
@@ -12,7 +12,7 @@ class TestIsRbacEnabledForStack:
     TEST_FEATURE_TOGGLE = "helloWorld"
 
     @pytest.mark.parametrize(
-        "gcom_api_response,expected",
+        "instance_info,expected",
         [
             (None, False),
             ({}, False),
@@ -22,16 +22,9 @@ class TestIsRbacEnabledForStack:
             ({"config": {"feature_toggles": {"accessControlOnCall": "true"}}}, True),
         ],
     )
-    @patch("apps.grafana_plugin.helpers.client.GcomAPIClient.api_get")
-    def test_it_returns_based_on_feature_toggle_value(
-        self, mocked_gcom_api_client_api_get, gcom_api_response, expected
-    ):
-        stack_id = 5
-        mocked_gcom_api_client_api_get.return_value = (gcom_api_response, {"status_code": 200})
-
+    def test_it_returns_based_on_feature_toggle_value(self, instance_info, expected):
         api_client = GcomAPIClient("someFakeApiToken")
-        assert api_client.is_rbac_enabled_for_stack(stack_id) == expected
-        assert mocked_gcom_api_client_api_get.called_once_with(f"instances/{stack_id}?config=true")
+        assert api_client.is_rbac_enabled_for_instance(instance_info) == expected
 
     @pytest.mark.parametrize(
         "instance_info_feature_toggles,delimiter,expected",

--- a/engine/apps/user_management/tests/test_sync.py
+++ b/engine/apps/user_management/tests/test_sync.py
@@ -312,18 +312,36 @@ def test_sync_organization_is_rbac_permissions_enabled_open_source(make_organiza
     assert organization.is_rbac_permissions_enabled == grafana_api_response
 
 
-@pytest.mark.parametrize("gcom_api_response", [False, True])
-@patch("apps.user_management.sync.GcomAPIClient")
-@override_settings(LICENSE=settings.CLOUD_LICENSE_NAME)
-@override_settings(GRAFANA_COM_ADMIN_API_TOKEN="mockedToken")
+@patch("apps.user_management.sync.GcomAPIClient.api_get")
+@pytest.mark.parametrize(
+    "instance_info,expected",
+    [
+        ({"config": {"feature_toggles": {}}}, False),
+        ({"config": {"feature_toggles": {"accessControlOnCall": "false"}}}, False),
+        ({"config": {"feature_toggles": {"accessControlOnCall": "true"}}}, True),
+    ],
+)
 @pytest.mark.django_db
-def test_sync_organization_is_rbac_permissions_enabled_cloud(mocked_gcom_client, make_organization, gcom_api_response):
+def test_sync_organization_is_rbac_permissions_enabled_cloud(
+    mocked_gcom_client, make_organization, instance_info, expected
+):
     stack_id = 5
-    organization = make_organization(stack_id=stack_id)
+    organization = make_organization(stack_id=stack_id, gcom_token="TEST_GCOM_TOKEN")
 
     api_check_token_call_status = {"connected": True}
 
-    mocked_gcom_client.return_value.is_rbac_enabled_for_stack.return_value = gcom_api_response
+    instance_info.update(
+        {
+            "orgId": organization.org_id,
+            "slug": organization.stack_slug,
+            "orgSlug": organization.org_slug,
+            "orgName": organization.org_title,
+            "regionSlug": organization.region_slug,
+            "url": organization.grafana_url,
+            "clusterSlug": organization.cluster_slug,
+        }
+    )
+    mocked_gcom_client.return_value = (instance_info, {"status_code": 200})
 
     api_users_response = (
         {
@@ -367,10 +385,7 @@ def test_sync_organization_is_rbac_permissions_enabled_cloud(mocked_gcom_client,
                         sync_organization(organization)
 
     organization.refresh_from_db()
-
-    assert mocked_gcom_client.return_value.called_once_with("mockedToken")
-    assert mocked_gcom_client.return_value.is_rbac_enabled_for_stack.called_once_with(stack_id)
-    assert organization.is_rbac_permissions_enabled == gcom_api_response
+    assert organization.is_rbac_permissions_enabled == expected
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Make one API call instead of two.