### PR TITLE
Add test_connection endpoint for alert receive channel backsync setup

### DIFF
--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -3,7 +3,6 @@ from unittest.mock import ANY, Mock, patch
 
 import pytest
 from django.urls import reverse
-from requests.exceptions import HTTPError
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.test import APIClient
@@ -11,6 +10,7 @@ from rest_framework.test import APIClient
 from apps.alerts.models import AlertReceiveChannel, EscalationPolicy
 from apps.api.permissions import LegacyAccessControlRole
 from apps.labels.models import LabelKeyCache, LabelValueCache
+from common.exceptions import TestConnectionError
 
 
 class AdditionalSettingsTestSerializer(serializers.Serializer):
@@ -1962,7 +1962,7 @@ def test_alert_receive_channel_test_connection(
 
     # test error
     def testing_error(instance):
-        raise HTTPError("Error!")
+        raise TestConnectionError(error_msg="Error!")
 
     with patch.object(integration_config, "test_connection", side_effect=testing_error, create=True):
         response = client.post(url, data, format="json", **make_user_auth_headers(user, token))

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -6,7 +6,6 @@ from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.plumbing import resolve_type_hint
 from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema, extend_schema_view, inline_serializer
-from requests.exceptions import RequestException
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -50,7 +49,12 @@ from common.api_helpers.mixins import (
     UpdateSerializerMixin,
 )
 from common.api_helpers.paginators import FifteenPageSizePaginator
-from common.exceptions import MaintenanceCouldNotBeStartedError, TeamCanNotBeChangedError, UnableToSendDemoAlert
+from common.exceptions import (
+    MaintenanceCouldNotBeStartedError,
+    TeamCanNotBeChangedError,
+    TestConnectionError,
+    UnableToSendDemoAlert,
+)
 from common.insight_log import EntityEvent, write_resource_insight_log
 
 
@@ -287,8 +291,8 @@ class AlertReceiveChannelView(
         if test_connection_func:
             try:
                 test_connection_func(instance)
-            except RequestException as e:
-                raise BadRequest(detail=str(e))
+            except TestConnectionError as e:
+                raise BadRequest(detail=e.error_msg)
 
         return Response(status=status.HTTP_200_OK)
 

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -6,6 +6,7 @@ from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.plumbing import resolve_type_hint
 from drf_spectacular.utils import PolymorphicProxySerializer, extend_schema, extend_schema_view, inline_serializer
+from requests.exceptions import RequestException
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound
@@ -166,6 +167,7 @@ class AlertReceiveChannelView(
         "connect_contact_point": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "create_contact_point": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "disconnect_contact_point": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
+        "test_connection": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "webhooks_get": [RBACPermission.Permissions.INTEGRATIONS_READ],
         "webhooks_post": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "webhooks_put": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
@@ -268,6 +270,25 @@ class AlertReceiveChannelView(
             instance.send_demo_alert(payload=payload)
         except UnableToSendDemoAlert as e:
             raise BadRequest(detail=str(e))
+
+        return Response(status=status.HTTP_200_OK)
+
+    @extend_schema(request=AlertReceiveChannelSerializer)
+    @action(detail=False, methods=["post"])
+    def test_connection(self, request):
+        # create in-memory instance to test with the (possible) unsaved data
+        data = request.data
+        # clear name while testing connection (to avoid name already used validation error)
+        data["verbal_name"] = None
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        instance = AlertReceiveChannel(**serializer.validated_data)
+        test_connection_func = getattr(instance.config, "test_connection", None)
+        if test_connection_func:
+            try:
+                test_connection_func(instance)
+            except RequestException as e:
+                raise BadRequest(detail=str(e))
 
         return Response(status=status.HTTP_200_OK)
 

--- a/engine/common/exceptions/__init__.py
+++ b/engine/common/exceptions/__init__.py
@@ -1,6 +1,7 @@
 from .exceptions import (  # noqa: F401
     MaintenanceCouldNotBeStartedError,
     TeamCanNotBeChangedError,
+    TestConnectionError,
     UnableToSendDemoAlert,
     UserNotificationPolicyCouldNotBeDeleted,
 )

--- a/engine/common/exceptions/exceptions.py
+++ b/engine/common/exceptions/exceptions.py
@@ -21,3 +21,11 @@ class UnableToSendDemoAlert(OperationCouldNotBePerformedError):
 
 class UserNotificationPolicyCouldNotBeDeleted(OperationCouldNotBePerformedError):
     pass
+
+
+class TestConnectionError(Exception):
+    """Error testing alert receive channel connection."""
+
+    def __init__(self, *args, **kwargs):
+        self.error_msg = kwargs.pop("error_msg", None)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2542