### PR TITLE
Update user details internal API perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Check for permissions on Slack escalate command ([#3891](https://github.com/grafana/oncall/pull/3891))
 - Do not delete webhook if its team is deleted @mderynck ([#3873](https://github.com/grafana/oncall/pull/3873))
+- Update user details internal API perms ([#3900](https://github.com/grafana/oncall/pull/3900))
 
 ## v1.3.105 (2024-02-13)
 

--- a/engine/apps/api/tests/test_team.py
+++ b/engine/apps/api/tests/test_team.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 
 from apps.alerts.models import AlertReceiveChannel
 from apps.api.permissions import LegacyAccessControlRole
+from apps.api.serializers.user import UserHiddenFieldsSerializer
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleCalendar, OnCallScheduleWeb
 from apps.user_management.models import Team
 from common.api_helpers.filters import NO_TEAM_VALUE
@@ -429,7 +430,11 @@ def test_team_permissions_not_in_team(
     url = reverse("api-internal:user-detail", kwargs={"pk": another_user.public_primary_key})
     response = client.get(url, **make_user_auth_headers(user, token))
 
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_200_OK
+    user_details = response.json()
+    for f_name in user_details:
+        if f_name not in UserHiddenFieldsSerializer.fields_available_for_all_users:
+            user_details[f_name] = "******"
 
 
 @pytest.mark.django_db

--- a/engine/apps/api/tests/test_user.py
+++ b/engine/apps/api/tests/test_user.py
@@ -557,8 +557,8 @@ def test_user_detail_self_permissions(
     "role,expected_status",
     [
         (LegacyAccessControlRole.ADMIN, status.HTTP_200_OK),
-        (LegacyAccessControlRole.EDITOR, status.HTTP_403_FORBIDDEN),
-        (LegacyAccessControlRole.VIEWER, status.HTTP_403_FORBIDDEN),
+        (LegacyAccessControlRole.EDITOR, status.HTTP_200_OK),
+        (LegacyAccessControlRole.VIEWER, status.HTTP_200_OK),
         (LegacyAccessControlRole.NONE, status.HTTP_403_FORBIDDEN),
     ],
 )
@@ -577,6 +577,12 @@ def test_user_detail_other_permissions(
     response = client.get(url, format="json", **make_user_auth_headers(tester, token))
 
     assert response.status_code == expected_status
+    # hidden information for editor/viewer
+    if role in (LegacyAccessControlRole.EDITOR, LegacyAccessControlRole.VIEWER):
+        user_details = response.json()
+        for f_name in user_details:
+            if f_name not in UserHiddenFieldsSerializer.fields_available_for_all_users:
+                user_details[f_name] = "******"
 
 
 @pytest.mark.django_db
@@ -1118,7 +1124,12 @@ def test_user_can_detail_users(
     url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
 
     response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
-    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert response.status_code == status.HTTP_200_OK
+    # hidden information though
+    user_details = response.json()
+    for f_name in user_details:
+        if f_name not in UserHiddenFieldsSerializer.fields_available_for_all_users:
+            user_details[f_name] = "******"
 
 
 @patch("apps.phone_notifications.phone_backend.PhoneBackend.send_verification_sms", return_value=Mock())
@@ -1411,20 +1422,6 @@ def test_viewer_can_list_users(make_organization_and_user_with_plugin_token, mak
 
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
     assert response.status_code == status.HTTP_200_OK
-
-
-@pytest.mark.django_db
-def test_viewer_cant_detail_users(
-    make_organization_and_user_with_plugin_token, make_user_for_organization, make_user_auth_headers
-):
-    organization, first_user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
-    second_user = make_user_for_organization(organization, role=LegacyAccessControlRole.VIEWER)
-
-    client = APIClient()
-    url = reverse("api-internal:user-detail", kwargs={"pk": first_user.public_primary_key})
-    response = client.get(url, format="json", **make_user_auth_headers(second_user, token))
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @patch("apps.phone_notifications.phone_backend.PhoneBackend.send_verification_sms", return_value=Mock())

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -234,7 +234,6 @@ class UserView(
         IsOwnerOrHasUserSettingsAdminPermission: [
             "metadata",
             "list",
-            "retrieve",
             "update",
             "partial_update",
             "destroy",
@@ -255,6 +254,7 @@ class UserView(
         ],
         IsOwnerOrHasUserSettingsReadPermission: [
             "check_availability",
+            "retrieve",
         ],
     }
 


### PR DESCRIPTION
Related to https://github.com/grafana/oncall/issues/1820
Editor and Viewer roles have the user-settings:read permission, which allows them to list users but with some of the data hidden. It makes sense to allow the same thing for the detail endpoint, keeping the viewable data restriction (fixing the referenced issue too).