### PR TITLE
add `pytest-xdist` to speed up backend tests

### DIFF
--- a/engine/apps/integrations/tests/test_views.py
+++ b/engine/apps/integrations/tests/test_views.py
@@ -13,6 +13,9 @@ from rest_framework.test import APIClient
 from apps.alerts.models import AlertReceiveChannel
 from apps.integrations.mixins import AlertChannelDefiningMixin
 
+# https://github.com/pytest-dev/pytest-xdist/issues/432#issuecomment-528510433
+INTEGRATION_TYPES = sorted(AlertReceiveChannel.INTEGRATION_TYPES)
+
 
 class DatabaseBlocker(_DatabaseBlocker):
     """Customize pytest_django db blocker to raise OperationalError exception."""
@@ -78,7 +81,7 @@ def test_integration_form_data_too_big(settings, make_organization_and_user, mak
     "integration_type",
     [
         arc_type
-        for arc_type in AlertReceiveChannel.INTEGRATION_TYPES
+        for arc_type in INTEGRATION_TYPES
         if arc_type not in ["amazon_sns", "grafana", "alertmanager", "grafana_alerting", "maintenance"]
     ],
 )
@@ -230,7 +233,7 @@ def test_integration_old_grafana_endpoint(
     "integration_type",
     [
         arc_type
-        for arc_type in AlertReceiveChannel.INTEGRATION_TYPES
+        for arc_type in INTEGRATION_TYPES
         if arc_type not in ["amazon_sns", "grafana", "alertmanager", "grafana_alerting", "maintenance"]
     ],
 )
@@ -264,7 +267,7 @@ def test_integration_universal_endpoint_not_allow_files(
     "integration_type",
     [
         arc_type
-        for arc_type in AlertReceiveChannel.INTEGRATION_TYPES
+        for arc_type in INTEGRATION_TYPES
         if arc_type not in ["amazon_sns", "grafana", "alertmanager", "grafana_alerting", "maintenance"]
     ],
 )
@@ -367,7 +370,7 @@ def test_integration_grafana_endpoint_without_db_has_alerts(
     "integration_type",
     [
         arc_type
-        for arc_type in AlertReceiveChannel.INTEGRATION_TYPES
+        for arc_type in INTEGRATION_TYPES
         if arc_type not in ["amazon_sns", "grafana", "alertmanager", "grafana_alerting", "maintenance"]
     ],
 )
@@ -467,7 +470,7 @@ def test_integration_grafana_endpoint_without_cache_has_alerts(
     "integration_type",
     [
         arc_type
-        for arc_type in AlertReceiveChannel.INTEGRATION_TYPES
+        for arc_type in INTEGRATION_TYPES
         if arc_type not in ["amazon_sns", "grafana", "alertmanager", "grafana_alerting", "maintenance"]
     ],
 )

--- a/engine/requirements-dev.txt
+++ b/engine/requirements-dev.txt
@@ -12,3 +12,4 @@ types-PyMySQL==1.0.19.7
 types-python-dateutil==2.8.19.13
 types-requests==2.31.0.1
 httpretty==1.1.4
+pytest-xdist[psutil]==3.5.0

--- a/engine/tox.ini
+++ b/engine/tox.ini
@@ -10,6 +10,6 @@ banned-modules =
 [pytest]
 # https://pytest-django.readthedocs.io/en/latest/configuring_django.html#order-of-choosing-settings
 # https://pytest-django.readthedocs.io/en/latest/database.html
-addopts = --no-migrations --color=yes --showlocals
+addopts = -n auto --no-migrations --color=yes --showlocals
 # https://pytest-django.readthedocs.io/en/latest/faq.html#my-tests-are-not-being-found-why
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
# What this PR does

Speeds up `pytest` test execution by ~30%.

More specifically, adds [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/), which according to their docs:
> plugin extends pytest with new test execution modes, the most used being distributing tests across multiple CPUs to speed up test execution 

**Before**
<img width="270" alt="Screenshot 2024-02-05 at 15 53 13" src="https://github.com/grafana/oncall/assets/9406895/4da33299-5bd0-4dc3-86e1-32cfdf9106f7">

**After**
<img width="254" alt="Screenshot 2024-02-05 at 15 53 04" src="https://github.com/grafana/oncall/assets/9406895/a59eeb52-291d-4cdc-82b2-55fd31e1c1c5">
