### PR TITLE
Fix rounding issue with displayed time when sending "You're going oncall" push notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow mobile app to access escalation options endpoints @imtoori ([#3847](https://github.com/grafana/oncall/pull/3847))
 - Enable templating for alert escalation mobile app push notifications by @joeyorlando ([#3845](https://github.com/grafana/oncall/pull/3845))
 
+### Fixed
+
+- Fix rounding issue with displayed time when sending "You're going oncall" push notification by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+
 ## v1.3.102 (2024-02-06)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix rounding issue with displayed time when sending "You're going oncall" push notification by @joeyorlando ([#TBD](https://github.com/grafana/oncall/pull/TBD))
+- Fix rounding issue with displayed time when sending "You're going oncall" push notification by @joeyorlando ([#3872](https://github.com/grafana/oncall/pull/3872))
 
 ## v1.3.102 (2024-02-06)
 

--- a/engine/apps/mobile_app/models.py
+++ b/engine/apps/mobile_app/models.py
@@ -177,6 +177,8 @@ class MobileAppUserSettings(models.Model):
         (TWELVE_HOURS_IN_SECONDS, "12 hours before"),
         (ONE_DAY_IN_SECONDS, "1 day before"),
     )
+    ALL_NOTIFICATION_TIMING_CHOICES_SECONDS = [choice[0] for choice in NOTIFICATION_TIMING_CHOICES]
+
     going_oncall_notification_timing = JSONField(default=default_notification_timing_options)
 
     locale = models.CharField(max_length=50, null=True)

--- a/engine/apps/mobile_app/tasks/going_oncall_notification.py
+++ b/engine/apps/mobile_app/tasks/going_oncall_notification.py
@@ -33,7 +33,12 @@ logger.setLevel(logging.DEBUG)
 
 
 def _get_notification_title(seconds_until_going_oncall: int) -> str:
-    return f"Your on-call shift starts in {humanize.naturaldelta(seconds_until_going_oncall)}"
+    from apps.mobile_app.models import MobileAppUserSettings
+
+    rounded_seconds = min(
+        MobileAppUserSettings.ALL_NOTIFICATION_TIMING_CHOICES_SECONDS, key=lambda x: abs(x - seconds_until_going_oncall)
+    )
+    return f"Your on-call shift starts in {humanize.naturaldelta(rounded_seconds)}"
 
 
 def _get_notification_subtitle(

--- a/engine/apps/mobile_app/tests/tasks/test_going_oncall_notification.py
+++ b/engine/apps/mobile_app/tests/tasks/test_going_oncall_notification.py
@@ -59,12 +59,11 @@ def test_shift_starts_within_range(timing_window_lower, timing_window_upper, sec
 @pytest.mark.parametrize(
     "seconds_until_going_oncall,humanized_time_until_going_oncall",
     [
-        (600, "10 minutes"),
-        # TODO: right now this returns 11 hours but it should probably round up to 12 hours instead..
-        # 11 hours and 53 minutes
-        ((60 * 60 * 11) + (53 * 60), "11 hours"),
-        # 12 hours and 10 minutes
-        ((60 * 60 * 12) + (10 * 60), "12 hours"),
+        (8 * 60, "15 minutes"),  # 8 minutes
+        (600, "15 minutes"),
+        ((60 * 60 * 11) + (53 * 60), "12 hours"),  # 11 hours and 53 minutes
+        ((60 * 60 * 12) + (10 * 60), "12 hours"),  # 12 hours and 10 minutes
+        (60 * 60 * 26, "a day"),  # 1 day and 2 hours
     ],
 )
 @pytest.mark.django_db


### PR DESCRIPTION
# Which issue(s) this PR fixes

So because of how we run the task that sends the "You're going oncall" push notifications, there are sometimes rounding "errors" in the displayed text of the push notification. For example, if you've configured your mobile app to remind you 12h before your on-call shift starts it sometimes might say:

> You're going oncall in 11 hours

This is because of the [background task being executed every 10mins](https://github.com/grafana/oncall/blob/dev/engine/settings/base.py#L545-L548) and us continually checking if now is the appropriate time to send the notification (we took this approach because we don't have any easy way of emitting an event exactly when a shift starts.. yay ical).

This PR corrects that by rounding to the closest configuration value that we allow.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
