### PR TITLE
Add ability to create an Outgoing Webhook with the PATCH HTTP method via the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add ability to create an Outgoing Webhook with the PATCH HTTP method via the UI by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+- Add ability to create an Outgoing Webhook with the PATCH HTTP method via the UI by @joeyorlando ([#3604](https://github.com/grafana/oncall/pull/3604))
 
 ## v1.3.81 (2023-12-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add ability to create an Outgoing Webhook with the PATCH HTTP method via the UI by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+
 ## v1.3.81 (2023-12-28)
 
 ### Added

--- a/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookForm.config.tsx
+++ b/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookForm.config.tsx
@@ -123,6 +123,10 @@ export function createForm(
               label: 'PUT',
             },
             {
+              value: 'PATCH',
+              label: 'PATCH',
+            },
+            {
               value: 'DELETE',
               label: 'DELETE',
             },


### PR DESCRIPTION
# What this PR does

Closes https://github.com/grafana/oncall/issues/3564

## TODO
- [ ] add e2e tests for creating Outgoing Webhooks

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
