### PR TITLE
OnCall Docs: Fix 'escalations' typo on Get Started page

### DIFF
--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -86,7 +86,7 @@ customize visualizations and notifications by extracting data from alerts. See m
 
 ### Configure Escalation Chains
 
-Escalation chains are a set of steps that define who to notify, and when.
+Escalation Chains are a set of steps that define who to notify, and when.
 
 See more details in the [Escalation Chains][escalation-chains] section.
 

--- a/docs/sources/get-started/_index.md
+++ b/docs/sources/get-started/_index.md
@@ -84,7 +84,7 @@ Review and customize templates to interpret monitoring alerts and minimize noise
 customize visualizations and notifications by extracting data from alerts. See more details in the
 [Jinja2 templating][jinja2-templating] section.
 
-### Configure scalation Chains
+### Configure Escalation Chains
 
 Escalation chains are a set of steps that define who to notify, and when.
 


### PR DESCRIPTION
# What this PR does
Fixes the escalations typo.

## Which issue(s) this PR fixes
Someone noticed the typo internally.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
