### PR TITLE
Add parse_json template function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support prescribed labels ([#3848](https://github.com/grafana/oncall/pull/3848))
 - Add status change trigger type to webhooks ([#3920](https://github.com/grafana/oncall/pull/3920))
 - Add `EMAIL_USE_SSL` environment setting by @WoodyWoodsta ([#3911](https://github.com/grafana/oncall/pull/3911))
-- Add `json_loads` Jinja2 template filter by @KarimDarwish ([#00](https://github.com/grafana/oncall/pull/00))
+- Add `parse_json` Jinja2 template filter by @KarimDarwish ([#00](https://github.com/grafana/oncall/pull/00))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support prescribed labels ([#3848](https://github.com/grafana/oncall/pull/3848))
 - Add status change trigger type to webhooks ([#3920](https://github.com/grafana/oncall/pull/3920))
 - Add `EMAIL_USE_SSL` environment setting by @WoodyWoodsta ([#3911](https://github.com/grafana/oncall/pull/3911))
+- Add `json_loads` Jinja2 template filter by @KarimDarwish ([#00](https://github.com/grafana/oncall/pull/00))
 
 ### Fixed
 

--- a/docs/sources/configure/jinja2-templating/index.md
+++ b/docs/sources/configure/jinja2-templating/index.md
@@ -118,17 +118,17 @@ How alerts are displayed in the UI, messengers, and notifications
 #### Behavioral templates
 
 - `Grouping Id` - applied to every incoming alert payload after the `Routing Template`. It
-  can be based on time, alert content, or both. If the resulting grouping id matches an
-  existing non-resolved alert group grouping id, the alert will be grouped accordingly.
-  Otherwise, a new alert group will be created
+can be based on time, alert content, or both. If the resulting grouping id matches an
+existing non-resolved alert group grouping id, the alert will be grouped accordingly.
+Otherwise, a new alert group will be created
 - `Autoresolution` - used to auto-resolve alert groups with status `Resolved by source`
-  (Conditional template, output should be `True`)
+(Conditional template, output should be `True`)
 - `Auto acknowledge` - used to auto-acknowledge alert groups with status `Acknowledged by
-  source` (Conditional template, output should be `True`)
+source` (Conditional template, output should be `True`)
 - `Source link` - Used to customize the URL link to provide as the "source" of the alert.
 
-  > **Note:** For conditional templates, the output should be `True` to be applied, for
-  example `{{ True if payload.state == 'OK' else False }}`
+   > **Note:** For conditional templates, the output should be `True` to be applied, for
+   example `{{ True if payload.state == 'OK' else False }}`
 
 > **Pro Tip:** As a best practice, add _Playbooks_, _Useful links_, or _Checklists_ to the
 alert message.
@@ -136,21 +136,21 @@ alert message.
 #### How to edit templates
 
 1. Open the **Integration** page for the integration you want to edit
-   1`. Click the **Edit** button for the Templates Section. Now you can see previews of all
-   templates for the Integration
+1`. Click the **Edit** button for the Templates Section. Now you can see previews of all
+templates for the Integration
 1. Select the template you want to edit and click the **Edit** button to the right to the template
-   name. The template editor will open. The first column is the example alert payload, second
-   column is the Template itself, and third column is used to view rendered result.
+name. The template editor will open. The first column is the example alert payload, second
+column is the Template itself, and third column is used to view rendered result.
 1. Select one of the **Recent Alert groups** for the integration to see its `latest alert
-   payload`. If you want to edit this payload, click the **Edit** button right to the Alert Group
-   Name.
+payload`. If you want to edit this payload, click the **Edit** button right to the Alert Group
+Name.
 1. Alternatively, you can click **Use custom payload** and write your own payload to see
-   how it will be rendered
+how it will be rendered
 1. Press `Control + Enter` in the editor to see suggestions
 1. Click **Cheatsheet** in the second column to get some inspiration.
 1. If you edit Messenger templates, click **Save and open Alert Group in ChatOps** to see
-   how the alert will be rendered in the messenger, right in the messenger (Only works for
-   an Alert Group that exists in the messenger)
+how the alert will be rendered in the messenger, right in the messenger (Only works for
+an Alert Group that exists in the messenger)
 1. Click **Save** to save the template
 
 ## Advanced Jinja templates

--- a/docs/sources/configure/jinja2-templating/index.md
+++ b/docs/sources/configure/jinja2-templating/index.md
@@ -17,7 +17,6 @@ aliases:
   - ../jinja2-templating/ # /docs/oncall/<ONCALL_VERSION>/jinja2-templating/
 ---
 
-
 ## Jinja2 templating
 
 Grafana OnCall can integrate with any monitoring system that can send alerts via
@@ -98,9 +97,11 @@ customization, use Jinja templates.
 
 ### Routing template
 
-- `Routing Template` - used to route alerts to different Escalation Chains based on alert content (conditional template, output should be `True`)
+- `Routing Template` - used to route alerts to different Escalation Chains based on alert content (conditional template,
+  output should be `True`)
 
-   > **Note:** For conditional templates, the output should be `True` to be applied, for example `{{ True if payload.state == 'OK' else False }}`
+  > **Note:** For conditional templates, the output should be `True` to be applied, for
+  example `{{ True if payload.state == 'OK' else False }}`
 
 #### Appearance templates
 
@@ -118,39 +119,39 @@ How alerts are displayed in the UI, messengers, and notifications
 #### Behavioral templates
 
 - `Grouping Id` - applied to every incoming alert payload after the `Routing Template`. It
-can be based on time, alert content, or both. If the resulting grouping id matches an
-existing non-resolved alert group grouping id, the alert will be grouped accordingly.
-Otherwise, a new alert group will be created
+  can be based on time, alert content, or both. If the resulting grouping id matches an
+  existing non-resolved alert group grouping id, the alert will be grouped accordingly.
+  Otherwise, a new alert group will be created
 - `Autoresolution` - used to auto-resolve alert groups with status `Resolved by source`
-(Conditional template, output should be `True`)
+  (Conditional template, output should be `True`)
 - `Auto acknowledge` - used to auto-acknowledge alert groups with status `Acknowledged by
-source` (Conditional template, output should be `True`)
+  source` (Conditional template, output should be `True`)
 - `Source link` - Used to customize the URL link to provide as the "source" of the alert.
 
-   > **Note:** For conditional templates, the output should be `True` to be applied, for
-   example `{{ True if payload.state == 'OK' else False }}`
+  > **Note:** For conditional templates, the output should be `True` to be applied, for
+  example `{{ True if payload.state == 'OK' else False }}`
 
 > **Pro Tip:** As a best practice, add _Playbooks_, _Useful links_, or _Checklists_ to the
-alert message.
+> alert message.
 
 #### How to edit templates
 
 1. Open the **Integration** page for the integration you want to edit
-1`. Click the **Edit** button for the Templates Section. Now you can see previews of all
-templates for the Integration
+   1`. Click the **Edit** button for the Templates Section. Now you can see previews of all
+   templates for the Integration
 1. Select the template you want to edit and click the **Edit** button to the right to the template
-name. The template editor will open. The first column is the example alert payload, second
-column is the Template itself, and third column is used to view rendered result.
+   name. The template editor will open. The first column is the example alert payload, second
+   column is the Template itself, and third column is used to view rendered result.
 1. Select one of the **Recent Alert groups** for the integration to see its `latest alert
-payload`. If you want to edit this payload, click the **Edit** button right to the Alert Group
-Name.
+   payload`. If you want to edit this payload, click the **Edit** button right to the Alert Group
+   Name.
 1. Alternatively, you can click **Use custom payload** and write your own payload to see
-how it will be rendered
+   how it will be rendered
 1. Press `Control + Enter` in the editor to see suggestions
 1. Click **Cheatsheet** in the second column to get some inspiration.
 1. If you edit Messenger templates, click **Save and open Alert Group in ChatOps** to see
-how the alert will be rendered in the messenger, right in the messenger (Only works for
-an Alert Group that exists in the messenger)
+   how the alert will be rendered in the messenger, right in the messenger (Only works for
+   an Alert Group that exists in the messenger)
 1. Click **Save** to save the template
 
 ## Advanced Jinja templates
@@ -166,7 +167,8 @@ functions, and more.
 
 > **NOTE:** Every alert from a monitoring system comes in the key/value format.
 
-Grafana OnCall has rules about which of the keys match to: `__title`, `message`, `image`, `grouping`, and `auto-resolve__`.
+Grafana OnCall has rules about which of the keys match to: `__title`, `message`, `image`, `grouping`,
+and `auto-resolve__`.
 
 ### Loops
 
@@ -211,7 +213,8 @@ Built-in functions:
 - `abs`
 - `capitalize`
 - `trim`
-- You can see the full list of Jinja built-in functions on github [here](https://github.com/pallets/jinja/blob/3915eb5c2a7e2e4d49ebdf0ecb167ea9c21c60b2/src/jinja2/filters.py#L1307)
+- You can see the full list of Jinja built-in functions on
+  github [here](https://github.com/pallets/jinja/blob/3915eb5c2a7e2e4d49ebdf0ecb167ea9c21c60b2/src/jinja2/filters.py#L1307)
 
 ### Functions added by Grafana OnCall
 
@@ -221,9 +224,12 @@ Built-in functions:
 - `iso8601_to_time` - converts time from iso8601 (`2015-02-17T18:30:20.000Z`) to datetime
 - `datetimeformat` - converts time from datetime to the given format (`%H:%M / %d-%m-%Y` by default)
 - `datetimeformat_as_timezone` - same as `datetimeformat`, with the inclusion of timezone conversion (`UTC` by default)
-  - Usage example: `{{ payload.alerts.startsAt | iso8601_to_time | datetimeformat_as_timezone('%Y-%m-%dT%H:%M:%S%z', 'America/Chicago') }}`
+    - Usage
+      example: `{{ payload.alerts.startsAt | iso8601_to_time | datetimeformat_as_timezone('%Y-%m-%dT%H:%M:%S%z', 'America/Chicago') }}`
 - `regex_replace` - performs a regex find and replace
 - `regex_match` - performs a regex match, returns `True` or `False`
-  - Usage example: `{{ payload.ruleName | regex_match(".*") }}`
+    - Usage example: `{{ payload.ruleName | regex_match(".*") }}`
 - `b64decode` - performs a base64 string decode
-  - Usage example: `{{ payload.data | b64decode }}`
+    - Usage example: `{{ payload.data | b64decode }}`
+- `json_loads` - loads a given json string into an object
+    - Usage example: `{{ (payload.data | b64decode | json_loads).name }}`

--- a/docs/sources/configure/jinja2-templating/index.md
+++ b/docs/sources/configure/jinja2-templating/index.md
@@ -17,6 +17,7 @@ aliases:
   - ../jinja2-templating/ # /docs/oncall/<ONCALL_VERSION>/jinja2-templating/
 ---
 
+
 ## Jinja2 templating
 
 Grafana OnCall can integrate with any monitoring system that can send alerts via
@@ -97,11 +98,9 @@ customization, use Jinja templates.
 
 ### Routing template
 
-- `Routing Template` - used to route alerts to different Escalation Chains based on alert content (conditional template,
-  output should be `True`)
+- `Routing Template` - used to route alerts to different Escalation Chains based on alert content (conditional template, output should be `True`)
 
-  > **Note:** For conditional templates, the output should be `True` to be applied, for
-  example `{{ True if payload.state == 'OK' else False }}`
+   > **Note:** For conditional templates, the output should be `True` to be applied, for example `{{ True if payload.state == 'OK' else False }}`
 
 #### Appearance templates
 
@@ -132,7 +131,7 @@ How alerts are displayed in the UI, messengers, and notifications
   example `{{ True if payload.state == 'OK' else False }}`
 
 > **Pro Tip:** As a best practice, add _Playbooks_, _Useful links_, or _Checklists_ to the
-> alert message.
+alert message.
 
 #### How to edit templates
 
@@ -167,8 +166,7 @@ functions, and more.
 
 > **NOTE:** Every alert from a monitoring system comes in the key/value format.
 
-Grafana OnCall has rules about which of the keys match to: `__title`, `message`, `image`, `grouping`,
-and `auto-resolve__`.
+Grafana OnCall has rules about which of the keys match to: `__title`, `message`, `image`, `grouping`, and `auto-resolve__`.
 
 ### Loops
 
@@ -213,8 +211,7 @@ Built-in functions:
 - `abs`
 - `capitalize`
 - `trim`
-- You can see the full list of Jinja built-in functions on
-  github [here](https://github.com/pallets/jinja/blob/3915eb5c2a7e2e4d49ebdf0ecb167ea9c21c60b2/src/jinja2/filters.py#L1307)
+- You can see the full list of Jinja built-in functions on github [here](https://github.com/pallets/jinja/blob/3915eb5c2a7e2e4d49ebdf0ecb167ea9c21c60b2/src/jinja2/filters.py#L1307)
 
 ### Functions added by Grafana OnCall
 
@@ -224,12 +221,11 @@ Built-in functions:
 - `iso8601_to_time` - converts time from iso8601 (`2015-02-17T18:30:20.000Z`) to datetime
 - `datetimeformat` - converts time from datetime to the given format (`%H:%M / %d-%m-%Y` by default)
 - `datetimeformat_as_timezone` - same as `datetimeformat`, with the inclusion of timezone conversion (`UTC` by default)
-    - Usage
-      example: `{{ payload.alerts.startsAt | iso8601_to_time | datetimeformat_as_timezone('%Y-%m-%dT%H:%M:%S%z', 'America/Chicago') }}`
+  - Usage example: `{{ payload.alerts.startsAt | iso8601_to_time | datetimeformat_as_timezone('%Y-%m-%dT%H:%M:%S%z', 'America/Chicago') }}`
 - `regex_replace` - performs a regex find and replace
 - `regex_match` - performs a regex match, returns `True` or `False`
-    - Usage example: `{{ payload.ruleName | regex_match(".*") }}`
+  - Usage example: `{{ payload.ruleName | regex_match(".*") }}`
 - `b64decode` - performs a base64 string decode
-    - Usage example: `{{ payload.data | b64decode }}`
+  - Usage example: `{{ payload.data | b64decode }}`
 - `json_loads` - loads a given json string into an object
-    - Usage example: `{{ (payload.data | b64decode | json_loads).name }}`
+  - Usage example: `{{ (payload.data | b64decode | json_loads).name }}`

--- a/docs/sources/configure/jinja2-templating/index.md
+++ b/docs/sources/configure/jinja2-templating/index.md
@@ -227,5 +227,5 @@ Built-in functions:
   - Usage example: `{{ payload.ruleName | regex_match(".*") }}`
 - `b64decode` - performs a base64 string decode
   - Usage example: `{{ payload.data | b64decode }}`
-- `json_loads` - loads a given json string into an object
-  - Usage example: `{{ (payload.data | b64decode | json_loads).name }}`
+- `parse_json` - parses a given json string to an object
+  - Usage example: `{{ (payload.data | b64decode | parse_json).name }}`

--- a/engine/common/jinja_templater/filters.py
+++ b/engine/common/jinja_templater/filters.py
@@ -68,3 +68,10 @@ def b64decode(value):
         return base64.b64decode(value).decode("utf-8")
     except (ValueError, AttributeError, TypeError):
         return None
+
+
+def json_loads(value):
+    try:
+        return json.loads(value)
+    except (ValueError, AttributeError, TypeError, json.JSONDecodeError):
+        return None

--- a/engine/common/jinja_templater/filters.py
+++ b/engine/common/jinja_templater/filters.py
@@ -73,5 +73,5 @@ def b64decode(value):
 def json_loads(value):
     try:
         return json.loads(value)
-    except (ValueError, AttributeError, TypeError, json.JSONDecodeError):
+    except (ValueError, AttributeError, TypeError):
         return None

--- a/engine/common/jinja_templater/filters.py
+++ b/engine/common/jinja_templater/filters.py
@@ -70,7 +70,7 @@ def b64decode(value):
         return None
 
 
-def json_loads(value):
+def parse_json(value):
     try:
         return json.loads(value)
     except (ValueError, AttributeError, TypeError):

--- a/engine/common/jinja_templater/jinja_template_env.py
+++ b/engine/common/jinja_templater/jinja_template_env.py
@@ -13,6 +13,7 @@ from .filters import (
     regex_replace,
     regex_search,
     to_pretty_json,
+    json_loads
 )
 
 
@@ -33,3 +34,4 @@ jinja_template_env.filters["regex_match"] = regex_match
 jinja_template_env.filters["regex_search"] = regex_search
 jinja_template_env.filters["json_dumps"] = json_dumps
 jinja_template_env.filters["b64decode"] = b64decode
+jinja_template_env.filters["json_loads"] = json_loads

--- a/engine/common/jinja_templater/jinja_template_env.py
+++ b/engine/common/jinja_templater/jinja_template_env.py
@@ -9,7 +9,7 @@ from .filters import (
     datetimeformat_as_timezone,
     iso8601_to_time,
     json_dumps,
-    json_loads,
+    parse_json,
     regex_match,
     regex_replace,
     regex_search,
@@ -34,4 +34,4 @@ jinja_template_env.filters["regex_match"] = regex_match
 jinja_template_env.filters["regex_search"] = regex_search
 jinja_template_env.filters["json_dumps"] = json_dumps
 jinja_template_env.filters["b64decode"] = b64decode
-jinja_template_env.filters["json_loads"] = json_loads
+jinja_template_env.filters["parse_json"] = parse_json

--- a/engine/common/jinja_templater/jinja_template_env.py
+++ b/engine/common/jinja_templater/jinja_template_env.py
@@ -9,11 +9,11 @@ from .filters import (
     datetimeformat_as_timezone,
     iso8601_to_time,
     json_dumps,
+    json_loads,
     regex_match,
     regex_replace,
     regex_search,
     to_pretty_json,
-    json_loads
 )
 
 

--- a/engine/common/tests/test_apply_jinja_template.py
+++ b/engine/common/tests/test_apply_jinja_template.py
@@ -189,13 +189,13 @@ def test_templated_value_is_truthy(value, expected):
     assert templated_value_is_truthy(value) == expected
 
 
-def test_apply_jinja_template_json_loads():
+def test_apply_jinja_template_parse_json():
     payload = {"message": base64.b64encode(b'{"name": "test"}').decode("utf-8")}
     expected_name = "test"
 
     assert (
         apply_jinja_template(
-            "{{ (payload.message | b64decode | json_loads).name }}",
+            "{{ (payload.message | b64decode | parse_json).name }}",
             payload,
         )
         == expected_name

--- a/engine/common/tests/test_apply_jinja_template.py
+++ b/engine/common/tests/test_apply_jinja_template.py
@@ -187,3 +187,15 @@ def test_apply_jinja_template_to_alert_payload_and_labels(mock_apply_jinja_templ
 )
 def test_templated_value_is_truthy(value, expected):
     assert templated_value_is_truthy(value) == expected
+
+
+def test_apply_jinja_template_json_loads():
+    payload = {"message": "eyJuYW1lIjogInRlc3QifQ=="}
+    decoded = base64.b64decode(payload["message"]).decode("utf-8")
+
+    expected = json.loads(decoded)["name"]
+
+    assert apply_jinja_template(
+        "{{ (payload.message | b64decode | json_loads).name }}",
+        payload,
+    ) == expected

--- a/engine/common/tests/test_apply_jinja_template.py
+++ b/engine/common/tests/test_apply_jinja_template.py
@@ -195,7 +195,10 @@ def test_apply_jinja_template_json_loads():
 
     expected = json.loads(decoded)["name"]
 
-    assert apply_jinja_template(
-        "{{ (payload.message | b64decode | json_loads).name }}",
-        payload,
-    ) == expected
+    assert (
+        apply_jinja_template(
+            "{{ (payload.message | b64decode | json_loads).name }}",
+            payload,
+        )
+        == expected
+    )

--- a/engine/common/tests/test_apply_jinja_template.py
+++ b/engine/common/tests/test_apply_jinja_template.py
@@ -190,15 +190,13 @@ def test_templated_value_is_truthy(value, expected):
 
 
 def test_apply_jinja_template_json_loads():
-    payload = {"message": "eyJuYW1lIjogInRlc3QifQ=="}
-    decoded = base64.b64decode(payload["message"]).decode("utf-8")
-
-    expected = json.loads(decoded)["name"]
+    payload = {"message": base64.b64encode(b'{"name": "test"}').decode("utf-8")}
+    expected_name = "test"
 
     assert (
         apply_jinja_template(
             "{{ (payload.message | b64decode | json_loads).name }}",
             payload,
         )
-        == expected
+        == expected_name
     )


### PR DESCRIPTION
# What this PR does

Adds a jinja2 template function that performs `json.loads` and parses a string into a json object so that e.g. b64encoded json objects can be fully used

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
