### PR TITLE
Create default webhooks on integration creation

### DIFF
--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -20,6 +20,7 @@ from apps.alerts.models.maintainable_object import MaintainableObject
 from apps.api.label_filtering import parse_label_query
 from apps.api.permissions import RBACPermission
 from apps.api.serializers.alert_receive_channel import (
+    AlertReceiveChannelCreateSerializer,
     AlertReceiveChannelSerializer,
     AlertReceiveChannelUpdateSerializer,
     FilterAlertReceiveChannelSerializer,
@@ -39,6 +40,7 @@ from apps.mobile_app.auth import MobileAppAuthTokenAuthentication
 from common.api_helpers.exceptions import BadRequest
 from common.api_helpers.filters import NO_TEAM_VALUE, ByTeamModelFieldFilterMixin, TeamModelMultipleChoiceFilter
 from common.api_helpers.mixins import (
+    CreateSerializerMixin,
     FilterSerializerMixin,
     PreviewTemplateException,
     PreviewTemplateMixin,
@@ -113,6 +115,7 @@ class AlertReceiveChannelView(
     TeamFilteringMixin,
     PublicPrimaryKeyMixin[AlertReceiveChannel],
     FilterSerializerMixin,
+    CreateSerializerMixin,
     UpdateSerializerMixin,
     ModelViewSet,
 ):
@@ -130,6 +133,7 @@ class AlertReceiveChannelView(
     queryset = AlertReceiveChannel.objects.none()  # needed for drf-spectacular introspection
     serializer_class = AlertReceiveChannelSerializer
     filter_serializer_class = FilterAlertReceiveChannelSerializer
+    create_serializer_class = AlertReceiveChannelCreateSerializer
     update_serializer_class = AlertReceiveChannelUpdateSerializer
 
     filter_backends = [SearchFilter, DjangoFilterBackend]


### PR DESCRIPTION
## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2541

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
