### PR TITLE
Fix calculating number of oncall users per team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dynamic labels & multi-label extraction label are broken ([#3750](https://github.com/grafana/oncall/issues/3750))
 - Add check whether organization has Slack connection on update Slack related field using public api endpoints
   by @Ferril ([#3751](https://github.com/grafana/oncall/pull/3751))
+- Fixed calculating the number of on-call users per team by @Ferril ([#3773](https://github.com/grafana/oncall/pull/3773))
 
 ## v1.3.92 (2024-01-23)
 

--- a/engine/apps/api/serializers/team.py
+++ b/engine/apps/api/serializers/team.py
@@ -50,10 +50,10 @@ class TeamLongSerializer(TeamSerializer):
         ]
 
     def get_number_of_users_currently_oncall(self, obj: Team) -> int:
-        num_of_users_oncall_for_team = 0
+        oncall_users = set()
 
         for schedule, users in self.context["schedules_with_oncall_users"].items():
             if schedule.team == obj:
-                num_of_users_oncall_for_team += len(users)
+                oncall_users |= set(users)
 
-        return num_of_users_oncall_for_team
+        return len(oncall_users)

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -193,6 +193,8 @@ def test_teams_number_of_users_currently_oncall_attribute_works_properly(
             schedule.refresh_ical_file()
             schedule.refresh_ical_final_schedule()
 
+    # create two schedules for team 1 to make sure that every user is calculated only once per team
+    _make_schedule(team=team1, oncall_users=[user1, user2])
     _make_schedule(team=team1, oncall_users=[user1, user2])
     _make_schedule(team=team2, oncall_users=[user1])
     _make_schedule(team=team3, oncall_users=[])

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -166,7 +166,7 @@ def test_teams_number_of_users_currently_oncall_attribute_works_properly(
     team3 = make_team(organization)
 
     team1.users.set([user1, user2, user3])
-    team2.users.set([user1])
+    team2.users.set([user1, user2])
     team3.users.set([user3])
 
     def _make_schedule(team=None, oncall_users=None):
@@ -195,7 +195,7 @@ def test_teams_number_of_users_currently_oncall_attribute_works_properly(
 
     # create two schedules for team 1 to make sure that every user is calculated only once per team
     _make_schedule(team=team1, oncall_users=[user1, user2])
-    _make_schedule(team=team1, oncall_users=[user1, user2])
+    _make_schedule(team=team1, oncall_users=[user1, user3])
     _make_schedule(team=team2, oncall_users=[user1])
     _make_schedule(team=team3, oncall_users=[])
 
@@ -205,7 +205,7 @@ def test_teams_number_of_users_currently_oncall_attribute_works_properly(
     response = client.get(url, format="json", **make_user_auth_headers(user1, token))
 
     number_of_oncall_users = {
-        team1.public_primary_key: 2,
+        team1.public_primary_key: 3,
         team2.public_primary_key: 1,
         team3.public_primary_key: 0,
         NO_TEAM_VALUE: 0,  # this covers the case of "No team"


### PR DESCRIPTION
# What this PR does
Fixes calculating number of oncall users per team for `team` api endpoint

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
