### PR TITLE
Don't update alert group metrics when deleting an alert group

### DIFF
--- a/engine/apps/alerts/tasks/delete_alert_group.py
+++ b/engine/apps/alerts/tasks/delete_alert_group.py
@@ -24,6 +24,8 @@ def delete_alert_group(alert_group_pk, user_pk):
         logger.debug("User not found, skipping delete_alert_group")
         return
 
+    logger.debug(f"User {user} is deleting alert group {alert_group} (channel: {alert_group.channel})")
+
     try:
         alert_group.delete_by_user(user)
     except SlackAPIRatelimitError as e:


### PR DESCRIPTION
# Which issue(s) this PR fixes

Fixes https://github.com/grafana/oncall-private/issues/2376

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
