### PR TITLE
use forked version of redis-py which adds extra debug logging

### DIFF
--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -5,7 +5,10 @@ whitenoise==5.3.0
 twilio~=6.37.0
 phonenumbers==8.10.0
 celery[amqp,redis]==5.3.1
-redis==5.0.1
+# NOTE: temporarily installing a forked version of redis-py which adds some more debug logging
+# in an effort to fix https://github.com/grafana/oncall-private/issues/2406
+# revert this change once done debugging
+git+https://github.com/grafana/redis-py@c0f167c
 humanize==0.5.1
 uwsgi==2.0.21
 django-cors-headers==3.7.0


### PR DESCRIPTION
# Which issue(s) this PR fixes

This helps with debugging https://github.com/grafana/oncall-private/issues/2406 (**note**: it doesn't fix it)

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated (N/A)
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
