### PR TITLE
Fix path for plugin release publish

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,7 +40,7 @@ steps:
     image: plugins/gcs
     settings:
       acl: allUsers:READER
-      source: grafana-plugin/ci/dist/grafana-oncall-app-${DRONE_TAG}.zip
+      source: grafana-plugin/grafana-oncall-app-${DRONE_TAG}.zip
       target: grafana-oncall-app/releases/grafana-oncall-app-${DRONE_TAG}.zip
       token:
         from_secret: gcs_oncall_publisher_key
@@ -385,4 +385,6 @@ name: cloud_access_policy_token
 
 ---
 kind: signature
-hmac: 198b7c7d2c94fc5698b22a722e7748181990207755cf1778b2290137e262518c
+hmac: d541ed21fc2472272c6772e246aaf1a2606db112b4e72a44bc4530831e9ca4d3
+
+...


### PR DESCRIPTION
# What this PR does
Fixes the path of the plugin file to public.  Leftover from last round of build changes 

## Which issue(s) this PR fixes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
