### PR TITLE
Speed up send email notification task

### DIFF
--- a/engine/apps/user_management/subscription_strategy/free_public_beta_subscription_strategy.py
+++ b/engine/apps/user_management/subscription_strategy/free_public_beta_subscription_strategy.py
@@ -25,7 +25,6 @@ class FreePublicBetaSubscriptionStrategy(BaseSubscriptionStrategy):
         day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
         emails_today = EmailMessage.objects.filter(
             created_at__gte=day_start,
-            represents_alert_group__channel__organization=self.organization,
             receiver=user,
         ).count()
         return self._emails_limit - emails_today


### PR DESCRIPTION
# What this PR does
Removes unnecessary filtering by organization during emails limit check in send email notification task since there is filtering by user there, so there is no need to check organization
## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2205
## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
