### PR TITLE
Fix unicode character encoding in JSON for webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix unicode characters not rendering correctly in webhooks @mderynck ([#3670](https://github.com/grafana/oncall/pull/3670))
+
 ## v1.3.84 (2024-01-10)
 
 ### Added

--- a/engine/apps/webhooks/tests/test_webhook.py
+++ b/engine/apps/webhooks/tests/test_webhook.py
@@ -278,3 +278,21 @@ def test_escaping_payload_with_single_quote_in_string(make_organization, make_cu
     }
     request_kwargs = webhook.build_request_kwargs(payload)
     assert request_kwargs == {"headers": {}, "json": {"data": "{'text': \"Hi, it's alert\"}"}}
+
+
+@pytest.mark.django_db
+def test_escaping_unicode_in_string(make_organization, make_custom_webhook):
+    organization = make_organization()
+    webhook = make_custom_webhook(
+        organization=organization,
+        data='{"data" : "{{ alert_payload.text }}"}',
+        forward_all=False,
+    )
+
+    payload = {
+        "alert_payload": {
+            "text": "東京",
+        }
+    }
+    request_kwargs = webhook.build_request_kwargs(payload)
+    assert request_kwargs == {"headers": {}, "json": {"data": "東京"}}

--- a/engine/apps/webhooks/utils.py
+++ b/engine/apps/webhooks/utils.py
@@ -58,7 +58,6 @@ def parse_url(url):
 def apply_jinja_template_for_json(template, payload):
     escaped_payload = escape_payload(payload)
     return apply_jinja_template(template, **escaped_payload)
-    # return apply_jinja_template(template, **payload)
 
 
 def escape_payload(payload: dict):

--- a/engine/apps/webhooks/utils.py
+++ b/engine/apps/webhooks/utils.py
@@ -58,6 +58,7 @@ def parse_url(url):
 def apply_jinja_template_for_json(template, payload):
     escaped_payload = escape_payload(payload)
     return apply_jinja_template(template, **escaped_payload)
+    # return apply_jinja_template(template, **payload)
 
 
 def escape_payload(payload: dict):
@@ -82,7 +83,7 @@ def escape_string(string: str):
     json.dumps is the simples way to escape all special characters in string.
     First and last chars are quotes from json.dumps(), we don't need them, only escaping.
     """
-    return json.dumps(string)[1:-1]
+    return json.dumps(string, ensure_ascii=False)[1:-1]
 
 
 class EscapeDoubleQuotesDict(dict):


### PR DESCRIPTION
# What this PR does
Fixes escaping for unicode characters in webhooks.

## Which issue(s) this PR fixes
#3149 

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
