### PR TITLE
Fix link on inbound email integration docs

### DIFF
--- a/docs/sources/integrations/inbound-email/index.md
+++ b/docs/sources/integrations/inbound-email/index.md
@@ -18,7 +18,7 @@ Inbound Email integration will consume emails from dedicated email address and m
 
 ## Configure required environment variables
 
-Refer to [Inbound Email Setup][] for details.
+Refer to [Inbound Email Setup] for details.
 
 ## Configure Inbound Email integration for Grafana OnCall
 
@@ -47,6 +47,6 @@ Alerts from Inbound Email integration have the following payload:
 [jinja2-templating]: "/docs/oncall/ -> /docs/oncall/<ONCALL_VERSION>/configure/jinja2-templating"
 [jinja2-templating]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/oncall/configure/jinja2-templating"
 
-[Inbound Email Setup]: "/docs/oncall/ -> /docs/oncall/<ONCALL_VERSION>/set-up/open-source#inbound-email-setup)
-[Inbound Email Setup]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/oncall/set-up/open-source#inbound-email-setup)
+[Inbound Email Setup]: "/docs/oncall/ -> /docs/oncall/<ONCALL_VERSION>/set-up/open-source#inbound-email-setup"
+[Inbound Email Setup]: "/docs/grafana-cloud/ -> /docs/grafana-cloud/alerting-and-irm/oncall/set-up/open-source#inbound-email-setup"
 {{% /docs/reference %}}


### PR DESCRIPTION
# What this PR does

**Before**
<img width="812" alt="Screenshot 2024-03-06 at 12 52 12" src="https://github.com/grafana/oncall/assets/9406895/b93982e7-b092-450c-ac5b-95ccb8d33ebf">

**After**
<img width="796" alt="Screenshot 2024-03-06 at 12 50 39" src="https://github.com/grafana/oncall/assets/9406895/edae5d53-78b5-446c-b8df-3e433b8c174d">


## Which issue(s) this PR closes

Fixes issue reported in GH issue comment [here](https://github.com/grafana/oncall/issues/3700#issuecomment-1980991146)

Closes [issue link here]

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
