### PR TITLE
Google Calendar Integration - consider current oncall shifts for autogeneration of shift swap requests

### DIFF
--- a/engine/apps/google/tasks.py
+++ b/engine/apps/google/tasks.py
@@ -41,16 +41,16 @@ def sync_out_of_office_calendar_events_for_user(google_oauth2_user_pk: int) -> N
         )
 
         for schedule in users_schedules:
-            _, _, upcoming_shifts = schedule.shifts_for_user(
+            _, current_shifts, upcoming_shifts = schedule.shifts_for_user(
                 user,
                 start_time_utc,
                 datetime_end=end_time_utc,
             )
 
-            if upcoming_shifts:
+            if current_shifts or upcoming_shifts:
                 logger.info(
-                    f"Found {len(upcoming_shifts)} upcoming shift(s) for user {user_id} "
-                    f"during the out of office event {event_id}"
+                    f"Found {len(current_shifts)} current shift(s) and {len(upcoming_shifts)} upcoming shift(s) "
+                    f"for user {user_id} during the out of office event {event_id}"
                 )
 
                 shift_swap_request_exists = ShiftSwapRequest.objects.filter(
@@ -78,7 +78,9 @@ def sync_out_of_office_calendar_events_for_user(google_oauth2_user_pk: int) -> N
                 else:
                     logger.info(f"Shift swap request already exists for user {user_id} schedule {schedule.pk}")
             else:
-                logger.info(f"No upcoming shifts found for user {user_id} during the out of office event {event_id}")
+                logger.info(
+                    f"No current or upcoming shifts found for user {user_id} during the out of office event {event_id}"
+                )
 
 
 @shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True)


### PR DESCRIPTION
# What this PR does

Fixes issue where you create a Google Calendar OOO that overlaps with an in-progress oncall shift (currently we only consider future/upcoming shifts).

Related to https://github.com/grafana/oncall-private/issues/2555

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
