### PR TITLE
Handle ag telegram message does not exist

### DIFF
--- a/engine/apps/telegram/client.py
+++ b/engine/apps/telegram/client.py
@@ -8,6 +8,7 @@ from telegram.utils.request import Request
 
 from apps.alerts.models import AlertGroup
 from apps.base.utils import live_settings
+from apps.telegram.exceptions import AlertGroupTelegramMessageDoesNotExist
 from apps.telegram.models import TelegramMessage
 from apps.telegram.renderers.keyboard import TelegramKeyboardRenderer
 from apps.telegram.renderers.message import TelegramMessageRenderer
@@ -157,7 +158,10 @@ class TelegramClient:
             ).first()
 
             if alert_group_message is None:
-                raise Exception("No alert group message found, probably it is not saved to database yet")
+                raise AlertGroupTelegramMessageDoesNotExist(
+                    f"No alert group message found, probably it is not saved to database yet, "
+                    f"alert group: {alert_group.id}"
+                )
 
             include_title = message_type == TelegramMessage.LINK_TO_CHANNEL_MESSAGE
             link = alert_group_message.link

--- a/engine/apps/telegram/exceptions.py
+++ b/engine/apps/telegram/exceptions.py
@@ -1,0 +1,2 @@
+class AlertGroupTelegramMessageDoesNotExist(Exception):
+    pass

--- a/engine/apps/telegram/tasks.py
+++ b/engine/apps/telegram/tasks.py
@@ -16,6 +16,7 @@ from apps.telegram.decorators import (
     ignore_message_unchanged,
     ignore_reply_to_message_deleted,
 )
+from apps.telegram.exceptions import AlertGroupTelegramMessageDoesNotExist
 from apps.telegram.models import TelegramMessage, TelegramToOrganizationConnector
 from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 from common.utils import OkToRetry
@@ -84,7 +85,7 @@ def edit_message(self, message_pk):
 
 @shared_dedicated_queue_retry_task(bind=True, autoretry_for=(Exception,), retry_backoff=True, max_retries=None)
 def send_link_to_channel_message_or_fallback_to_full_alert_group(
-    self, alert_group_pk, notification_policy_pk, user_connector_pk
+    self, alert_group_pk, notification_policy_pk, user_connector_pk, is_first_message_check=True
 ):
     from apps.telegram.models import TelegramToUserConnector
 
@@ -101,6 +102,16 @@ def send_link_to_channel_message_or_fallback_to_full_alert_group(
         else:
             # seems like the message won't appear in Telegram channel, so send the full alert group to user
             user_connector.send_full_alert_group(alert_group=alert_group, notification_policy=notification_policy)
+    except AlertGroupTelegramMessageDoesNotExist as e:
+        # On the first run, if alert group message doesn't exist in db, restart the task without retry.
+        # The message is expected to appear by the next call, otherwise Exception will be raised.
+        if is_first_message_check:
+            logger.warning(f"{e}. Restarting task")
+            send_link_to_channel_message_or_fallback_to_full_alert_group.apply_async(
+                (alert_group_pk, notification_policy_pk, user_connector_pk, False), countdown=3
+            )
+        else:
+            raise e
     except TelegramToUserConnector.DoesNotExist:
         # Handle cases when user deleted the bot while escalation is active
         logger.warning(

--- a/engine/apps/telegram/tests/test_tasks.py
+++ b/engine/apps/telegram/tests/test_tasks.py
@@ -3,9 +3,14 @@ from unittest.mock import patch
 import pytest
 from telegram import error
 
+from apps.base.models import UserNotificationPolicy
 from apps.telegram.client import TelegramClient
-from apps.telegram.models import TelegramMessage
-from apps.telegram.tasks import send_log_and_actions_message
+from apps.telegram.exceptions import AlertGroupTelegramMessageDoesNotExist
+from apps.telegram.models import TelegramMessage, TelegramToUserConnector
+from apps.telegram.tasks import (
+    send_link_to_channel_message_or_fallback_to_full_alert_group,
+    send_log_and_actions_message,
+)
 
 
 @patch.object(TelegramClient, "send_raw_message", side_effect=error.BadRequest("Message to reply not found"))
@@ -45,3 +50,43 @@ def test_send_log_and_actions_replied_message_not_found(
         f"due to 'Message to reply not found'. alert_group {alert_group.pk}"
     )
     assert expected_msg in caplog.text
+
+
+@patch.object(TelegramToUserConnector, "send_link_to_channel_message")
+@pytest.mark.django_db
+def test_send_link_to_channel_message_or_fallback_to_full_alert_group_message_does_not_exist(
+    mock_send_link_to_channel_message,
+    make_organization_and_user,
+    make_telegram_user_connector,
+    make_user_notification_policy,
+    make_alert_receive_channel,
+    make_alert_group,
+):
+    organization, user = make_organization_and_user()
+    user_connector = make_telegram_user_connector(user)
+    user_notification_policy = make_user_notification_policy(
+        user=user,
+        step=UserNotificationPolicy.Step.NOTIFY,
+        notify_by=UserNotificationPolicy.NotificationChannel.TELEGRAM,
+    )
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    mock_send_link_to_channel_message.side_effect = AlertGroupTelegramMessageDoesNotExist(
+        f"No alert group message found, probably it is not saved to database yet, alert group: {alert_group.id}"
+    )
+
+    with patch.object(send_link_to_channel_message_or_fallback_to_full_alert_group, "apply_async") as mocked_task_call:
+        send_link_to_channel_message_or_fallback_to_full_alert_group(
+            alert_group.id, user_notification_policy.id, user_connector.id
+        )
+    # No exception raised, task restarted with `is_first_message_check=False`
+    mocked_task_call.assert_called_once_with(
+        (alert_group.id, user_notification_policy.id, user_connector.id, False), countdown=3
+    )
+    # if task started with `is_first_message_check=False` and alert group telegram message was not found,
+    # exception will be raised
+    with pytest.raises(AlertGroupTelegramMessageDoesNotExist):
+        send_link_to_channel_message_or_fallback_to_full_alert_group(
+            alert_group.id, user_notification_policy.id, user_connector.id, False
+        )


### PR DESCRIPTION
# What this PR does
Restart `send_link_to_channel_message_or_fallback_to_full_alert_group` task without retry on the first run if alert group telegram message doesn't exist. On the second run raise Exception

## Which issue(s) this PR fixes
https://github.com/grafana/oncall-private/issues/2492
## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
