### PR TITLE
add `grafana_incident_enabled` to `GET /organization` internal API response

### DIFF
--- a/engine/apps/api/serializers/organization.py
+++ b/engine/apps/api/serializers/organization.py
@@ -23,6 +23,7 @@ class OrganizationSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     slack_channel = serializers.SerializerMethodField()
 
     rbac_enabled = serializers.BooleanField(read_only=True, source="is_rbac_permissions_enabled")
+    grafana_incident_enabled = serializers.BooleanField(read_only=True, source="is_grafana_incident_enabled")
 
     SELECT_RELATED = ["slack_team_identity"]
 
@@ -35,11 +36,13 @@ class OrganizationSerializer(EagerLoadingMixin, serializers.ModelSerializer):
             "slack_team_identity",
             "slack_channel",
             "rbac_enabled",
+            "grafana_incident_enabled",
         ]
         read_only_fields = [
             "stack_slug",
             "slack_team_identity",
             "rbac_enabled",
+            "grafana_incident_enabled",
         ]
 
     def get_slack_channel(self, obj):

--- a/engine/apps/api/tests/test_organization.py
+++ b/engine/apps/api/tests/test_organization.py
@@ -43,6 +43,7 @@ def test_get_organization(
         "slack_team_identity": None,
         "slack_channel": None,
         "rbac_enabled": organization.is_rbac_permissions_enabled,
+        "grafana_incident_enabled": organization.is_grafana_incident_enabled,
         "is_resolution_note_required": False,
         "env_status": mock_env_status,
         "banner": mock_banner,


### PR DESCRIPTION
# What this PR does

Needed for some mobile app work.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
