### PR TITLE
Update alert group personal notifications checker to check sent SMS

### DIFF
--- a/engine/apps/alerts/tests/test_check_escalation_finished_task.py
+++ b/engine/apps/alerts/tests/test_check_escalation_finished_task.py
@@ -15,6 +15,7 @@ from apps.alerts.tasks.check_escalation_finished import (
     send_alert_group_escalation_auditor_task_heartbeat,
 )
 from apps.base.models import UserNotificationPolicy, UserNotificationPolicyLogRecord
+from apps.twilioapp.models import TwilioSMS, TwilioSMSstatuses
 
 MOCKED_HEARTBEAT_URL = "https://hello.com/lsdjjkf"
 
@@ -407,6 +408,7 @@ def test_check_escalation_finished_task_calls_audit_alert_group_personal_notific
     make_alert_receive_channel,
     make_alert_group_that_started_at_specific_date,
     make_user_notification_policy_log_record,
+    make_sms_record,
     caplog,
 ):
     organization, user = make_organization_and_user()
@@ -461,7 +463,7 @@ def test_check_escalation_finished_task_calls_audit_alert_group_personal_notific
     # records created > 5 mins ago
     alert_group1.personal_log_records.update(created_at=now - timezone.timedelta(minutes=7))
 
-    # alert_group2: notify user, notification failed
+    # alert_group2: notify user, notification failed; triggered sms, sent status
     make_user_notification_policy_log_record(
         author=user,
         alert_group=alert_group2,
@@ -476,8 +478,24 @@ def test_check_escalation_finished_task_calls_audit_alert_group_personal_notific
         notification_step=UserNotificationPolicy.Step.NOTIFY,
         type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED,
     )
+    make_user_notification_policy_log_record(
+        author=user,
+        alert_group=alert_group2,
+        notification_policy=user_notification_policy,
+        notification_step=UserNotificationPolicy.Step.NOTIFY,
+        type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_TRIGGERED,
+    )
+    # no failed or succeed record, but SMS was sent (without Twilio delivered confirmation yet)
+    sms_record = make_sms_record(
+        receiver=user,
+        represents_alert_group=alert_group2,
+        notification_policy=user_notification_policy,
+    )
+    sent_sms = TwilioSMS.objects.create(sid="someid", sms_record=sms_record, status=TwilioSMSstatuses.SENT)
     # records created > 5 mins ago
     alert_group2.personal_log_records.update(created_at=now - timezone.timedelta(minutes=7))
+    sent_sms.created_at = now - timezone.timedelta(minutes=6)
+    sent_sms.save()
 
     # alert_group3: notify user, missing completion
     make_user_notification_policy_log_record(
@@ -521,4 +539,4 @@ def test_check_escalation_finished_task_calls_audit_alert_group_personal_notific
     # also trigger the general personal notification checker
     check_personal_notifications_task()
 
-    assert "personal_notifications_triggered=4 personal_notifications_completed=2" in caplog.text
+    assert "personal_notifications_triggered=5 personal_notifications_completed=2" in caplog.text


### PR DESCRIPTION
Sent SMS messages are considered completed for our purpose here (ie. do not wait for Twilio delivered confirmation).