### PR TITLE
Added Outgoing Web hooks to escalation policy log

### DIFF
--- a/engine/apps/alerts/incident_log_builder/incident_log_builder.py
+++ b/engine/apps/alerts/incident_log_builder/incident_log_builder.py
@@ -554,7 +554,15 @@ class IncidentLogBuilder:
                 # notification_plan_dict structure - {timedelta: [{"user_id": user.pk, "plan_lines": []}]
                 for timedelta, notification_plan in notification_plan_dict.items():
                     escalation_plan_dict.setdefault(timedelta, []).extend(notification_plan)
-        # TODO: should we add logic here for new webhooks?
+        elif escalation_policy_snapshot.step == EscalationPolicy.STEP_TRIGGER_CUSTOM_WEBHOOK:
+            if future_step:
+                custom_webhook = escalation_policy_snapshot.custom_webhook
+                if custom_webhook is not None:
+                    plan_line = f'trigger outgoing webhook "{custom_webhook.name}"'
+                else:
+                    plan_line = f'escalation step "{escalation_policy_snapshot.step_display}" but outgoing webhook is unspecified. Skipping'
+                plan = {"plan_lines": [plan_line]}
+                escalation_plan_dict.setdefault(timedelta, []).append(plan)
         elif escalation_policy_snapshot.step == EscalationPolicy.STEP_NOTIFY_IF_TIME:
             if future_step:
                 if escalation_policy_snapshot.from_time is not None and escalation_policy_snapshot.to_time is not None:


### PR DESCRIPTION
# What this PR does

Adds the Outgoing web hooks escalation step to the escalation plan log.

## Which issue(s) this PR closes

Closes #4037

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
