### PR TITLE
Support nullable shift.by_day

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -209,11 +209,11 @@ export const RotationForm = observer((props: RotationFormProps) => {
       rolling_users: userGroups,
       interval: repeatEveryValue,
       frequency: repeatEveryPeriod,
-      by_day: getUTCByDay(
-        store.scheduleStore.byDayOptions,
-        selectedDays,
-        store.timezoneStore.getDateInSelectedTimezone(shiftStart)
-      ),
+      by_day: getUTCByDay({
+        dayOptions: store.scheduleStore.byDayOptions,
+        by_day: selectedDays,
+        moment: store.timezoneStore.getDateInSelectedTimezone(shiftStart),
+      }),
       week_start: getUTCWeekStart(
         store.scheduleStore.byDayOptions,
         store.timezoneStore.getDateInSelectedTimezone(shiftStart)
@@ -385,11 +385,11 @@ export const RotationForm = observer((props: RotationFormProps) => {
       setRepeatEveryValue(shift.interval);
       setRepeatEveryPeriod(shift.frequency);
       setSelectedDays(
-        getSelectedDays(
-          store.scheduleStore.byDayOptions,
-          shift.by_day,
-          store.timezoneStore.getDateInSelectedTimezone(shiftStart)
-        )
+        getSelectedDays({
+          dayOptions: store.scheduleStore.byDayOptions,
+          by_day: shift.by_day,
+          moment: store.timezoneStore.getDateInSelectedTimezone(shiftStart),
+        })
       );
 
       setShowActiveOnSelectedDays(Boolean(shift.by_day?.length));
@@ -413,11 +413,11 @@ export const RotationForm = observer((props: RotationFormProps) => {
   useEffect(() => {
     if (shift) {
       setSelectedDays(
-        getSelectedDays(
-          store.scheduleStore.byDayOptions,
-          shift.by_day,
-          store.timezoneStore.getDateInSelectedTimezone(shiftStart)
-        )
+        getSelectedDays({
+          dayOptions: store.scheduleStore.byDayOptions,
+          by_day: shift.by_day,
+          moment: store.timezoneStore.getDateInSelectedTimezone(shiftStart),
+        })
       );
     }
   }, [store.timezoneStore.selectedTimezoneOffset]);

--- a/grafana-plugin/src/models/schedule/schedule.types.ts
+++ b/grafana-plugin/src/models/schedule/schedule.types.ts
@@ -57,7 +57,7 @@ export interface CreateScheduleExportTokenResponse {
 }
 
 export interface Shift {
-  by_day: string[];
+  by_day?: string[] | null;
   week_start: string;
   frequency: number | null;
   id: string;

--- a/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
+++ b/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
@@ -61,7 +61,15 @@ const getUTCDayIndex = (index: number, moment: dayjs.Dayjs, reverse: boolean) =>
   return utc_index;
 };
 
-export const getUTCByDay = (dayOptions: SelectOption[], by_day: string[], moment: dayjs.Dayjs) => {
+export const getUTCByDay = ({
+  dayOptions,
+  by_day = [],
+  moment,
+}: {
+  dayOptions: SelectOption[];
+  by_day?: string[] | null;
+  moment: dayjs.Dayjs;
+}) => {
   if (moment.day() === moment.utc().day()) {
     return by_day;
   }
@@ -80,7 +88,15 @@ export const getUTCByDay = (dayOptions: SelectOption[], by_day: string[], moment
   return UTCDays;
 };
 
-export const getSelectedDays = (dayOptions: SelectOption[], by_day: string[], moment: dayjs.Dayjs) => {
+export const getSelectedDays = ({
+  dayOptions,
+  by_day = [],
+  moment,
+}: {
+  dayOptions: SelectOption[];
+  by_day?: string[] | null;
+  moment: dayjs.Dayjs;
+}) => {
   if (moment.day() === moment.utc().day()) {
     return by_day;
   }

--- a/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
+++ b/grafana-plugin/src/pages/schedule/Schedule.helpers.ts
@@ -79,7 +79,7 @@ export const getUTCByDay = ({
   let UTCDays = [];
   let byDayOptions = [];
   dayOptions.forEach(({ value }) => byDayOptions.push(value));
-  by_day.forEach((element) => {
+  by_day?.forEach((element) => {
     let index = byDayOptions.indexOf(element);
     index = getUTCDayIndex(index, moment, false);
     UTCDays.push(byDayOptions[index]);
@@ -104,7 +104,7 @@ export const getSelectedDays = ({
   const byDayOptions = dayOptions.map(({ value }) => value);
 
   let selectedTimezoneDays = [];
-  by_day.forEach((element) => {
+  by_day?.forEach((element) => {
     let index = byDayOptions.indexOf(element);
     index = getUTCDayIndex(index, moment, true);
     selectedTimezoneDays.push(byDayOptions[index]);


### PR DESCRIPTION
# What this PR does

- handle nullable shift.by_day

## Which issue(s) this PR fixes

https://github.com/grafana/support-escalations/issues/9548

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] `CHANGELOG.md` updated (or `pr:no changelog` PR label added if not required)
