### PR TITLE
Add access for alerts and alert groups on public api 

### DIFF
--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -1881,3 +1881,14 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         """
         count = self.alerts.all()[: max_alerts + 1].count()
         return count > max_alerts
+
+    def save(self, *args, **kwargs):
+        from apps.auth_token.auth import GRAFANA_SA_USERNAME
+
+        if self.acknowledged_by_user and self.acknowledged_by_user.username == GRAFANA_SA_USERNAME:
+            self.acknowledged_by_user = None
+        if self.resolved_by_user and self.resolved_by_user.username == GRAFANA_SA_USERNAME:
+            self.resolved_by_user = None
+        if self.silenced_by_user and self.silenced_by_user.username == GRAFANA_SA_USERNAME:
+            self.silenced_by_user = None
+        super().save(*args, **kwargs)

--- a/engine/apps/alerts/models/alert_group_log_record.py
+++ b/engine/apps/alerts/models/alert_group_log_record.py
@@ -600,6 +600,13 @@ class AlertGroupLogRecord(models.Model):
         )
         super().delete()
 
+    def save(self, *args, **kwargs):
+        from apps.auth_token.auth import GRAFANA_SA_USERNAME
+
+        if self.author and self.author.username == GRAFANA_SA_USERNAME:
+            self.author = None
+        super().save(*args, **kwargs)
+
 
 @receiver(post_save, sender=AlertGroupLogRecord)
 def listen_for_alertgrouplogrecord(sender, instance, created, *args, **kwargs):

--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -288,6 +288,8 @@ class UserScheduleExportAuthentication(BaseAuthentication):
 
 X_GRAFANA_INSTANCE_ID = "X-Grafana-Instance-ID"
 GRAFANA_SA_PREFIX = "glsa_"
+GRAFANA_SA_USERNAME = "grafana_service_account"
+GRAFANA_SA_NAME = "Grafana Service Account"
 
 
 class GrafanaServiceAccountAuthentication(BaseAuthentication):
@@ -330,8 +332,8 @@ class GrafanaServiceAccountAuthentication(BaseAuthentication):
 
         user = User(
             organization_id=organization.pk,
-            name="Grafana Service Account",
-            username="grafana_service_account",
+            name=GRAFANA_SA_NAME,
+            username=GRAFANA_SA_USERNAME,
             role=role,
             permissions=[GrafanaAPIPermission(action=key) for key, _ in permissions.items()],
         )

--- a/engine/apps/public_api/views/alerts.py
+++ b/engine/apps/public_api/views/alerts.py
@@ -6,7 +6,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
 from apps.alerts.models import Alert
-from apps.auth_token.auth import ApiTokenAuthentication
+from apps.api.permissions import RBACPermission
+from apps.auth_token.auth import ApiTokenAuthentication, GrafanaServiceAccountAuthentication
 from apps.public_api.serializers.alerts import AlertSerializer
 from apps.public_api.throttlers.user_throttle import UserThrottle
 from common.api_helpers.mixins import RateLimitHeadersMixin
@@ -18,8 +19,18 @@ class AlertFilter(filters.FilterSet):
 
 
 class AlertView(RateLimitHeadersMixin, mixins.ListModelMixin, GenericViewSet):
-    authentication_classes = (ApiTokenAuthentication,)
-    permission_classes = (IsAuthenticated,)
+    authentication_classes = (
+        GrafanaServiceAccountAuthentication,
+        ApiTokenAuthentication,
+    )
+    permission_classes = (IsAuthenticated, RBACPermission)
+
+    rbac_permissions = {
+        "metadata": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "list": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "retrieve": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "filters": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+    }
 
     throttle_classes = [UserThrottle]
 

--- a/engine/apps/public_api/views/incidents.py
+++ b/engine/apps/public_api/views/incidents.py
@@ -10,7 +10,8 @@ from rest_framework.viewsets import GenericViewSet
 from apps.alerts.constants import ActionSource
 from apps.alerts.models import AlertGroup
 from apps.alerts.tasks import delete_alert_group, wipe
-from apps.auth_token.auth import ApiTokenAuthentication
+from apps.api.permissions import RBACPermission
+from apps.auth_token.auth import ApiTokenAuthentication, GrafanaServiceAccountAuthentication
 from apps.public_api.constants import VALID_DATE_FOR_DELETE_INCIDENT
 from apps.public_api.helpers import is_valid_group_creation_date, team_has_slack_token_for_deleting
 from apps.public_api.serializers import IncidentSerializer
@@ -37,8 +38,23 @@ class IncidentByTeamFilter(ByTeamModelFieldFilterMixin, filters.FilterSet):
 class IncidentView(
     RateLimitHeadersMixin, mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.DestroyModelMixin, GenericViewSet
 ):
-    authentication_classes = (ApiTokenAuthentication,)
-    permission_classes = (IsAuthenticated,)
+    authentication_classes = (
+        GrafanaServiceAccountAuthentication,
+        ApiTokenAuthentication,
+    )
+    permission_classes = (IsAuthenticated, RBACPermission)
+
+    rbac_permissions = {
+        "metadata": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "list": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "retrieve": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "filters": [RBACPermission.Permissions.ALERT_GROUPS_READ],
+        "destroy": [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+        "acknowledge": [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+        "unacknowledge": [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+        "resolve": [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+        "unresolve": [RBACPermission.Permissions.ALERT_GROUPS_WRITE],
+    }
 
     throttle_classes = [UserThrottle]
 


### PR DESCRIPTION
# What this PR does
Allow use of grafana service account token to access alerts and alert groups through public API.
We don't currently track author, or acknowledge, resolve, unsilence by after a user is deleted, the field is set to null.  
It's a bit hacky around the solution to not having a user object for the service account.  
A different way we can go would be to establish user objects for service accounts but it affects more code since we need to exclude these users in most cases.

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
