### PR TITLE
allow `@grafana/grafana-oncall` GitHub team users to approve changes to `/docs`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 * @grafana/grafana-oncall-backend
 /grafana-plugin @grafana/grafana-oncall-frontend
-/docs @grafana/docs-gops
+/docs @grafana/docs-gops @grafana/grafana-oncall
 
 # `make docs` procedure is owned by @jdbaldry of @grafana/docs-squad.
 /.github/workflows/update-make-docs.yml @jdbaldry


### PR DESCRIPTION
# What this PR does

On https://github.com/grafana/oncall/pull/3992 I needed to poke the `docs-gops` team for an approval, even though it was only a one line change and can be safely approved by anyone on the OnCall team

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
