### PR TITLE
Handle a possible outdated cached integration error

### DIFF
--- a/engine/apps/integrations/mixins/alert_channel_defining_mixin.py
+++ b/engine/apps/integrations/mixins/alert_channel_defining_mixin.py
@@ -35,7 +35,13 @@ class AlertChannelDefiningMixin(object):
             cache_key_short_term = self.CACHE_KEY_SHORT_TERM + "_" + str(kwargs["alert_channel_key"])
             cached_alert_receive_channel_raw = cache.get(cache_key_short_term)
             if cached_alert_receive_channel_raw is not None:
-                alert_receive_channel = next(serializers.deserialize("json", cached_alert_receive_channel_raw)).object
+                try:
+                    alert_receive_channel = next(
+                        serializers.deserialize("json", cached_alert_receive_channel_raw)
+                    ).object
+                except serializers.base.DeserializationError:
+                    # cached object model is outdated
+                    alert_receive_channel = None
 
             if alert_receive_channel is None:
                 # Trying to define channel from DB


### PR DESCRIPTION
Related to [logs](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22hum%22:%7B%22datasource%22:%22c-R8UWvVk%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22amixr-prod%5C%22,%20job%3D%5C%22amixr-prod%2Famixr-integrations%5C%22%7D%20%7C%3D%20%5C%22django.core.serializers.base.DeserializationError%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22c-R8UWvVk%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%221706023840486%22,%22to%22:%221706024722486%22%7D%7D%7D&orgId=1)