### PR TITLE
Pin markdown2 to 2.4.10

### DIFF
--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -54,3 +54,4 @@ lxml==4.9.2
 babel==2.12.1
 drf-spectacular==0.26.5
 grpcio==1.57.0
+markdown2==2.4.10


### PR DESCRIPTION
# What this PR does

Pins markdown to 2.4.10 to fix [failing test](https://github.com/grafana/oncall/actions/runs/7082829248/job/19276914906?pr=3490).

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
