### PR TITLE
Use local arm64 grpcio wheel to make local builds on arm64 faster

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:3.11.4-alpine3.18 AS base
+ARG TARGETPLATFORM
 
 # Create a group and user to run an app
 ENV APP_USER=appuser
@@ -6,17 +7,25 @@ RUN addgroup --system --gid 2000 ${APP_USER} && \
     adduser --system --uid 1000 --ingroup ${APP_USER} ${APP_USER}
 
 RUN apk add bash \
-            python3-dev \
-            build-base \
-            linux-headers \
-            pcre-dev \
-            mariadb-connector-c-dev \
-            libffi-dev \
-            git \
-            postgresql-dev
+    python3-dev \
+    build-base \
+    linux-headers \
+    pcre-dev \
+    mariadb-connector-c-dev \
+    libffi-dev \
+    git \
+    postgresql-dev
 
 WORKDIR /etc/app
 COPY ./requirements.txt ./
+COPY ./grpcio-1.57.0-cp311-cp311-linux_aarch64.whl ./
+
+# grpcio is not available for arm64 on pypi, so we need to install it from a local wheel
+# this can be removed once https://github.com/grpc/grpc/issues/34998 is resolved
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+    pip install grpcio-1.57.0-cp311-cp311-linux_aarch64.whl  \
+    && rm grpcio-1.57.0-cp311-cp311-linux_aarch64.whl; \
+    fi
 
 # TODO: figure out how to get this to work.. see comment in .github/workflows/e2e-tests.yml
 # https://stackoverflow.com/a/71846527

--- a/engine/requirements.in
+++ b/engine/requirements.in
@@ -27,6 +27,8 @@ djangorestframework==3.14.0
 factory-boy<3.0
 drf-spectacular==0.26.5
 emoji==2.4.0
+# If the version of grpcio is changed
+# upload a new arm64 wheel instead of /engine/grpcio-1.57.0-cp311-cp311-linux_aarch64.whl
 grpcio==1.57.0
 fcm-django @ https://github.com/grafana/fcm-django/archive/refs/tags/v1.0.12r1.tar.gz#sha256=7ec7cd9d353fc9edf19a4acd4fa14090a31d83d02ac986c5e5e081dea29f564f
 hiredis==2.2.3


### PR DESCRIPTION
This is the workaround to make local image build faster on arm64 machines 
This commit can be reverted once https://github.com/grpc/grpc/issues/34998 is resolved
