### PR TITLE
Fix updating a shift swap with no Slack message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix updating a shift swap with no Slack message by @vadimkerr ([#3686](https://github.com/grafana/oncall/pull/3686))
+
 ## v1.3.86 (2024-01-12)
 
 ### Fixed

--- a/engine/apps/slack/scenarios/shift_swap_requests.py
+++ b/engine/apps/slack/scenarios/shift_swap_requests.py
@@ -165,6 +165,9 @@ class BaseShiftSwapRequestStep(scenario_step.ScenarioStep):
         )
 
     def update_message(self, shift_swap_request: "ShiftSwapRequest") -> None:
+        if not shift_swap_request.slack_message:
+            return
+
         self._slack_client.chat_update(
             channel=shift_swap_request.slack_channel_id,
             ts=shift_swap_request.slack_message.slack_id,

--- a/engine/apps/slack/tests/test_scenario_steps/test_shift_swap_requests.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_shift_swap_requests.py
@@ -183,6 +183,19 @@ class TestBaseShiftSwapRequestStep:
                 channel=ssr.slack_channel_id, ts=ts, blocks=mock_generate_blocks.return_value
             )
 
+    @patch("apps.slack.scenarios.shift_swap_requests.BaseShiftSwapRequestStep._generate_blocks")
+    @pytest.mark.django_db
+    def test_update_message_no_slack_message(self, mock_generate_blocks, setup, make_slack_message) -> None:
+        ssr, _, _, _ = setup()  # SSR without a Slack message
+        organization = ssr.organization
+        slack_team_identity = organization.slack_team_identity
+
+        step = scenarios.BaseShiftSwapRequestStep(slack_team_identity, organization)
+
+        with patch.object(step, "_slack_client") as mock_slack_client:
+            step.update_message(ssr)
+            mock_slack_client.chat_update.assert_not_called()
+
     @pytest.mark.django_db
     def test_post_message_to_thread(self, setup, make_slack_message) -> None:
         ts = "12345.67"


### PR DESCRIPTION
# What this PR does

Fixes https://github.com/grafana/oncall/issues/3648

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
