### PR TITLE
Fix edit default team by admin

### DIFF
--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/UserInfoTab/UserInfoTab.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/UserInfoTab/UserInfoTab.tsx
@@ -50,7 +50,7 @@ export const UserInfoTab = (props: UserInfoTabProps) => {
           withoutModal
           defaultValue={storeUser.current_team}
           onSelect={async (value) => {
-            await userStore.updateCurrentUser({ current_team: value });
+            await userStore.updateUser({ pk: storeUser.pk, current_team: value });
             store.grafanaTeamStore.updateItems();
           }}
         />


### PR DESCRIPTION
# What this PR does
Fixes issue where when an admin edits the default team of another user it would change the admin's default team instead of the selected user.

## Which issue(s) this PR fixes
#3819 

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
