### PR TITLE
Add permalinks field to the alert groups list view in internal api

### DIFF
--- a/engine/apps/api/serializers/alert_group.py
+++ b/engine/apps/api/serializers/alert_group.py
@@ -168,6 +168,7 @@ class AlertGroupListSerializer(
             "team",
             "grafana_incident_id",
             "labels",
+            "permalinks",
         ]
 
     def get_render_for_web(self, obj: "AlertGroup") -> RenderForWeb | EmptyRenderForWeb:
@@ -218,7 +219,6 @@ class AlertGroupSerializer(AlertGroupListSerializer):
             "alerts",
             "render_after_resolve_report_json",
             "slack_permalink",  # TODO: make plugin frontend use "permalinks" field to get Slack link
-            "permalinks",
             "last_alert_at",
             "paged_users",
         ]


### PR DESCRIPTION
# What this PR does

closes https://github.com/grafana/oncall/issues/4099

## Which issue(s) this PR closes

Closes [issue link here]

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
