### PR TITLE
remove duplicate `plugin.json` routes

### DIFF
--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -137,51 +137,6 @@
       ]
     },
     {
-      "path": "api/internal/v1/plugin/sync",
-      "method": "*",
-      "url": "{{ .JsonData.onCallApiUrl }}/api/internal/v1/plugin/sync",
-      "headers": [
-        {
-          "name": "X-Instance-Context",
-          "content": "{ \"stack_id\": \"{{ printf \"%.0f\" .JsonData.stackId }}\", \"org_id\": \"{{ printf \"%.0f\" .JsonData.orgId }}\" }"
-        },
-        {
-          "name": "Authorization",
-          "content": "{{ .SecureJsonData.onCallApiToken }}"
-        }
-      ]
-    },
-    {
-      "path": "api/internal/v1/plugin/*",
-      "method": "*",
-      "url": "{{ .JsonData.onCallApiUrl }}/api/internal/v1/plugin/",
-      "headers": [
-        {
-          "name": "X-Instance-Context",
-          "content": "{ \"stack_id\": \"{{ printf \"%.0f\" .JsonData.stackId }}\", \"org_id\": \"{{ printf \"%.0f\" .JsonData.orgId }}\" }"
-        },
-        {
-          "name": "Authorization",
-          "content": "{{ .SecureJsonData.onCallApiToken }}"
-        }
-      ]
-    },
-    {
-      "path": "api/internal/v1/login/slack-install-free/",
-      "method": "*",
-      "url": "{{ .JsonData.onCallApiUrl }}/api/internal/v1/login/slack-install-free/",
-      "headers": [
-        {
-          "name": "X-Instance-Context",
-          "content": "{ \"stack_id\": \"{{ printf \"%.0f\" .JsonData.stackId }}\", \"org_id\": \"{{ printf \"%.0f\" .JsonData.orgId }}\" }"
-        },
-        {
-          "name": "Authorization",
-          "content": "{{ .SecureJsonData.onCallApiToken }}"
-        }
-      ]
-    },
-    {
       "path": "api/internal/v1/*",
       "method": "*",
       "url": "{{ .JsonData.onCallApiUrl }}/api/internal/v1/",


### PR DESCRIPTION
# What this PR does

I'm _fairly_ certain these are duplicates of this 👇 route that already exists in our `plugin.json` ([here](https://github.com/grafana/oncall/blob/dev/grafana-plugin/src/plugin.json#L184C5-L198C6)):
```json
{
  "path": "api/internal/v1/*",
  "method": "*",
  "url": "{{ .JsonData.onCallApiUrl }}/api/internal/v1/",
  "headers": [
    {
      "name": "X-Instance-Context",
      "content": "{ \"stack_id\": \"{{ printf \"%.0f\" .JsonData.stackId }}\", \"org_id\": \"{{ printf \"%.0f\" .JsonData.orgId }}\" }"
    },
    {
      "name": "Authorization",
      "content": "{{ .SecureJsonData.onCallApiToken }}"
    }
  ]
}
```

all of the headers being sent are identical + the `api/internal/v1/*` route should forward all of these deleted routes to the right `api/internal/v1` api endpoint

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
