### PR TITLE
Do not trigger alert group update log signal before setting alert

### DIFF
--- a/engine/apps/alerts/models/alert_group_log_record.py
+++ b/engine/apps/alerts/models/alert_group_log_record.py
@@ -61,6 +61,12 @@ class AlertGroupLogRecord(models.Model):
         TYPE_RESTRICTED,
     ) = range(26)
 
+    TYPES_SKIPPING_UPDATE_SIGNAL = (
+        TYPE_DELETED,
+        TYPE_REGISTERED,  # set on creation before having an alert assigned, skip to avoid retries
+        TYPE_ROUTE_ASSIGNED,  # set on creation before having an alert assigned, skip to avoid retries
+    )
+
     TYPES_FOR_LICENCE_CALCULATION = (
         TYPE_ACK,
         TYPE_UN_ACK,
@@ -590,7 +596,7 @@ class AlertGroupLogRecord(models.Model):
 
 @receiver(post_save, sender=AlertGroupLogRecord)
 def listen_for_alertgrouplogrecord(sender, instance, created, *args, **kwargs):
-    if instance.type != AlertGroupLogRecord.TYPE_DELETED:
+    if instance.type not in AlertGroupLogRecord.TYPES_SKIPPING_UPDATE_SIGNAL:
         alert_group_pk = instance.alert_group.pk
         logger.debug(
             f"send_update_log_report_signal for alert_group {alert_group_pk}, "

--- a/engine/apps/alerts/tests/test_alert_group_log_record.py
+++ b/engine/apps/alerts/tests/test_alert_group_log_record.py
@@ -1,0 +1,39 @@
+from unittest.mock import patch
+
+import pytest
+
+from apps.alerts.models import AlertGroupLogRecord
+
+
+@pytest.mark.django_db
+def test_skip_update_signal(
+    make_organization_with_slack_team_identity,
+    make_alert_receive_channel,
+    make_alert_group,
+):
+    organization, _ = make_organization_with_slack_team_identity()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    for skip_type in AlertGroupLogRecord.TYPES_SKIPPING_UPDATE_SIGNAL:
+        with patch("apps.alerts.tasks.send_update_log_report_signal") as mock_update_log_signal:
+            alert_group.log_records.create(type=skip_type)
+        assert not mock_update_log_signal.apply_async.called
+
+
+@pytest.mark.django_db
+def test_trigger_update_signal(
+    make_organization_with_slack_team_identity,
+    make_alert_receive_channel,
+    make_alert_group,
+):
+    organization, _ = make_organization_with_slack_team_identity()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    for log_type, _ in AlertGroupLogRecord.TYPE_CHOICES:
+        if log_type in AlertGroupLogRecord.TYPES_SKIPPING_UPDATE_SIGNAL:
+            continue
+        with patch("apps.alerts.tasks.send_update_log_report_signal") as mock_update_log_signal:
+            alert_group.log_records.create(type=log_type)
+        mock_update_log_signal.apply_async.assert_called_once()


### PR DESCRIPTION
Do not trigger update log report signal until there is an alert set for the [recently created alert group](https://github.com/grafana/oncall/blob/dev/engine/apps/alerts/models/alert.py#L110) to avoid retries when trying to post an updated report when there isn't yet a message posted (or an alert to render).