### PR TITLE
Skip empty alert group labels

### DIFF
--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -103,6 +103,10 @@ def _custom_labels(alert_receive_channel: "AlertReceiveChannel", raw_request_dat
         value = rendered_labels[key]
 
         # check value length
+        if len(value) == 0:
+            logger.warning("Template result value is empty. %s", value)
+            continue
+
         if len(value) > MAX_VALUE_NAME_LENGTH:
             logger.warning("Template result value is too long. %s", value)
             continue
@@ -147,11 +151,19 @@ def _template_labels(alert_receive_channel: "AlertReceiveChannel", raw_request_d
         value = str(value)
 
         # check key length
+        if len(key) == 0:
+            logger.warning("Template result key is empty. %s", key)
+            continue
+
         if len(key) > MAX_KEY_NAME_LENGTH:
             logger.warning("Template result key is too long. %s", key)
             continue
 
         # check value length
+        if len(value) == 0:
+            logger.warning("Template result value is empty. %s", value)
+            continue
+
         if len(value) > MAX_VALUE_NAME_LENGTH:
             logger.warning("Template result value is too long. %s", value)
             continue

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -46,6 +46,7 @@ def test_assign_labels(
     label_key_1 = make_label_key(organization=organization, key_name="c")
     label_key_2 = make_label_key(organization=organization)
     label_key_3 = make_label_key(organization=organization)
+    label_key_4 = make_label_key(organization=organization)
 
     # create alert receive channel with all 3 types of labels
     alert_receive_channel = make_alert_receive_channel(
@@ -56,6 +57,7 @@ def test_assign_labels(
             [label_key_2.id, "nonexistent", None],  # plain label with nonexistent value ID
             [label_key_1.id, None, "{{ payload.c }}"],  # templated label
             [label_key_3.id, None, TOO_LONG_VALUE_NAME],  # templated label too long
+            [label_key_4.id, None, "{{ payload.nonexistent }}"],  # templated label with nonexistent key
         ],
         alert_group_labels_template="{{ payload.advanced_template | tojson }}",
     )
@@ -94,8 +96,6 @@ def test_assign_labels(
 def test_assign_labels_custom_labels_none(
     make_organization,
     make_alert_receive_channel,
-    make_label_key_and_value,
-    make_label_key,
     make_integration_label_association,
 ):
     organization = make_organization()


### PR DESCRIPTION
# What this PR does

Makes sure there are no empty alert group label values.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
