### PR TITLE
Update OrderedModel.swap to retry on IntegrityError

### DIFF
--- a/engine/common/ordered_model/ordered_model.py
+++ b/engine/common/ordered_model/ordered_model.py
@@ -179,7 +179,7 @@ class OrderedModel(models.Model):
         self.order = order
         self._manager.filter(pk__in=pks).bulk_update([self] + instances_to_move, fields=["order"])
 
-    @_retry(OperationalError)  # retry on deadlock
+    @_retry((IntegrityError, OperationalError))  # retry on duplicate order or deadlock
     def swap(self, order: int) -> None:
         """
         Swap self with an instance at a given order.


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2386.

Issue seems related to [multiple concurrent Terraform-triggered updates](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22j0s%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22expr%22:%22%7Bcluster%3D%5C%22prod-eu-west-0%5C%22,%20namespace%3D%5C%22amixr-prod%5C%22%7D%20%7C%3D%20%5C%22logger%3Dinsight_logger%20tenant_id%3D735393%5C%22%20%7C%3D%20%5C%22resource_type%3Droute%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22%7D%5D,%22range%22:%7B%22from%22:%221707813893526%22,%22to%22:%221707815856774%22%7D%7D%7D&orgId=1
) changing the route order to zero (and eventually succeeding)

Sample test run with the failing error:
```
========================================== short test summary info ===========================================
FAILED common/tests/test_ordered_model.py::test_ordered_model_swap_all_to_zero - assert not [DoesNotExist(), IntegrityError(1062, "Duplicate entry 'test-0' for key 'base_testorderedmodel...
======================================= 1 failed, 5 warnings in 34.39s =======================================
make: *** [Makefile:283: run-backend-test] Error 1
```