### PR TITLE
attempt to address some `SlackAPIRatelimitError` exceptions 

### DIFF
--- a/engine/apps/slack/models/slack_message.py
+++ b/engine/apps/slack/models/slack_message.py
@@ -131,7 +131,7 @@ class SlackMessage(models.Model):
                 },
             }
         ]
-        sc = SlackClient(self.slack_team_identity)
+        sc = SlackClient(self.slack_team_identity, enable_ratelimit_retry=True)
         channel_id = slack_message.channel_id
 
         try:

--- a/engine/apps/slack/utils.py
+++ b/engine/apps/slack/utils.py
@@ -70,7 +70,7 @@ def post_message_to_channel(organization: "Organization", channel_id: str, text:
     if not organization.slack_team_identity:
         return
 
-    slack_client = SlackClient(organization.slack_team_identity)
+    slack_client = SlackClient(organization.slack_team_identity, enable_ratelimit_retry=True)
     try:
         slack_client.chat_postMessage(channel=channel_id, text=text)
     except (


### PR DESCRIPTION
# Which issue(s) this PR fixes

Closes https://github.com/grafana/oncall-private/issues/2515

Attempts to address some `SlackAPIRatelimitError` exceptions seen in the following tasks:
- `apps.slack.tasks.post_slack_rate_limit_message` ([logs](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22qhs%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%23%20%7Bcluster%3D~%5C%22prod-%28us-central-0%7Ceu-west-0%29%5C%22,%20namespace%3D%5C%22amixr-prod%5C%22,%20job%3D~%5C%22amixr-prod%2Famixr-engine-celery-retry%2A%5C%22%7D%5Cn%7Bcluster%3D~%5C%22prod-%28us-central-0%7Ceu-west-0%29%5C%22,%20namespace%3D%5C%22amixr-prod%5C%22%7D%20%7C%3D%20%5C%22apps.slack.tasks.post_slack_rate_limit_message%5C%22%20%7C%3D%20%5C%22retry%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1))
- `alerts.tasks.notify_user.perform_notification` ([logs](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22qhs%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bcluster%3D~%5C%22prod-%28us-central-0%7Ceu-west-0%29%5C%22,%20namespace%3D%5C%22amixr-prod%5C%22%7D%20%7C%3D%20%5C%22SlackAPIRatelimitError%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1))

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
