### PR TITLE
Minor Fix to Format of REFRESH-INTERVAL in ical_utils.py

### DIFF
--- a/engine/apps/schedules/ical_utils.py
+++ b/engine/apps/schedules/ical_utils.py
@@ -716,7 +716,7 @@ def create_base_icalendar(name: str) -> Calendar:
     cal.add("version", "2.0")
     cal.add("prodid", "//Grafana Labs//Grafana On-Call//")
     # suggested minimum interval for polling for changes
-    cal.add("REFRESH-INTERVAL;VALUE=DURATION", "P1H")
+    cal.add("REFRESH-INTERVAL;VALUE=DURATION", "PT1H")
 
     return cal
 


### PR DESCRIPTION



# What this PR does
Minor formatting change to the suggested REFRESH-INTERVAL of iCal exports. DURATION units less than 1d must be prefixed by "T". Fixes issue with Atlassian Confluence failing to subscribe to iCal URLs from Grafana OnCall

RFC 2445 explains this a bit more clearly in section 4.3.6 on DURATION. 
https://www.ietf.org/rfc/rfc2445.txt

Obviously I wish Atlassian could just be a little more forgiving in their digestion of the iCal data since clearly Gmail and others have no problem with it, but I doubt I'm going to get much traction with them (we do have a case open though).

## Which issue(s) this PR fixes
I haven't logged one yet but I can if you want. Again, my main issue was with Atlassian Confluence. Kept throwing errors of "The uploaded data does not seem to be iCalendar content" as long as the REFRESH-INTERVAL DURATION was less than 1 day and lacking the "T" character.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
