### PR TITLE
Google Calendar integration improvements

### DIFF
--- a/engine/apps/social_auth/pipeline/google.py
+++ b/engine/apps/social_auth/pipeline/google.py
@@ -24,7 +24,7 @@ def persist_access_and_refresh_tokens(backend: typing.Type[BaseAuth], response: 
 def disconnect_user_google_oauth2_settings(backend: typing.Type[BaseAuth], user: User, *args, **kwargs):
     """
     Don't use `google_oauth2_user.access_token` when revoking token, use `refresh_token` instead. If we use
-    the access token, we get an HTTP 400 from Google because the token may be invalid or revoked.
+    the access token, we may get an HTTP 400 from Google because the token may be invalid or revoked.
 
     https://stackoverflow.com/a/18578660/3902555
     """

--- a/engine/apps/social_auth/pipeline/google.py
+++ b/engine/apps/social_auth/pipeline/google.py
@@ -1,7 +1,6 @@
 import logging
 import typing
 
-import requests
 from rest_framework.response import Response
 from social_core.backends.base import BaseAuth
 


### PR DESCRIPTION
# What this PR does

- UI enhancements
- Fix bug when going through the Google OAuth2 disconnection flow. We should send the `refresh_token` in the `revoke` HTTP request, rather than the `access_token` (`access_token` expires frequently and can result in Google sending back HTTP 400.. `refresh_token` is long lived and can also be sent in the revoke flow)

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
