### PR TITLE
Fix `message is too big` exception for mobile push notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add error code for mobile push notification logs when device is not set up @Ferril ([#3554](https://github.com/grafana/oncall/pull/3554))
 
+### Fixed
+
+- Fix issue when mobile push notification message is too big @Ferril ([#3556](https://github.com/grafana/oncall/pull/3556)
+
 ## v1.3.77 (2023-12-11)
 
 ### Fixed

--- a/engine/apps/mobile_app/alert_rendering.py
+++ b/engine/apps/mobile_app/alert_rendering.py
@@ -10,9 +10,13 @@ class AlertMobileAppTemplater(AlertTemplater):
 
 
 def get_push_notification_subtitle(alert_group):
+    MAX_ALERT_TITLE_LENGTH = 200
     alert = alert_group.alerts.first()
     templated_alert = AlertMobileAppTemplater(alert).render()
     alert_title = str_or_backup(templated_alert.title, "Alert Group")
+    # limit alert title length to prevent FCM `message is too big` exception
+    if len(alert_title) > MAX_ALERT_TITLE_LENGTH:
+        alert_title = f"{alert_title[:MAX_ALERT_TITLE_LENGTH]}..."
 
     status_verbose = "Firing"  # TODO: we should probably de-duplicate this text
     if alert_group.resolved:

--- a/engine/apps/mobile_app/alert_rendering.py
+++ b/engine/apps/mobile_app/alert_rendering.py
@@ -11,11 +11,8 @@ class AlertMobileAppTemplater(AlertTemplater):
 
 def get_push_notification_subtitle(alert_group):
     MAX_ALERT_TITLE_LENGTH = 200
-    print(f"ALERTS COUNT: {alert_group.alerts.count}")  # TODO: debugging test. remove after debugging
     alert = alert_group.alerts.first()
-    print(f"ALERT TITLE: {alert.title}, DATA: {alert.raw_request_data}")  # TODO: debugging test. remove after debugging
     templated_alert = AlertMobileAppTemplater(alert).render()
-    print(f"TEMPLATED ALERT: {templated_alert}")  # TODO: debugging test. remove after debugging
     alert_title = str_or_backup(templated_alert.title, "Alert Group")
     # limit alert title length to prevent FCM `message is too big` exception
     # https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages

--- a/engine/apps/mobile_app/alert_rendering.py
+++ b/engine/apps/mobile_app/alert_rendering.py
@@ -11,8 +11,11 @@ class AlertMobileAppTemplater(AlertTemplater):
 
 def get_push_notification_subtitle(alert_group):
     MAX_ALERT_TITLE_LENGTH = 200
+    print(f"ALERTS COUNT: {alert_group.alerts.count}")  # TODO: debugging test. remove after debugging
     alert = alert_group.alerts.first()
+    print(f"ALERT TITLE: {alert.title}, DATA: {alert.raw_request_data}")  # TODO: debugging test. remove after debugging
     templated_alert = AlertMobileAppTemplater(alert).render()
+    print(f"TEMPLATED ALERT: {templated_alert}")  # TODO: debugging test. remove after debugging
     alert_title = str_or_backup(templated_alert.title, "Alert Group")
     # limit alert title length to prevent FCM `message is too big` exception
     # https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages

--- a/engine/apps/mobile_app/alert_rendering.py
+++ b/engine/apps/mobile_app/alert_rendering.py
@@ -15,6 +15,7 @@ def get_push_notification_subtitle(alert_group):
     templated_alert = AlertMobileAppTemplater(alert).render()
     alert_title = str_or_backup(templated_alert.title, "Alert Group")
     # limit alert title length to prevent FCM `message is too big` exception
+    # https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages
     if len(alert_title) > MAX_ALERT_TITLE_LENGTH:
         alert_title = f"{alert_title[:MAX_ALERT_TITLE_LENGTH]}..."
 

--- a/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
+++ b/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -178,6 +178,7 @@ def test_fcm_message_user_settings_critical_override_dnd_disabled(
     assert message.apns.payload.aps.custom_data["interruption-level"] == "time-sensitive"
 
 
+@patch("apps.base.messaging.get_messaging_backend_from_id", return_value=MagicMock())
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "alert_title",
@@ -187,6 +188,7 @@ def test_fcm_message_user_settings_critical_override_dnd_disabled(
     ],
 )
 def test_get_push_notification_subtitle(
+    mocked_messaging_backend,
     alert_title,
     make_organization_and_user,
     make_alert_receive_channel,

--- a/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
+++ b/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
@@ -178,7 +178,10 @@ def test_fcm_message_user_settings_critical_override_dnd_disabled(
     assert message.apns.payload.aps.custom_data["interruption-level"] == "time-sensitive"
 
 
-@patch("apps.base.messaging.get_messaging_backend_from_id", return_value=MagicMock())
+@patch(
+    "apps.alerts.incident_appearance.templaters.alert_templater.get_messaging_backend_from_id",
+    return_value=MagicMock(),
+)
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "alert_title",

--- a/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
+++ b/engine/apps/mobile_app/tests/tasks/test_new_alert_group.py
@@ -197,7 +197,7 @@ def test_get_push_notification_subtitle(
     organization, user = make_organization_and_user()
     alert_receive_channel = make_alert_receive_channel(organization=organization)
     alert_group = make_alert_group(alert_receive_channel)
-    make_alert(alert_group=alert_group, raw_request_data={"title": alert_title})
+    make_alert(alert_group=alert_group, title=alert_title, raw_request_data={"title": alert_title})
     expected_alert_title = (
         f"{alert_title[:MAX_ALERT_TITLE_LENGTH]}..." if len(alert_title) > MAX_ALERT_TITLE_LENGTH else alert_title
     )


### PR DESCRIPTION
# What this PR does
Adds limit for alert title length in mobile app push notifications
## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2375
## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
