### PR TITLE
Don't html escape quotes when rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Quotes in templates not rendering results correctly ([#3884](https://github.com/grafana/oncall/pull/3884))
+
 ## v1.3.103 (2024-02-12)
 
 ### Added

--- a/engine/apps/api/tests/test_alert_group.py
+++ b/engine/apps/api/tests/test_alert_group.py
@@ -1919,7 +1919,7 @@ def test_alert_group_preview_body_non_existent_template_var(
 
     # Return errors as preview body instead of None
     assert response.status_code == status.HTTP_200_OK
-    assert response.json()["preview"] == "Template Warning: &#x27;foobar&#x27; is undefined"
+    assert response.json()["preview"] == "Template Warning: 'foobar' is undefined"
 
 
 @pytest.mark.django_db
@@ -1942,7 +1942,7 @@ def test_alert_group_preview_body_invalid_template_syntax(
 
     # Errors now returned preview content
     assert response.status_code == status.HTTP_200_OK
-    assert response.data["preview"] == "Template Error: No test named &#x27;None&#x27; found."
+    assert response.data["preview"] == "Template Error: No test named 'None' found."
 
 
 @pytest.mark.django_db

--- a/engine/common/utils.py
+++ b/engine/common/utils.py
@@ -239,7 +239,7 @@ def clean_markup(text):
 
 
 def escape_html(text):
-    return html.escape(text)
+    return html.escape(text, quote=False)
 
 
 def urlize_with_respect_to_a(html):


### PR DESCRIPTION
# What this PR does
Disable escaping quotes for html in template results

![Screenshot from 2024-02-12 12-40-38](https://github.com/grafana/oncall/assets/28077050/221be1e9-1ced-48bf-9bbc-45fa8c9a4347)

Alert group 6 shows the new rendering vs group 5 which has the previous incorrect rendering.

## Which issue(s) this PR fixes
#3864 

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
