### PR TITLE
fix slack API rate limit errors in `send_message_to_thread_if_bot_not_in_channel` task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Address `SlackAPIRatelimitError` exceptions in `apps.slack.tasks.send_message_to_thread_if_bot_not_in_channel` task
-  by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+  by @joeyorlando ([#3803](https://github.com/grafana/oncall/pull/3803))
 
 ## v1.3.96 (2024-01-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Address `SlackAPIRatelimitError` exceptions in `apps.slack.tasks.send_message_to_thread_if_bot_not_in_channel` task
+  by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+
 ## v1.3.96 (2024-01-31)
 
 ### Added

--- a/engine/apps/slack/tests/tasks/test_send_message_to_thread_if_bot_not_in_channel.py
+++ b/engine/apps/slack/tests/tasks/test_send_message_to_thread_if_bot_not_in_channel.py
@@ -1,0 +1,99 @@
+from unittest.mock import ANY, patch
+
+import pytest
+from celery import exceptions
+
+from apps.slack.errors import SlackAPIRatelimitError
+from apps.slack.tasks import send_message_to_thread_if_bot_not_in_channel
+from apps.slack.tests.conftest import build_slack_response
+
+BOT_USER_ID = "U12345678"
+TEXT = f"Please invite <@{BOT_USER_ID}> to this channel to make all features available :wink:"
+
+
+@pytest.mark.parametrize("channel_members", [["U0909090"], [BOT_USER_ID]])
+@patch("apps.slack.models.SlackTeamIdentity.get_conversation_members")
+@patch("apps.slack.tasks.SlackClient")
+@patch("apps.slack.tasks.AlertGroupSlackService")
+@pytest.mark.django_db
+def test_send_message_to_thread_if_bot_not_in_channel(
+    MockAlertGroupSlackService,
+    MockSlackClient,
+    mock_get_conversation_members,
+    make_slack_team_identity,
+    make_slack_channel,
+    make_organization,
+    make_alert_receive_channel,
+    make_alert_group,
+    channel_members,
+):
+    mock_get_conversation_members.return_value = channel_members
+
+    slack_team_identity = make_slack_team_identity(bot_user_id=BOT_USER_ID)
+    slack_channel = make_slack_channel(slack_team_identity)
+
+    organization = make_organization(slack_team_identity=slack_team_identity)
+
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    send_message_to_thread_if_bot_not_in_channel(alert_group.pk, slack_team_identity.pk, slack_channel.pk)
+
+    MockSlackClient.assert_called_once_with(slack_team_identity, enable_ratelimit_retry=True)
+    mock_get_conversation_members.assert_called_once_with(MockSlackClient.return_value, slack_channel.pk)
+
+    if BOT_USER_ID not in channel_members:
+        MockAlertGroupSlackService.assert_called_once_with(slack_team_identity, MockSlackClient.return_value)
+
+        MockAlertGroupSlackService.return_value.publish_message_to_alert_group_thread.assert_called_once_with(
+            alert_group, text=TEXT
+        )
+    else:
+        MockAlertGroupSlackService.return_value.publish_message_to_alert_group_thread.assert_not_called()
+
+
+@patch("apps.slack.models.SlackTeamIdentity.get_conversation_members")
+@patch("apps.slack.tasks.SlackClient")
+@patch("apps.slack.tasks.AlertGroupSlackService")
+@patch("apps.slack.tasks.send_message_to_thread_if_bot_not_in_channel.retry")
+@pytest.mark.django_db
+def test_send_message_to_thread_if_bot_not_in_channel_slack_api_rate_limit_error(
+    mock_send_message_to_thread_if_bot_not_in_channel_retry,
+    MockAlertGroupSlackService,
+    MockSlackClient,
+    mock_get_conversation_members,
+    make_slack_team_identity,
+    make_slack_channel,
+    make_organization,
+    make_alert_receive_channel,
+    make_alert_group,
+):
+    mock_send_message_to_thread_if_bot_not_in_channel_retry.side_effect = exceptions.Retry()
+    mock_get_conversation_members.return_value = ["U0909090"]
+
+    RETRY_AFTER = 42
+
+    MockAlertGroupSlackService.return_value.publish_message_to_alert_group_thread.side_effect = SlackAPIRatelimitError(
+        response=build_slack_response({"ok": False, "error": "ratelimited"}, headers={"Retry-After": RETRY_AFTER})
+    )
+
+    slack_team_identity = make_slack_team_identity(bot_user_id=BOT_USER_ID)
+    slack_channel = make_slack_channel(slack_team_identity)
+
+    organization = make_organization(slack_team_identity=slack_team_identity)
+
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    with pytest.raises(exceptions.Retry):
+        send_message_to_thread_if_bot_not_in_channel(alert_group.pk, slack_team_identity.pk, slack_channel.pk)
+
+    MockAlertGroupSlackService.assert_called_once_with(slack_team_identity, MockSlackClient.return_value)
+
+    MockAlertGroupSlackService.return_value.publish_message_to_alert_group_thread.assert_called_once_with(
+        alert_group, text=TEXT
+    )
+
+    mock_send_message_to_thread_if_bot_not_in_channel_retry.assert_called_once_with(
+        (alert_group.pk, slack_team_identity.pk, slack_channel.pk), countdown=RETRY_AFTER, exc=ANY
+    )


### PR DESCRIPTION
# What this PR does

See [this conversation](https://raintank-corp.slack.com/archives/C04JCU51NF8/p1706722752735009) for more context.

Additionally, improves logging for this task + adds unit tests.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
