### PR TITLE
fix(3564) Support PATCH Method In Outgoing webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support e2e tests in Tilt and Makefile ([#3516](https://github.com/grafana/oncall/pull/3516))
-- Support PATCH method for outgoing webhooks by @ravishankar15 ([#3580](https://github.com/grafana/oncall/issues/3580))
+- Support PATCH method for outgoing webhooks by @ravishankar15 ([#3580](https://github.com/grafana/oncall/pull/3580))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support e2e tests in Tilt and Makefile ([#3516](https://github.com/grafana/oncall/pull/3516))
+- Support PATCH Method In Outgoing webhook([#3564](https://github.com/grafana/oncall/issues/3564))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support e2e tests in Tilt and Makefile ([#3516](https://github.com/grafana/oncall/pull/3516))
-- Support PATCH Method In Outgoing webhook([#3564](https://github.com/grafana/oncall/issues/3564))
+- Support PATCH method for outgoing webhooks by @ravishankar15 ([#3580](https://github.com/grafana/oncall/issues/3580))
 
 ### Changed
 

--- a/engine/apps/api/tests/test_webhooks.py
+++ b/engine/apps/api/tests/test_webhooks.py
@@ -701,7 +701,10 @@ def test_create_invalid_missing_fields(webhook_internal_api_setup, make_user_aut
     }
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["http_method"][0] == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']."
+    assert (
+        response.json()["http_method"][0]
+        == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']."
+    )
 
     data = {
         "name": "test webhook 3",
@@ -711,7 +714,10 @@ def test_create_invalid_missing_fields(webhook_internal_api_setup, make_user_aut
     }
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["http_method"][0] == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']."
+    assert (
+        response.json()["http_method"][0]
+        == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']."
+    )
 
     data = {"name": "test webhook 3", "url": TEST_URL, "trigger_type": 2000000, "http_method": "POST"}
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))

--- a/engine/apps/api/tests/test_webhooks.py
+++ b/engine/apps/api/tests/test_webhooks.py
@@ -701,7 +701,7 @@ def test_create_invalid_missing_fields(webhook_internal_api_setup, make_user_aut
     }
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["http_method"][0] == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']."
+    assert response.json()["http_method"][0] == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']."
 
     data = {
         "name": "test webhook 3",
@@ -711,7 +711,7 @@ def test_create_invalid_missing_fields(webhook_internal_api_setup, make_user_aut
     }
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json()["http_method"][0] == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']."
+    assert response.json()["http_method"][0] == "This field must be one of ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']."
 
     data = {"name": "test webhook 3", "url": TEST_URL, "trigger_type": 2000000, "http_method": "POST"}
     response = client.post(url, data, format="json", **make_user_auth_headers(user, token))

--- a/engine/apps/webhooks/models/webhook.py
+++ b/engine/apps/webhooks/models/webhook.py
@@ -32,7 +32,7 @@ if typing.TYPE_CHECKING:
     from apps.alerts.models import EscalationPolicy
 
 WEBHOOK_FIELD_PLACEHOLDER = "****************"
-PUBLIC_WEBHOOK_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+PUBLIC_WEBHOOK_HTTP_METHODS = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"]
 
 logger = get_task_logger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -186,7 +186,7 @@ class Webhook(models.Model):
         if self.authorization_header:
             request_kwargs["headers"]["Authorization"] = self.authorization_header
 
-        if self.http_method in ["POST", "PUT"]:
+        if self.http_method in ["POST", "PUT", "PATCH"]:
             if self.forward_all:
                 request_kwargs["json"] = event_data
                 if self.is_legacy:
@@ -255,6 +255,8 @@ class Webhook(models.Model):
             r = requests.delete(url, timeout=OUTGOING_WEBHOOK_TIMEOUT, **request_kwargs)
         elif self.http_method == "OPTIONS":
             r = requests.options(url, timeout=OUTGOING_WEBHOOK_TIMEOUT, **request_kwargs)
+        elif self.http_method == "PATCH":
+            r = requests.patch(url, timeout=OUTGOING_WEBHOOK_TIMEOUT, **request_kwargs)
         else:
             raise ValueError(f"Unsupported http method: {self.http_method}")
         return r

--- a/engine/apps/webhooks/tests/test_webhook.py
+++ b/engine/apps/webhooks/tests/test_webhook.py
@@ -231,7 +231,7 @@ def test_make_request(make_organization, make_custom_webhook):
     organization = make_organization()
 
     with patch("apps.webhooks.models.webhook.requests") as mock_requests:
-        for method in ("GET", "POST", "PUT", "DELETE", "OPTIONS"):
+        for method in ("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"):
             webhook = make_custom_webhook(organization=organization, http_method=method)
             webhook.make_request("url", {"foo": "bar"})
             expected_call = getattr(mock_requests, method.lower())


### PR DESCRIPTION
# What this PR does
Adds PATCH method Support for outgoing webhook

## Which issue(s) this PR fixes
Fixes #3564 

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
