### PR TITLE
Fix inbound email integration endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check reason to skip notification in Slack to avoid task perform_notification retries @Ferril ([#3562](https://github.com/grafana/oncall/pull/3562))
 - Fix alert group table columns validation @Ferril ([#3577](https://github.com/grafana/oncall/pull/3577))
 - Fix posting message about rate limit to Slack @Ferril ([#3582](https://github.com/grafana/oncall/pull/3582))
+- Fix issue with parsing sender email address from email message for inbound email integration endpoint @Ferril ([#3586](https://github.com/grafana/oncall/pull/3586))
 
 ## v1.3.80 (2023-12-14)
 


### PR DESCRIPTION
# What this PR does
Handle exception on parsing sender email address from email message for inbound email integration endpoint

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2398
## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
