### PR TITLE
Enable test_connection for existing integrations reusing data

### DIFF
--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -340,7 +340,7 @@ class AlertReceiveChannelSerializer(
             _additional_settings_serializer_from_type(self.instance.config.slug) if self.instance else None
         )
         if settings_serializer_cls:
-            additional_settings_data = data.get("additional_settings")
+            additional_settings_data = data.get("additional_settings", self.instance.additional_settings)
             settings_serializer = settings_serializer_cls(self.instance, data=additional_settings_data)
             settings_serializer.is_valid()
             if settings_serializer.errors:

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -172,6 +172,7 @@ class AlertReceiveChannelView(
         "connect_contact_point": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "create_contact_point": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "disconnect_contact_point": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
+        "test_connection_create": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "test_connection": [RBACPermission.Permissions.INTEGRATIONS_WRITE],
         "status_options": [RBACPermission.Permissions.INTEGRATIONS_READ],
         "webhooks_get": [RBACPermission.Permissions.INTEGRATIONS_READ],
@@ -290,24 +291,52 @@ class AlertReceiveChannelView(
             except BacksyncIntegrationRequestError as e:
                 raise BadRequest(detail=e.error_msg)
 
-    @extend_schema(
-        request=AlertReceiveChannelSerializer,
-        responses={status.HTTP_200_OK: None},
-    )
-    @action(detail=False, methods=["post"])
-    def test_connection(self, request):
-        # create in-memory instance to test with the (possible) unsaved data
+    def _test_connection(self, request, pk=None):
+        instance = None
         data = request.data
-        # clear name while testing connection (to avoid name already used validation error)
         data["verbal_name"] = None
-        serializer = self.get_serializer(data=request.data)
+        if pk is not None:
+            instance = self.get_object()
+            serializer = self.update_serializer_class(
+                instance,
+                data=data,
+                partial=True,
+                context={"request": request},
+            )
+        else:
+            serializer = self.create_serializer_class(data=data, context={"request": request})
+
+        # check we have all the required information
         serializer.is_valid(raise_exception=True)
-        instance = AlertReceiveChannel(**serializer.validated_data)
+        if instance is None:
+            serializer.validated_data.pop("create_default_webhooks", None)
+            # create in-memory instance to test with the (possible) unsaved data
+            instance = AlertReceiveChannel(**serializer.validated_data)
+        else:
+            # update instance with the validated data
+            for attr, val in serializer.validated_data.items():
+                setattr(instance, attr, val)
 
         # will raise if there are errors
         self._backsync_integration_request(instance, "test_connection")
 
         return Response(status=status.HTTP_200_OK)
+
+    @extend_schema(
+        request=AlertReceiveChannelSerializer,
+        responses={status.HTTP_200_OK: None},
+    )
+    @action(detail=False, methods=["post"], url_path="test_connection")
+    def test_connection_create(self, request):
+        return self._test_connection(request)
+
+    @extend_schema(
+        request=AlertReceiveChannelUpdateSerializer,
+        responses={status.HTTP_200_OK: None},
+    )
+    @action(detail=True, methods=["post"])
+    def test_connection(self, request, pk):
+        return self._test_connection(request, pk=pk)
 
     @extend_schema(
         responses=inline_serializer(


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2542
Make it possible to test connection for an existing integration, without needing to explicitly pass the password.