### PR TITLE
Fix `module 'apps.schedules.tasks.notify_about_empty_shifts_in_schedule' has no attribute 'apply_async'` `AttributeError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Address HTTP 500s occurring when receiving messages from Telegram user in a discussion group by @joeyorlando ([#3622](https://github.com/grafana/oncall/pull/3622))
+- Fix `module 'apps.schedules.tasks.notify_about_empty_shifts_in_schedule' has no attribute 'apply_async'`
+  `AttributeError` by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
 
 ## v1.3.83 (2024-01-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Address HTTP 500s occurring when receiving messages from Telegram user in a discussion group by @joeyorlando ([#3622](https://github.com/grafana/oncall/pull/3622))
 - Fix `module 'apps.schedules.tasks.notify_about_empty_shifts_in_schedule' has no attribute 'apply_async'`
-  `AttributeError` by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+  `AttributeError` by @joeyorlando ([#3640](https://github.com/grafana/oncall/pull/3640))
 
 ## v1.3.83 (2024-01-08)
 

--- a/engine/apps/schedules/tasks/__init__.py
+++ b/engine/apps/schedules/tasks/__init__.py
@@ -1,19 +1,18 @@
-from apps.schedules.tasks.notify_about_empty_shifts_in_schedule import (  # noqa: F401
+from .drop_cached_ical import drop_cached_ical_for_custom_events_for_organization, drop_cached_ical_task  # noqa: F401
+from .notify_about_empty_shifts_in_schedule import (  # noqa: F401
     check_empty_shifts_in_schedule,
-    notify_about_empty_shifts_in_schedule,
+    notify_about_empty_shifts_in_schedule_task,
     schedule_notify_about_empty_shifts_in_schedule,
     start_check_empty_shifts_in_schedule,
     start_notify_about_empty_shifts_in_schedule,
 )
-from apps.schedules.tasks.notify_about_gaps_in_schedule import (  # noqa: F401
+from .notify_about_gaps_in_schedule import (  # noqa: F401
     check_gaps_in_schedule,
-    notify_about_gaps_in_schedule,
+    notify_about_gaps_in_schedule_task,
     schedule_notify_about_gaps_in_schedule,
     start_check_gaps_in_schedule,
     start_notify_about_gaps_in_schedule,
 )
-
-from .drop_cached_ical import drop_cached_ical_for_custom_events_for_organization, drop_cached_ical_task  # noqa: F401
 from .refresh_ical_files import (  # noqa: F401
     refresh_ical_file,
     refresh_ical_final_schedule,

--- a/engine/apps/schedules/tasks/__init__.py
+++ b/engine/apps/schedules/tasks/__init__.py
@@ -1,18 +1,19 @@
-from .drop_cached_ical import drop_cached_ical_for_custom_events_for_organization, drop_cached_ical_task  # noqa: F401
-from .notify_about_empty_shifts_in_schedule import (  # noqa: F401
+from apps.schedules.tasks.notify_about_empty_shifts_in_schedule import (  # noqa: F401
     check_empty_shifts_in_schedule,
     notify_about_empty_shifts_in_schedule,
     schedule_notify_about_empty_shifts_in_schedule,
     start_check_empty_shifts_in_schedule,
     start_notify_about_empty_shifts_in_schedule,
 )
-from .notify_about_gaps_in_schedule import (  # noqa: F401
+from apps.schedules.tasks.notify_about_gaps_in_schedule import (  # noqa: F401
     check_gaps_in_schedule,
     notify_about_gaps_in_schedule,
     schedule_notify_about_gaps_in_schedule,
     start_check_gaps_in_schedule,
     start_notify_about_gaps_in_schedule,
 )
+
+from .drop_cached_ical import drop_cached_ical_for_custom_events_for_organization, drop_cached_ical_task  # noqa: F401
 from .refresh_ical_files import (  # noqa: F401
     refresh_ical_file,
     refresh_ical_final_schedule,

--- a/engine/apps/schedules/tasks/drop_cached_ical.py
+++ b/engine/apps/schedules/tasks/drop_cached_ical.py
@@ -2,14 +2,13 @@ from celery.utils.log import get_task_logger
 
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 
-from .refresh_ical_files import refresh_ical_final_schedule
-
 task_logger = get_task_logger(__name__)
 
 
 @shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True, max_retries=1)
 def drop_cached_ical_task(schedule_pk):
     from apps.schedules.models import OnCallSchedule
+    from apps.schedules.tasks import refresh_ical_final_schedule
 
     task_logger.info(f"Start drop_cached_ical_task for schedule {schedule_pk}")
     try:

--- a/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
@@ -57,26 +57,26 @@ def start_notify_about_empty_shifts_in_schedule():
     )
 
     for schedule in schedules:
-        notify_about_empty_shifts_in_schedule.apply_async((schedule.pk,))
+        notify_about_empty_shifts_in_schedule_task.apply_async((schedule.pk,))
 
     task_logger.info("Finish start_notify_about_empty_shifts_in_schedule")
 
 
 @shared_dedicated_queue_retry_task()
-def notify_about_empty_shifts_in_schedule(schedule_pk):
+def notify_about_empty_shifts_in_schedule_task(schedule_pk):
     from apps.schedules.models import OnCallSchedule
 
-    task_logger.info(f"Start notify_about_empty_shifts_in_schedule {schedule_pk}")
+    task_logger.info(f"Start notify_about_empty_shifts_in_schedule_task {schedule_pk}")
 
     cache_key = get_cache_key_notify_about_empty_shifts_in_schedule(schedule_pk)
     cached_task_id = cache.get(cache_key)
-    current_task_id = notify_about_empty_shifts_in_schedule.request.id
+    current_task_id = notify_about_empty_shifts_in_schedule_task.request.id
     if current_task_id != cached_task_id and cached_task_id is not None:
         return
     try:
         schedule = OnCallSchedule.objects.get(pk=schedule_pk, channel__isnull=False)
     except OnCallSchedule.DoesNotExist:
-        task_logger.info(f"Tried to notify_about_empty_shifts_in_schedule for non-existing schedule {schedule_pk}")
+        task_logger.info(f"Tried to notify_about_empty_shifts_in_schedule_task for non-existing schedule {schedule_pk}")
         return
 
     today = timezone.now().date()
@@ -119,7 +119,7 @@ def notify_about_empty_shifts_in_schedule(schedule_pk):
     else:
         schedule.has_empty_shifts = False
     schedule.save(update_fields=["empty_shifts_report_sent_at", "has_empty_shifts"])
-    task_logger.info(f"Finish notify_about_empty_shifts_in_schedule {schedule_pk}")
+    task_logger.info(f"Finish notify_about_empty_shifts_in_schedule_task {schedule_pk}")
 
 
 def get_cache_key_notify_about_empty_shifts_in_schedule(schedule_pk):
@@ -131,6 +131,6 @@ def get_cache_key_notify_about_empty_shifts_in_schedule(schedule_pk):
 def schedule_notify_about_empty_shifts_in_schedule(schedule_pk):
     CACHE_LIFETIME = 600
     START_TASK_DELAY = 60
-    task = notify_about_empty_shifts_in_schedule.apply_async(args=[schedule_pk], countdown=START_TASK_DELAY)
+    task = notify_about_empty_shifts_in_schedule_task.apply_async(args=[schedule_pk], countdown=START_TASK_DELAY)
     cache_key = get_cache_key_notify_about_empty_shifts_in_schedule(schedule_pk)
     cache.set(cache_key, task.id, timeout=CACHE_LIFETIME)

--- a/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
@@ -57,27 +57,27 @@ def start_notify_about_gaps_in_schedule():
     )
 
     for schedule in schedules:
-        notify_about_gaps_in_schedule.apply_async((schedule.pk,))
+        notify_about_gaps_in_schedule_task.apply_async((schedule.pk,))
 
     task_logger.info("Finish start_notify_about_gaps_in_schedule")
 
 
 @shared_dedicated_queue_retry_task()
-def notify_about_gaps_in_schedule(schedule_pk):
+def notify_about_gaps_in_schedule_task(schedule_pk):
     from apps.schedules.models import OnCallSchedule
 
-    task_logger.info(f"Start notify_about_gaps_in_schedule {schedule_pk}")
+    task_logger.info(f"Start notify_about_gaps_in_schedule_task {schedule_pk}")
 
     cache_key = get_cache_key_notify_about_gaps_in_schedule(schedule_pk)
     cached_task_id = cache.get(cache_key)
-    current_task_id = notify_about_gaps_in_schedule.request.id
+    current_task_id = notify_about_gaps_in_schedule_task.request.id
     if current_task_id != cached_task_id and cached_task_id is not None:
         return
 
     try:
         schedule = OnCallSchedule.objects.get(pk=schedule_pk, channel__isnull=False)
     except OnCallSchedule.DoesNotExist:
-        task_logger.info(f"Tried to notify_about_gaps_in_schedule for non-existing schedule {schedule_pk}")
+        task_logger.info(f"Tried to notify_about_gaps_in_schedule_task for non-existing schedule {schedule_pk}")
         return
 
     now = timezone.now()
@@ -104,7 +104,7 @@ def notify_about_gaps_in_schedule(schedule_pk):
     else:
         schedule.has_gaps = False
     schedule.save(update_fields=["gaps_report_sent_at", "has_gaps"])
-    task_logger.info(f"Finish notify_about_gaps_in_schedule {schedule_pk}")
+    task_logger.info(f"Finish notify_about_gaps_in_schedule_task {schedule_pk}")
 
 
 def get_cache_key_notify_about_gaps_in_schedule(schedule_pk):
@@ -116,6 +116,6 @@ def get_cache_key_notify_about_gaps_in_schedule(schedule_pk):
 def schedule_notify_about_gaps_in_schedule(schedule_pk):
     CACHE_LIFETIME = 600
     START_TASK_DELAY = 60
-    task = notify_about_gaps_in_schedule.apply_async(args=[schedule_pk], countdown=START_TASK_DELAY)
+    task = notify_about_gaps_in_schedule_task.apply_async(args=[schedule_pk], countdown=START_TASK_DELAY)
     cache_key = get_cache_key_notify_about_gaps_in_schedule(schedule_pk)
     cache.set(cache_key, task.id, timeout=CACHE_LIFETIME)

--- a/engine/apps/schedules/tasks/refresh_ical_files.py
+++ b/engine/apps/schedules/tasks/refresh_ical_files.py
@@ -1,6 +1,6 @@
 from celery.utils.log import get_task_logger
 
-from apps.alerts.tasks import notify_ical_schedule_shift
+from apps.alerts.tasks import notify_ical_schedule_shift  # type: ignore[no-redef]
 from apps.schedules.ical_utils import is_icals_equal
 from apps.schedules.tasks import notify_about_empty_shifts_in_schedule_task, notify_about_gaps_in_schedule_task
 from apps.slack.tasks import start_update_slack_user_group_for_schedules

--- a/engine/apps/schedules/tasks/refresh_ical_files.py
+++ b/engine/apps/schedules/tasks/refresh_ical_files.py
@@ -2,7 +2,7 @@ from celery.utils.log import get_task_logger
 
 from apps.alerts.tasks import notify_ical_schedule_shift
 from apps.schedules.ical_utils import is_icals_equal
-from apps.schedules.tasks import notify_about_empty_shifts_in_schedule, notify_about_gaps_in_schedule
+from apps.schedules.tasks import notify_about_empty_shifts_in_schedule_task, notify_about_gaps_in_schedule_task
 from apps.slack.tasks import start_update_slack_user_group_for_schedules
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 
@@ -82,8 +82,8 @@ def refresh_ical_file(schedule_pk):
     run_task = run_task_primary or run_task_overrides
 
     if run_task:
-        notify_about_empty_shifts_in_schedule.apply_async((schedule_pk,))
-        notify_about_gaps_in_schedule.apply_async((schedule_pk,))
+        notify_about_empty_shifts_in_schedule_task.apply_async((schedule_pk,))
+        notify_about_gaps_in_schedule_task.apply_async((schedule_pk,))
 
 
 @shared_dedicated_queue_retry_task()

--- a/engine/apps/schedules/tests/tasks/test_drop_cached_ical.py
+++ b/engine/apps/schedules/tests/tasks/test_drop_cached_ical.py
@@ -11,6 +11,6 @@ def test_drop_cached_ical_triggers_final_refresh(make_organization, make_schedul
     organization = make_organization()
     schedule = make_schedule(organization, schedule_class=OnCallScheduleWeb)
 
-    with patch("apps.schedules.tasks.drop_cached_ical.refresh_ical_final_schedule") as mock_refresh_final:
+    with patch("apps.schedules.tasks.refresh_ical_final_schedule") as mock_refresh_final:
         drop_cached_ical_task(schedule.pk)
         assert mock_refresh_final.apply_async.called

--- a/engine/apps/schedules/tests/tasks/test_refresh_ical_files.py
+++ b/engine/apps/schedules/tests/tasks/test_refresh_ical_files.py
@@ -48,10 +48,10 @@ def test_refresh_ical_file_trigger_run(
             # do not trigger tasks for real
             with patch("apps.schedules.tasks.refresh_ical_files.notify_ical_schedule_shift"):
                 with patch(
-                    "apps.schedules.tasks.refresh_ical_files.notify_about_empty_shifts_in_schedule"
+                    "apps.schedules.tasks.refresh_ical_files.notify_about_empty_shifts_in_schedule_task"
                 ) as mock_notify_empty:
                     with patch(
-                        "apps.schedules.tasks.refresh_ical_files.notify_about_gaps_in_schedule"
+                        "apps.schedules.tasks.refresh_ical_files.notify_about_gaps_in_schedule_task"
                     ) as mock_notify_gaps:
                         refresh_ical_file(schedule.pk)
 

--- a/engine/apps/schedules/tests/test_notify_about_empty_shifts_in_schedule.py
+++ b/engine/apps/schedules/tests/test_notify_about_empty_shifts_in_schedule.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 from apps.api.permissions import LegacyAccessControlRole
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleWeb
-from apps.schedules.tasks import notify_about_empty_shifts_in_schedule
+from apps.schedules.tasks import notify_about_empty_shifts_in_schedule_task
 
 
 @pytest.mark.django_db
@@ -47,7 +47,7 @@ def test_no_empty_shifts_no_triggering_notification(
     empty_shifts_report_sent_at = schedule.empty_shifts_report_sent_at
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_empty_shifts_in_schedule(schedule.pk)
+        notify_about_empty_shifts_in_schedule_task(schedule.pk)
 
     assert not mock_slack_api_call.called
 
@@ -93,7 +93,7 @@ def test_empty_shifts_trigger_notification(
     empty_shifts_report_sent_at = schedule.empty_shifts_report_sent_at
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_empty_shifts_in_schedule(schedule.pk)
+        notify_about_empty_shifts_in_schedule_task(schedule.pk)
 
     assert mock_slack_api_call.called
 
@@ -154,7 +154,7 @@ def test_empty_non_empty_shifts_trigger_notification(
     empty_shifts_report_sent_at = schedule.empty_shifts_report_sent_at
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_empty_shifts_in_schedule(schedule.pk)
+        notify_about_empty_shifts_in_schedule_task(schedule.pk)
 
     assert mock_slack_api_call.called
 

--- a/engine/apps/schedules/tests/test_notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tests/test_notify_about_gaps_in_schedule.py
@@ -5,7 +5,7 @@ import pytest
 from django.utils import timezone
 
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleWeb
-from apps.schedules.tasks import notify_about_gaps_in_schedule
+from apps.schedules.tasks import notify_about_gaps_in_schedule_task
 
 
 @pytest.mark.django_db
@@ -46,7 +46,7 @@ def test_no_gaps_no_triggering_notification(
     gaps_report_sent_at = schedule.gaps_report_sent_at
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_gaps_in_schedule(schedule.pk)
+        notify_about_gaps_in_schedule_task(schedule.pk)
 
     assert not mock_slack_api_call.called
 
@@ -109,7 +109,7 @@ def test_gaps_in_the_past_no_triggering_notification(
     gaps_report_sent_at = schedule.gaps_report_sent_at
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_gaps_in_schedule(schedule.pk)
+        notify_about_gaps_in_schedule_task(schedule.pk)
 
     assert not mock_slack_api_call.called
 
@@ -159,7 +159,7 @@ def test_gaps_now_trigger_notification(
     assert schedule.has_gaps is False
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_gaps_in_schedule(schedule.pk)
+        notify_about_gaps_in_schedule_task(schedule.pk)
 
     assert mock_slack_api_call.called
 
@@ -211,7 +211,7 @@ def test_gaps_near_future_trigger_notification(
     assert schedule.has_gaps is False
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_gaps_in_schedule(schedule.pk)
+        notify_about_gaps_in_schedule_task(schedule.pk)
 
     assert mock_slack_api_call.called
 
@@ -261,7 +261,7 @@ def test_gaps_later_than_7_days_no_triggering_notification(
     gaps_report_sent_at = schedule.gaps_report_sent_at
 
     with patch("apps.slack.client.SlackClient.chat_postMessage") as mock_slack_api_call:
-        notify_about_gaps_in_schedule(schedule.pk)
+        notify_about_gaps_in_schedule_task(schedule.pk)
 
     assert not mock_slack_api_call.called
 

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -73,7 +73,6 @@ CELERY_TASK_ROUTES = {
     "apps.migration_tool.tasks.migrate_log": {"queue": "default"},
     "apps.migration_tool.tasks.start_migration_user_data": {"queue": "default"},
     "apps.migration_tool.tasks.migrate_user_data": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_gaps_in_schedule.notify_about_gaps_in_schedule": {"queue": "default"},
     "celery.backend_cleanup": {"queue": "default"},
     "apps.heartbeat.tasks.check_heartbeats": {"queue": "default"},
     "apps.oss_installation.tasks.send_cloud_heartbeat_task": {"queue": "default"},

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -33,7 +33,7 @@ CELERY_TASK_ROUTES = {
     "apps.schedules.tasks.notify_about_gaps_in_schedule.check_empty_shifts_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.start_notify_about_gaps_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.check_gaps_in_schedule": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_gaps_in_schedule.notify_about_empty_shifts_in_schedule": {"queue": "default"},
+    "apps.schedules.tasks.notify_about_gaps_in_schedule.notify_about_gaps_in_schedule_task": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.schedule_notify_about_gaps_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.start_check_empty_shifts_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.start_check_gaps_in_schedule": {"queue": "default"},
@@ -41,7 +41,7 @@ CELERY_TASK_ROUTES = {
         "queue": "default"
     },
     "apps.schedules.tasks.notify_about_empty_shifts_in_schedule.check_empty_shifts_in_schedule": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_empty_shifts_in_schedule.notify_about_empty_shifts_in_schedule": {
+    "apps.schedules.tasks.notify_about_empty_shifts_in_schedule.notify_about_empty_shifts_in_schedule_task": {
         "queue": "default"
     },
     "apps.schedules.tasks.notify_about_empty_shifts_in_schedule.start_check_empty_shifts_in_schedule": {


### PR DESCRIPTION
# Which issue(s) this PR fixes

We've been seeing this `AttributeError` quite frequently for quite some time ([logs](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22oPl%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcluster%3D~%5C%22prod-%28eu-west-0%7Cus-central-0%29%5C%22,%20namespace%3D%5C%22amixr-prod%5C%22%7D%20%7C%3D%20%60AttributeError%28%5C%22module%20%27apps.schedules.tasks.notify_about_empty_shifts_in_schedule%27%20has%20no%20attribute%20%27apply_async%27%5C%22%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1))

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
