### PR TITLE
Hide "Limit each shift length" control for month-based rotations

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -388,6 +388,7 @@ const RotationForm = observer((props: RotationFormProps) => {
       setShowActiveOnSelectedDays(Boolean(shift.by_day?.length));
 
       const activeOnSelectedPartOfDay =
+        shift.frequency !== RepeatEveryPeriod.MONTHS &&
         repeatEveryInSeconds(shift.frequency, shift.interval) !== shiftEnd.diff(shiftStart, 'seconds');
 
       setShowActiveOnSelectedPartOfDay(activeOnSelectedPartOfDay);


### PR DESCRIPTION
# What this PR does

Hide "Limit each shift length" control for month-based rotations

## Which issue(s) this PR fixes

https://github.com/grafana/support-escalations/issues/8874

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
