### PR TITLE
Fix Incident plugin status sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fix exception when parsing incident plugin config @mderynck ([#3802](https://github.com/grafana/oncall/pull/3802))
+
 ## v1.3.96 (2024-01-31)
 
 ### Added

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -111,9 +111,12 @@ def _sync_grafana_incident_plugin(organization: Organization, grafana_api_client
     It intended to use only inside _sync_organization. It mutates, but not saves org, it's saved in _sync_organization.
     """
     grafana_incident_settings, _ = grafana_api_client.get_grafana_incident_plugin_settings()
+    organization.grafana_incident_enabled = False
+    organization.grafana_incident_backend_url = None
+
     if grafana_incident_settings is not None:
-        organization.is_grafana_incident_enabled = grafana_incident_settings["enabled"]
-        organization.grafana_incident_backend_url = grafana_incident_settings.get("jsonData", {}).get(
+        organization.grafana_incident_enabled = grafana_incident_settings["enabled"]
+        organization.grafana_incident_backend_url = (grafana_incident_settings.get("jsonData") or {}).get(
             GrafanaAPIClient.GRAFANA_INCIDENT_PLUGIN_BACKEND_URL_KEY
         )
 

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -111,11 +111,11 @@ def _sync_grafana_incident_plugin(organization: Organization, grafana_api_client
     It intended to use only inside _sync_organization. It mutates, but not saves org, it's saved in _sync_organization.
     """
     grafana_incident_settings, _ = grafana_api_client.get_grafana_incident_plugin_settings()
-    organization.grafana_incident_enabled = False
+    organization.is_grafana_incident_enabled = False
     organization.grafana_incident_backend_url = None
 
     if grafana_incident_settings is not None:
-        organization.grafana_incident_enabled = grafana_incident_settings["enabled"]
+        organization.is_grafana_incident_enabled = grafana_incident_settings["enabled"]
         organization.grafana_incident_backend_url = (grafana_incident_settings.get("jsonData") or {}).get(
             GrafanaAPIClient.GRAFANA_INCIDENT_PLUGIN_BACKEND_URL_KEY
         )

--- a/engine/apps/user_management/tests/test_sync.py
+++ b/engine/apps/user_management/tests/test_sync.py
@@ -541,6 +541,7 @@ class TestSyncGrafanaIncidentParams:
             MOCK_GRAFANA_INCIDENT_BACKEND_URL,
         ),
         TestSyncGrafanaIncidentParams(({"enabled": True}, None), True, None),
+        TestSyncGrafanaIncidentParams(({"enabled": True, "jsonData": None}, None), True, None),
         # missing jsonData (sometimes this is what we get back from the Grafana API)
         TestSyncGrafanaIncidentParams(({"enabled": False}, None), False, None),  # plugin is disabled for some reason
     ],


### PR DESCRIPTION
# What this PR does
- Handle case where key exists for jsonData but explicitly set to None
- Disable incident if plugin disabled after or in the case it was removed completely from the Grafana instance

## Which issue(s) this PR fixes

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
