### PR TITLE
Render alert group action buttons even if getting AG data fails

### DIFF
--- a/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.helpers.tsx
+++ b/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.helpers.tsx
@@ -1,7 +1,7 @@
 import { PageErrorData } from 'components/PageErrorHandlingWrapper/PageErrorHandlingWrapper';
 
 export function initErrorDataState(): Partial<PageErrorData> {
-  return { isWrongTeamError: false, wrongTeamNoPermissions: false };
+  return { isUnknownError: false, isWrongTeamError: false, wrongTeamNoPermissions: false };
 }
 
 export function getWrongTeamResponseInfo({ response }): Partial<PageErrorData> {
@@ -18,5 +18,5 @@ export function getWrongTeamResponseInfo({ response }): Partial<PageErrorData> {
     }
   }
 
-  return { isNotFoundError: true };
+  return { isUnknownError: true };
 }

--- a/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.tsx
+++ b/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.tsx
@@ -18,6 +18,7 @@ export interface PageBaseState {
 export interface PageErrorData {
   isNotFoundError?: boolean;
   isWrongTeamError?: boolean;
+  isUnknownError?: boolean;
   wrongTeamNoPermissions?: boolean;
   switchToTeam?: { name: string; id: string };
 }

--- a/grafana-plugin/src/pages/incident/Incident.helpers.tsx
+++ b/grafana-plugin/src/pages/incident/Incident.helpers.tsx
@@ -144,16 +144,16 @@ export function renderRelatedUsers(incident: Alert, isFull = false) {
   );
 }
 
-export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key: string]: any }) {
-  if (incident.root_alert_group) {
+export function getActionButtons(incident: AlertType, callbacks: { [key: string]: any }) {
+  const { onResolve, onUnresolve, onAcknowledge, onUnacknowledge, onSilence, onUnsilence } = callbacks;
+
+  if (incident?.root_alert_group) {
     return null;
   }
 
-  const { onResolve, onUnresolve, onAcknowledge, onUnacknowledge, onSilence, onUnsilence } = callbacks;
-
   const resolveButton = (
     <WithPermissionControlTooltip key="resolve" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading} onClick={onResolve} variant="primary">
+      <Button disabled={incident?.loading} onClick={onResolve} variant="primary">
         Resolve
       </Button>
     </WithPermissionControlTooltip>
@@ -161,7 +161,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const unacknowledgeButton = (
     <WithPermissionControlTooltip key="unacknowledge" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading} onClick={onUnacknowledge} variant="secondary">
+      <Button disabled={incident?.loading} onClick={onUnacknowledge} variant="secondary">
         Unacknowledge
       </Button>
     </WithPermissionControlTooltip>
@@ -169,7 +169,7 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const unresolveButton = (
     <WithPermissionControlTooltip key="unacknowledge" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading} onClick={onUnresolve} variant="primary">
+      <Button disabled={incident?.loading} onClick={onUnresolve} variant="primary">
         Unresolve
       </Button>
     </WithPermissionControlTooltip>
@@ -177,31 +177,37 @@ export function getActionButtons(incident: AlertType, cx: any, callbacks: { [key
 
   const acknowledgeButton = (
     <WithPermissionControlTooltip key="acknowledge" userAction={UserActions.AlertGroupsWrite}>
-      <Button disabled={incident.loading} onClick={onAcknowledge} variant="secondary">
+      <Button disabled={incident?.loading} onClick={onAcknowledge} variant="secondary">
         Acknowledge
       </Button>
     </WithPermissionControlTooltip>
   );
 
+  const silenceButton = (
+    <WithPermissionControlTooltip key="silence" userAction={UserActions.AlertGroupsWrite}>
+      <SilenceButtonCascader key="silence" disabled={incident?.loading} onSelect={onSilence} />
+    </WithPermissionControlTooltip>
+  );
+
+  const unsilenceButton = (
+    <WithPermissionControlTooltip key="silence" userAction={UserActions.AlertGroupsWrite}>
+      <Button disabled={incident?.loading} variant="secondary" onClick={onUnsilence}>
+        Unsilence
+      </Button>
+    </WithPermissionControlTooltip>
+  );
+
+  if (!incident?.status) {
+    // to render all buttons if status unknown
+    return [unsilenceButton, silenceButton, acknowledgeButton, unacknowledgeButton, resolveButton, unresolveButton];
+  }
+
   const buttons = [];
 
   if (incident.status === IncidentStatus.Silenced) {
-    buttons.push(
-      <WithPermissionControlTooltip key="silence" userAction={UserActions.AlertGroupsWrite}>
-        <Button disabled={incident.loading} variant="secondary" onClick={onUnsilence}>
-          Unsilence
-        </Button>
-      </WithPermissionControlTooltip>
-    );
+    buttons.push(unsilenceButton);
   } else if (incident.status !== IncidentStatus.Resolved) {
-    buttons.push(
-      <SilenceButtonCascader
-        className={cx('silence-button-inline')}
-        key="silence"
-        disabled={incident.loading}
-        onSelect={onSilence}
-      />
-    );
+    buttons.push(silenceButton);
   }
 
   if (!incident.resolved && !incident.acknowledged) {

--- a/grafana-plugin/src/pages/incidents/Incidents.module.scss
+++ b/grafana-plugin/src/pages/incidents/Incidents.module.scss
@@ -45,12 +45,6 @@
   color: var(--secondary-text-color);
 }
 
-.silence-button-inline {
-  font-size: 12px;
-  height: 24px;
-  margin-right: 0;
-}
-
 .pagination {
   width: 100%;
   margin-top: 20px;


### PR DESCRIPTION
# What this PR does

Render alert group action buttons even if getting AG data fails

## Which issue(s) this PR fixes

https://github.com/grafana/oncall-private/issues/2383

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
