### PR TITLE
Remove unneeded filter making query slower

### DIFF
--- a/engine/apps/alerts/tasks/check_escalation_finished.py
+++ b/engine/apps/alerts/tasks/check_escalation_finished.py
@@ -106,7 +106,7 @@ def check_escalation_finished_task() -> None:
     )
     total_alert_groups_count = alert_groups.count()
 
-    creation_deltas = alert_groups.filter(received_at__isnull=False).aggregate(
+    creation_deltas = alert_groups.aggregate(
         avg_delta=Avg(F("started_at") - F("received_at")),
         max_delta=Max(F("started_at") - F("received_at")),
     )


### PR DESCRIPTION
There is no index for the `received_at` column, and the filter isn't really needed (aggregation will work in any case, considering only the entries for which we have data).