### PR TITLE
Check for backsync updates before triggering connected webhooks

### DIFF
--- a/engine/apps/webhooks/listeners.py
+++ b/engine/apps/webhooks/listeners.py
@@ -7,10 +7,17 @@ logger.setLevel(logging.DEBUG)
 
 
 def on_alert_group_created(**kwargs):
-    alert_group_created.apply_async((kwargs["alert_group"].id,))
+    alert_group = kwargs["alert_group"]
+
+    # if we have an external_id, this alert_group was just created from a backsync update
+    external_id = alert_group.external_ids.filter(source_alert_receive_channel=alert_group.channel).first()
+    is_backsync = external_id is not None
+
+    alert_group_created.apply_async((kwargs["alert_group"].id,), kwargs={"is_backsync": is_backsync})
 
 
 def on_action_triggered(**kwargs):
+    from apps.alerts.constants import ActionSource
     from apps.alerts.models import AlertGroupLogRecord
 
     log_record = kwargs["log_record"]
@@ -20,4 +27,9 @@ def on_action_triggered(**kwargs):
         except AlertGroupLogRecord.DoesNotExist as e:
             logger.warning(f"Webhook action triggered: log record {log_record} never created or has been deleted")
             raise e
-    alert_group_status_change.apply_async((log_record.type, log_record.alert_group_id, log_record.author_id))
+
+    # keep track if this status change was triggered by a backsync event
+    is_backsync = log_record.action_source == ActionSource.BACKSYNC
+    alert_group_status_change.apply_async(
+        (log_record.type, log_record.alert_group_id, log_record.author_id), kwargs={"is_backsync": is_backsync}
+    )

--- a/engine/apps/webhooks/tasks/trigger_webhook.py
+++ b/engine/apps/webhooks/tasks/trigger_webhook.py
@@ -62,7 +62,7 @@ class WebhookRequestStatus(typing.TypedDict):
 @shared_dedicated_queue_retry_task(
     autoretry_for=(Exception,), retry_backoff=True, max_retries=1 if settings.DEBUG else None
 )
-def send_webhook_event(trigger_type, alert_group_id, organization_id=None, user_id=None):
+def send_webhook_event(trigger_type, alert_group_id, organization_id=None, user_id=None, is_backsync=False):
     from apps.webhooks.models import Webhook
 
     webhooks_qs = Webhook.objects.filter(
@@ -75,6 +75,9 @@ def send_webhook_event(trigger_type, alert_group_id, organization_id=None, user_
             trigger_type=Webhook.TRIGGER_STATUS_CHANGE,
             organization_id=organization_id,
         ).exclude(is_webhook_enabled=False)
+
+    if is_backsync:
+        webhooks_qs = webhooks_qs.filter(is_from_connected_integration=False)
 
     for webhook in webhooks_qs:
         execute_webhook.apply_async((webhook.pk, alert_group_id, user_id, None), kwargs={"trigger_type": trigger_type})

--- a/engine/apps/webhooks/tests/test_trigger_webhook.py
+++ b/engine/apps/webhooks/tests/test_trigger_webhook.py
@@ -42,7 +42,10 @@ def test_send_webhook_event_filters(
     webhooks = {}
     for trigger_type in trigger_types:
         webhooks[trigger_type] = make_custom_webhook(
-            organization=organization, trigger_type=trigger_type, team=make_team(organization)
+            organization=organization,
+            trigger_type=trigger_type,
+            team=make_team(organization),
+            is_from_connected_integration=(trigger_type != Webhook.TRIGGER_ACKNOWLEDGE),
         )
 
     for trigger_type in trigger_types:
@@ -51,6 +54,18 @@ def test_send_webhook_event_filters(
         assert mock_execute.call_args == call(
             (webhooks[trigger_type].pk, alert_group.pk, None, None), kwargs={"trigger_type": trigger_type}
         )
+
+    # backsync event exclude connected integration webhooks
+    for trigger_type in trigger_types:
+        with patch("apps.webhooks.tasks.trigger_webhook.execute_webhook.apply_async") as mock_execute:
+            send_webhook_event(trigger_type, alert_group.pk, organization_id=organization.pk, is_backsync=True)
+            if trigger_type == Webhook.TRIGGER_ACKNOWLEDGE:
+                assert mock_execute.call_args == call(
+                    (webhooks[trigger_type].pk, alert_group.pk, None, None), kwargs={"trigger_type": trigger_type}
+                )
+            else:
+                # except for the acknowledge webhook (not connected integration set), the webhook is not triggered
+                mock_execute.assert_not_called()
 
     # other org
     other_org_webhook = make_custom_webhook(


### PR DESCRIPTION
Avoid triggering a webhook if it is from a connected integration and the triggering event was caused by a backsync update.

Related to https://github.com/grafana/oncall-private/issues/2615