### PR TITLE
Fix rotation creation form "Limit each shift length" feature

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.helpers.ts
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.helpers.ts
@@ -198,6 +198,8 @@ export const dayJSAddWithDSTFixed = ({
   // At first we add time as usual
   let newDateCandidate = baseDate.add(...addParams);
 
+  return newDateCandidate;
+
   const differenceInHoursInLocalTimezone = newDateCandidate.hour() - baseDate.hour();
   const differenceInHoursInUTC = newDateCandidate.utc().hour() - baseDate.utc().hour();
 

--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -394,7 +394,7 @@ export const RotationForm = observer((props: RotationFormProps) => {
       setShowActiveOnSelectedPartOfDay(value);
 
       if (!value) {
-        if (showActiveOnSelectedPartOfDay) {
+        if (showActiveOnSelectedDays) {
           setShiftEnd(
             dayJSAddWithDSTFixed({
               baseDate: shiftStart,
@@ -411,7 +411,7 @@ export const RotationForm = observer((props: RotationFormProps) => {
         }
       }
     },
-    [shiftStart, repeatEveryPeriod, repeatEveryValue, showActiveOnSelectedPartOfDay]
+    [shiftStart, repeatEveryPeriod, repeatEveryValue, showActiveOnSelectedDays]
   );
 
   useEffect(() => {


### PR DESCRIPTION
# What this PR does

Fix rotation creation form "Limit each shift length" feature

## Which issue(s) this PR closes

Closes https://github.com/grafana/support-escalations/issues/9970

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
