### PR TITLE
Fix team changing on PUT request if team is not in request data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix setting integration team to default on update @Ferril ([#3530](https://github.com/grafana/oncall/pull/3530))
+
 ## v1.3.74 (2023-12-06)
 
 ### Fixed

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -20,7 +20,6 @@ from apps.user_management.models import Organization
 from common.api_helpers.custom_fields import TeamPrimaryKeyRelatedField
 from common.api_helpers.exceptions import BadRequest
 from common.api_helpers.mixins import APPEARANCE_TEMPLATE_NAMES, EagerLoadingMixin
-from common.api_helpers.utils import CurrentTeamDefault
 from common.jinja_templater import jinja_template_env
 
 from .integration_heartbeat import IntegrationHeartBeatSerializer
@@ -211,7 +210,7 @@ class AlertReceiveChannelSerializer(
     alert_groups_count = serializers.SerializerMethodField()
     author = serializers.CharField(read_only=True, source="author.public_primary_key")
     organization = serializers.CharField(read_only=True, source="organization.public_primary_key")
-    team = TeamPrimaryKeyRelatedField(allow_null=True, default=CurrentTeamDefault())
+    team = TeamPrimaryKeyRelatedField(allow_null=True, required=False)
     is_able_to_autoresolve = serializers.ReadOnlyField()
     default_channel_filter = serializers.SerializerMethodField()
     instructions = serializers.SerializerMethodField()
@@ -320,7 +319,12 @@ class AlertReceiveChannelSerializer(
 
         return instance
 
+    def to_internal_value(self, data):
+        print("TO INTERNAL: ", data)
+        return super().to_internal_value(data)
+
     def update(self, instance, validated_data):
+        print(validated_data)
         # update associated labels
         labels = validated_data.pop("labels", None)
         self.update_labels_association_if_needed(labels, instance, self.context["request"].auth.organization)

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -319,9 +319,6 @@ class AlertReceiveChannelSerializer(
 
         return instance
 
-    def to_internal_value(self, data):
-        return super().to_internal_value(data)
-
     def update(self, instance, validated_data):
         # update associated labels
         labels = validated_data.pop("labels", None)

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -320,11 +320,9 @@ class AlertReceiveChannelSerializer(
         return instance
 
     def to_internal_value(self, data):
-        print("TO INTERNAL: ", data)
         return super().to_internal_value(data)
 
     def update(self, instance, validated_data):
-        print(validated_data)
         # update associated labels
         labels = validated_data.pop("labels", None)
         self.update_labels_association_if_needed(labels, instance, self.context["request"].auth.organization)

--- a/engine/apps/api/serializers/escalation_chain.py
+++ b/engine/apps/api/serializers/escalation_chain.py
@@ -2,13 +2,13 @@ from rest_framework import serializers
 
 from apps.alerts.models import EscalationChain
 from common.api_helpers.custom_fields import TeamPrimaryKeyRelatedField
-from common.api_helpers.utils import CurrentOrganizationDefault, CurrentTeamDefault
+from common.api_helpers.utils import CurrentOrganizationDefault
 
 
 class EscalationChainSerializer(serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, source="public_primary_key")
     organization = serializers.HiddenField(default=CurrentOrganizationDefault())
-    team = TeamPrimaryKeyRelatedField(allow_null=True, default=CurrentTeamDefault())
+    team = TeamPrimaryKeyRelatedField(allow_null=True, required=False)
 
     class Meta:
         model = EscalationChain

--- a/engine/apps/api/serializers/schedule_base.py
+++ b/engine/apps/api/serializers/schedule_base.py
@@ -5,13 +5,13 @@ from apps.schedules.models import OnCallSchedule
 from apps.schedules.tasks import schedule_notify_about_empty_shifts_in_schedule, schedule_notify_about_gaps_in_schedule
 from common.api_helpers.custom_fields import TeamPrimaryKeyRelatedField
 from common.api_helpers.mixins import EagerLoadingMixin
-from common.api_helpers.utils import CurrentOrganizationDefault, CurrentTeamDefault
+from common.api_helpers.utils import CurrentOrganizationDefault
 
 
 class ScheduleBaseSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, source="public_primary_key")
     organization = serializers.HiddenField(default=CurrentOrganizationDefault())
-    team = TeamPrimaryKeyRelatedField(allow_null=True, default=CurrentTeamDefault())
+    team = TeamPrimaryKeyRelatedField(allow_null=True, required=False)
     slack_channel = serializers.SerializerMethodField()
     user_group = UserGroupSerializer()
     warnings = serializers.SerializerMethodField()

--- a/engine/apps/api/serializers/webhook.py
+++ b/engine/apps/api/serializers/webhook.py
@@ -8,7 +8,7 @@ from apps.webhooks.models import Webhook, WebhookResponse
 from apps.webhooks.models.webhook import PUBLIC_WEBHOOK_HTTP_METHODS, WEBHOOK_FIELD_PLACEHOLDER
 from apps.webhooks.presets.preset_options import WebhookPresetOptions
 from common.api_helpers.custom_fields import TeamPrimaryKeyRelatedField
-from common.api_helpers.utils import CurrentOrganizationDefault, CurrentTeamDefault, CurrentUserDefault
+from common.api_helpers.utils import CurrentOrganizationDefault, CurrentUserDefault
 from common.jinja_templater import apply_jinja_template
 from common.jinja_templater.apply_jinja_template import JinjaTemplateError, JinjaTemplateWarning
 
@@ -31,7 +31,7 @@ class WebhookResponseSerializer(serializers.ModelSerializer):
 class WebhookSerializer(LabelsSerializerMixin, serializers.ModelSerializer):
     id = serializers.CharField(read_only=True, source="public_primary_key")
     organization = serializers.HiddenField(default=CurrentOrganizationDefault())
-    team = TeamPrimaryKeyRelatedField(allow_null=True, default=CurrentTeamDefault())
+    team = TeamPrimaryKeyRelatedField(allow_null=True, required=False)
     user = serializers.HiddenField(default=CurrentUserDefault())
     forward_all = serializers.BooleanField(allow_null=True, required=False)
     last_response_log = serializers.SerializerMethodField()

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -2384,3 +2384,27 @@ def test_current_user_events_multiple_schedules(
     assert result["schedules"][1]["name"] in (schedule_1.name, schedule_2.name)
     assert len(result["schedules"][0]["events"]) > 0
     assert len(result["schedules"][1]["events"]) > 0
+
+
+@pytest.mark.django_db
+def test_team_not_updated_if_not_in_data(
+    make_organization_and_user_with_plugin_token,
+    make_team,
+    make_schedule,
+    make_user_auth_headers,
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    team = make_team(organization)
+    schedule = make_schedule(organization, team=team, schedule_class=OnCallScheduleWeb)
+
+    assert schedule.team == team
+
+    client = APIClient()
+    url = reverse("api-internal:schedule-detail", kwargs={"pk": schedule.public_primary_key})
+    data = {"name": "renamed", "type": 2}
+    response = client.put(url, data=data, format="json", **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["team"] == schedule.team.public_primary_key
+
+    schedule.refresh_from_db()
+    assert schedule.team == team


### PR DESCRIPTION
# What this PR does
Removes setting team to default value on PUT request to internal endpoints if team is not in request data.
(For integrations, escalation chains, schedules and webhooks)

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2368

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
