### PR TITLE
Fix `routes` and `schedules` public api endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed too frequent retry of `perform_notification` task on Telegram ratelimit error by @Ferril ([#3744](https://github.com/grafana/oncall/pull/3744))
+- Add check whether organization has Slack connection on update Slack related field using public api endpoints
+  by @Ferril ([#3751](https://github.com/grafana/oncall/pull/3751))
 
 ## v1.3.92 (2024-01-23)
 

--- a/engine/apps/public_api/serializers/routes.py
+++ b/engine/apps/public_api/serializers/routes.py
@@ -86,6 +86,8 @@ class BaseChannelFilterSerializer(OrderedModelSerializer):
             slack_channel_id = slack_channel_id.upper()
             organization = self.context["request"].auth.organization
             slack_team_identity = organization.slack_team_identity
+            if not slack_team_identity:
+                raise BadRequest(detail="Slack isn't connected to this workspace")
             try:
                 slack_team_identity.get_cached_channels().get(slack_id=slack_channel_id)
             except SlackChannel.DoesNotExist:

--- a/engine/apps/public_api/serializers/schedules_base.py
+++ b/engine/apps/public_api/serializers/schedules_base.py
@@ -45,6 +45,9 @@ class ScheduleBaseSerializer(serializers.ModelSerializer):
         organization = self.context["request"].auth.organization
         slack_team_identity = organization.slack_team_identity
 
+        if (slack_channel_id or user_group_id) and not slack_team_identity:
+            raise BadRequest(detail="Slack isn't connected to this workspace")
+
         if slack_channel_id is not None:
             slack_channel_id = slack_channel_id.upper()
             try:

--- a/engine/apps/public_api/tests/test_schedules.py
+++ b/engine/apps/public_api/tests/test_schedules.py
@@ -845,6 +845,65 @@ def test_create_schedule_invalid_timezone(make_organization_and_user_with_token,
 
 
 @pytest.mark.django_db
+def test_create_calendar_schedule_slack_error(make_organization_and_user_with_token):
+    organization, user, token = make_organization_and_user_with_token()
+    client = APIClient()
+
+    url = reverse("api-public:schedules-list")
+    # with slack channel id
+    data = {
+        "team_id": None,
+        "name": "schedule test name",
+        "time_zone": "Europe/Moscow",
+        "type": "calendar",
+        "slack": {
+            "channel_id": "TEST_SLACK_ID",
+        },
+    }
+
+    response = client.post(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["detail"] == "Slack isn't connected to this workspace"
+    # with slack user group id
+    data = {
+        "team_id": None,
+        "name": "schedule test name",
+        "time_zone": "Europe/Moscow",
+        "type": "calendar",
+        "slack": {
+            "user_group_id": "TEST_SLACK_ID",
+        },
+    }
+
+    response = client.post(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["detail"] == "Slack isn't connected to this workspace"
+
+
+@pytest.mark.django_db
+def test_update_calendar_schedule_slack_error(
+    make_organization_and_user_with_token,
+    make_schedule,
+):
+    organization, user, token = make_organization_and_user_with_token()
+    client = APIClient()
+    schedule = make_schedule(organization, schedule_class=OnCallScheduleCalendar)
+    url = reverse("api-public:schedules-detail", kwargs={"pk": schedule.public_primary_key})
+
+    data = {"slack": {"channel_id": "TEST_SLACK_ID"}}
+
+    response = client.put(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["detail"] == "Slack isn't connected to this workspace"
+
+    data = {"slack": {"user_group_id": "TEST_SLACK_ID"}}
+
+    response = client.put(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["detail"] == "Slack isn't connected to this workspace"
+
+
+@pytest.mark.django_db
 def test_create_ical_schedule_without_ical_url(make_organization_and_user_with_token):
     _, _, token = make_organization_and_user_with_token()
     client = APIClient()


### PR DESCRIPTION
# What this PR does
Add check whether organization has Slack connection on update Slack related field using public api endpoints
## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/1611
## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
