### PR TITLE
Return 404 from mobile app gateway viewset

### DIFF
--- a/engine/apps/api/views/labels.py
+++ b/engine/apps/api/views/labels.py
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
 
 class LabelsFeatureFlagViewSet(ViewSet):
     def initial(self, request, *args, **kwargs):
-        super().initial(request, *args, **kwargs)
         if not is_labels_feature_enabled(self.request.auth.organization):
             raise NotFound
+        super().initial(request, *args, **kwargs)
 
 
 class LabelsViewSet(LabelsFeatureFlagViewSet):

--- a/engine/apps/mobile_app/tests/test_mobile_app_gateway.py
+++ b/engine/apps/mobile_app/tests/test_mobile_app_gateway.py
@@ -23,11 +23,9 @@ MOCK_JWT_PRIVATE_KEY = "asd,mzcxn,vmnzxcv,mnzx,cvmnzaslkdjflaksjdf"
 
 
 @pytest.fixture(autouse=True)
-def setup_urls(settings, reload_urls):
+def enable_mobile_app_gateway(settings):
     settings.MOBILE_APP_GATEWAY_ENABLED = True
     settings.MOBILE_APP_GATEWAY_RSA_PRIVATE_KEY = MOCK_JWT_PRIVATE_KEY
-
-    reload_urls("apps.mobile_app.urls")
 
 
 class MockResponse:

--- a/engine/apps/mobile_app/urls.py
+++ b/engine/apps/mobile_app/urls.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.urls import re_path
 
 from apps.mobile_app.fcm_relay import FCMRelayView
@@ -34,11 +33,10 @@ urlpatterns += [
     optional_slash_path("fcm_relay", FCMRelayView.as_view(), name="fcm_relay"),
 ]
 
-if settings.MOBILE_APP_GATEWAY_ENABLED:
-    urlpatterns += [
-        re_path(
-            r"^gateway/(?P<downstream_backend>\w*)/(?P<downstream_path>.*)$",
-            MobileAppGatewayView.as_view(),
-            name="gateway",
-        ),
-    ]
+urlpatterns += [
+    re_path(
+        r"^gateway/(?P<downstream_backend>\w*)/(?P<downstream_path>.*)$",
+        MobileAppGatewayView.as_view(),
+        name="gateway",
+    ),
+]

--- a/engine/apps/mobile_app/views.py
+++ b/engine/apps/mobile_app/views.py
@@ -99,6 +99,12 @@ class MobileAppGatewayView(APIView):
         SupportedDownstreamBackends.INCIDENT,
     ]
 
+    def initial(self, request, *args, **kwargs):
+        # If the mobile app gateway is not enabled, return a 404
+        if not settings.MOBILE_APP_GATEWAY_ENABLED:
+            raise NotFound
+        super().initial(request, *args, **kwargs)
+
     @classmethod
     def _construct_jwt_payload(cls, user: "User") -> typing.Dict[str, typing.Any]:
         organization = user.organization


### PR DESCRIPTION
# What this PR does

Changes how the `MOBILE_APP_GATEWAY_ENABLED` feature flag enables/disables the mobile app gateway viewset.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
