### PR TITLE
Fix passing additional headers to custom fetch

### DIFF
--- a/grafana-plugin/src/network/oncall-api/http-client.test.ts
+++ b/grafana-plugin/src/network/oncall-api/http-client.test.ts
@@ -21,10 +21,10 @@ jest.mock('openapi-fetch', () => ({
 
 const fetchMock = jest.fn().mockResolvedValue(true);
 
+const HEADERS = new Headers();
+HEADERS.set('Content-Type', 'application/json');
 const REQUEST_CONFIG = {
-  headers: {
-    'Content-Type': 'application/json',
-  },
+  headers: HEADERS,
 };
 const URL = 'https://someurl.com';
 const SUCCESSFUL_RESPONSE_MOCK = { ok: true };


### PR DESCRIPTION
# What this PR does

Fix passing additional headers to custom fetch

## Which issue(s) this PR closes

Closes https://github.com/grafana/support-escalations/issues/9630

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
