### PR TITLE
Add error code for mobile notification logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Add error code for mobile push notification logs when device is not set up @Ferril ([#3554](https://github.com/grafana/oncall/pull/3554))
+
 ## v1.3.77 (2023-12-11)
 
 ### Fixed

--- a/engine/apps/base/models/user_notification_policy_log_record.py
+++ b/engine/apps/base/models/user_notification_policy_log_record.py
@@ -69,7 +69,8 @@ class UserNotificationPolicyLogRecord(models.Model):
         ERROR_NOTIFICATION_MESSAGING_BACKEND_ERROR,
         ERROR_NOTIFICATION_FORBIDDEN,
         ERROR_NOTIFICATION_TELEGRAM_USER_IS_DEACTIVATED,
-    ) = range(27)
+        ERROR_NOTIFICATION_MOBILE_USER_HAS_NO_ACTIVE_DEVICE,
+    ) = range(28)
 
     # for this errors we want to send message to general log channel
     ERRORS_TO_SEND_IN_SLACK_CHANNEL = [
@@ -264,6 +265,11 @@ class UserNotificationPolicyLogRecord(models.Model):
                 == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_TELEGRAM_USER_IS_DEACTIVATED
             ):
                 result += f"failed to send telegram message to {user_verbal} because user has been deactivated"
+            elif (
+                self.notification_error_code
+                == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_MOBILE_USER_HAS_NO_ACTIVE_DEVICE
+            ):
+                result += f"failed to send push notification to {user_verbal} because user has no device set up"
             else:
                 # TODO: handle specific backend errors
                 try:

--- a/engine/apps/mobile_app/tasks/new_alert_group.py
+++ b/engine/apps/mobile_app/tasks/new_alert_group.py
@@ -113,7 +113,7 @@ def notify_user_about_new_alert_group(user_pk, alert_group_pk, notification_poli
         logger.warning(f"User notification policy {notification_policy_pk} does not exist")
         return
 
-    def _create_error_log_record():
+    def _create_error_log_record(notification_error_code=None):
         """
         Utility method to create a UserNotificationPolicyLogRecord with error
         """
@@ -125,13 +125,14 @@ def notify_user_about_new_alert_group(user_pk, alert_group_pk, notification_poli
             reason="Mobile push notification error",
             notification_step=notification_policy.step,
             notification_channel=notification_policy.notify_by,
+            notification_error_code=notification_error_code,
         )
 
     device_to_notify = FCMDevice.get_active_device_for_user(user)
 
     # create an error log in case user has no devices set up
     if not device_to_notify:
-        _create_error_log_record()
+        _create_error_log_record(UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_MOBILE_USER_HAS_NO_ACTIVE_DEVICE)
         logger.error(f"Error while sending a mobile push notification: user {user_pk} has no device set up")
         return
 

--- a/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
+++ b/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
@@ -82,6 +82,10 @@ def test_notify_user_about_new_alert_group_no_device_connected(
 
     log_record = alert_group.personal_log_records.last()
     assert log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED
+    assert (
+        log_record.notification_error_code
+        == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_MOBILE_USER_HAS_NO_ACTIVE_DEVICE
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# What this PR does
Adds error code for mobile notification logs
## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
