### PR TITLE
Fix for update to axios that changed how paramsSerializer is setup

### DIFF
--- a/grafana-plugin/src/network/network.ts
+++ b/grafana-plugin/src/network/network.ts
@@ -12,8 +12,10 @@ const instance = axios.create();
 
 instance.interceptors.request.use(function (config) {
   // Do something before request is sent
-  config.paramsSerializer = (params) => {
-    return qs.stringify(params, { arrayFormat: 'none' });
+  config.paramsSerializer = {
+    serialize: (params) => {
+      return qs.stringify(params, { arrayFormat: 'none' });
+    },
   };
 
   config.validateStatus = (status) => {


### PR DESCRIPTION
# What this PR does
Fixes the issue that after axios was updated the paramsSerializer was not being set correctly. I am not sure if there are other changes we need to make after updating. No changelog as the version with the issue has not been released.

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
