### PR TITLE
Remove updating user's timezone on backend if there are no changes

### DIFF
--- a/grafana-plugin/src/models/user/user.ts
+++ b/grafana-plugin/src/models/user/user.ts
@@ -100,7 +100,7 @@ export class UserStore {
   }
 
   async loadCurrentUser() {
-    const response = await makeRequest('/user/', {});
+    const response = await makeRequest<ApiSchemas['User']>('/user/', {});
     const timezone = await this.refreshTimezoneIfNeeded(response);
 
     runInAction(() => {

--- a/grafana-plugin/src/models/user/user.ts
+++ b/grafana-plugin/src/models/user/user.ts
@@ -101,7 +101,7 @@ export class UserStore {
 
   async loadCurrentUser() {
     const response = await makeRequest('/user/', {});
-    const timezone = await this.refreshTimezone(response.pk);
+    const timezone = await this.refreshTimezoneIfNeeded(response);
 
     runInAction(() => {
       this.items = {
@@ -112,13 +112,13 @@ export class UserStore {
     });
   }
 
-  async refreshTimezone(id: ApiSchemas['User']['pk']) {
+  async refreshTimezoneIfNeeded(user: ApiSchemas['User']) {
     const { timezone: grafanaPreferencesTimezone } = config.bootData.user;
     const timezone = grafanaPreferencesTimezone === 'browser' ? dayjs.tz.guess() : grafanaPreferencesTimezone;
 
-    if (isUserActionAllowed(UserActions.UserSettingsWrite)) {
+    if (user.timezone !== timezone && isUserActionAllowed(UserActions.UserSettingsWrite)) {
       await onCallApi().PUT('/users/{id}/', {
-        params: { path: { id } },
+        params: { path: { id: user.pk } },
         body: { timezone } as ApiSchemas['User'],
       });
     }


### PR DESCRIPTION
# What this PR does

Remove updating user's timezone on backend if there are no changes

## Which issue(s) this PR closes

Closes https://github.com/grafana/oncall/issues/4112

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
