### PR TITLE
fix duplicate teams showing up in teams dropdown for `/escalate` slack command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check reason to skip notification in Slack to avoid task perform_notification retries @Ferril ([#3562](https://github.com/grafana/oncall/pull/3562))
 - Fix alert group table columns validation @Ferril ([#3577](https://github.com/grafana/oncall/pull/3577))
 - Fix posting message about rate limit to Slack @Ferril ([#3582](https://github.com/grafana/oncall/pull/3582))
+- Fix PUT /api/v1/escalation_policies/id issue when updating `from_time` and `to_time` by @joeyorlando ([#3581](https://github.com/grafana/oncall/pull/3581))
+- Fix issue where duplicate team options would show up in the teams dropdown for the `/escalate` Slack command
+  by @joeyorlando ([#3590](https://github.com/grafana/oncall/pull/3590))
 
 ## v1.3.80 (2023-12-14)
 
@@ -32,10 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add backend for multi-stack support for mobile-app @Ferril ([#3500](https://github.com/grafana/oncall/pull/3500))
-
-### Fixed
-
-- Fix PUT /api/v1/escalation_policies/id issue when updating `from_time` and `to_time` by @joeyorlando ([#3581](https://github.com/grafana/oncall/pull/3581))
 
 ## v1.3.78 (2023-12-12)
 

--- a/engine/apps/user_management/models/organization.py
+++ b/engine/apps/user_management/models/organization.py
@@ -323,16 +323,20 @@ class Organization(MaintainableObject):
         """
         from apps.alerts.models import AlertReceiveChannel
 
-        return self.alert_receive_channels.annotate(
-            num_channel_filters=Count("channel_filters"),
-            # used to determine if the organization has telegram configured
-            num_org_telegram_channels=Count("organization__telegram_channel"),
-        ).filter(
-            Q(num_channel_filters__gt=1)
-            | (Q(organization__slack_team_identity__isnull=False) | Q(num_org_telegram_channels__gt=0))
-            | Q(channel_filters__is_default=True, channel_filters__escalation_chain__isnull=False)
-            | Q(channel_filters__is_default=True, channel_filters__notification_backends__isnull=False),
-            integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING,
+        return (
+            self.alert_receive_channels.annotate(
+                num_channel_filters=Count("channel_filters"),
+                # used to determine if the organization has telegram configured
+                num_org_telegram_channels=Count("organization__telegram_channel"),
+            )
+            .filter(
+                Q(num_channel_filters__gt=1)
+                | (Q(organization__slack_team_identity__isnull=False) | Q(num_org_telegram_channels__gt=0))
+                | Q(channel_filters__is_default=True, channel_filters__escalation_chain__isnull=False)
+                | Q(channel_filters__is_default=True, channel_filters__notification_backends__isnull=False),
+                integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING,
+            )
+            .distinct()
         )
 
     @property

--- a/engine/apps/user_management/tests/test_organization.py
+++ b/engine/apps/user_management/tests/test_organization.py
@@ -217,6 +217,7 @@ def test_get_notifiable_direct_paging_integrations(
             assert arc in notifiable_direct_paging_integrations
         else:
             assert arc not in notifiable_direct_paging_integrations
+        return notifiable_direct_paging_integrations
 
     # integration has no default channel filter
     org, arc = _make_org_and_arc()
@@ -269,3 +270,11 @@ def test_get_notifiable_direct_paging_integrations(
     escalation_chain = make_escalation_chain(org)
     make_channel_filter(arc, is_default=True, notify_in_slack=False, escalation_chain=escalation_chain)
     _assert(org, arc)
+
+    # integration has more than one channel filter associated with it, nevertheless the integration should only
+    # be returned once
+    org, arc = _make_org_and_arc()
+    make_channel_filter(arc, is_default=True)
+    make_channel_filter(arc, is_default=False)
+    notifiable_direct_paging_integrations = _assert(org, arc)
+    assert notifiable_direct_paging_integrations.count() == 1


### PR DESCRIPTION
# Which issue(s) this PR fixes
- Closes https://github.com/grafana/support-escalations/issues/8763
- Closes https://github.com/grafana/oncall/issues/3388

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
