### PR TITLE
Improve performance for deleted integration lookups

### DIFF
--- a/engine/apps/integrations/mixins/alert_channel_defining_mixin.py
+++ b/engine/apps/integrations/mixins/alert_channel_defining_mixin.py
@@ -11,6 +11,7 @@ from apps.user_management.exceptions import OrganizationMovedException
 INTEGRATION_PERMISSION_DENIED_MESSAGE = "Integration key was not found. Permission denied."
 
 CHANNEL_DOES_NOT_EXIST_PLACEHOLDER = "DOES_NOT_EXIST"
+CHANNEL_MOVED_PLACEHOLDER = "MOVED"
 
 logger = logging.getLogger(__name__)
 
@@ -29,83 +30,100 @@ class AlertChannelDefiningMixin(object):
     CACHE_SHORT_TERM_TIMEOUT = 5
 
     def dispatch(self, *args, **kwargs):
-        from apps.alerts.models import AlertReceiveChannel
-
-        logger.info("AlertChannelDefiningMixin started")
+        token = str(kwargs["alert_channel_key"])
+        logger.info(f"AlertChannelDefiningMixin started token={token}")
         start = perf_counter()
-        alert_receive_channel = None
-        try:
-            # Trying to define from short-term cache
-            cache_key_short_term = self.CACHE_KEY_SHORT_TERM + "_" + str(kwargs["alert_channel_key"])
-            cached_alert_receive_channel_raw = cache.get(cache_key_short_term)
-            if cached_alert_receive_channel_raw == CHANNEL_DOES_NOT_EXIST_PLACEHOLDER:
-                logger.info(f"Integration {kwargs['alert_channel_key']} already cached as non-existent")
-                raise PermissionDenied(INTEGRATION_PERMISSION_DENIED_MESSAGE)
+        alert_receive_channel, status = self.get_alert_receive_channel_from_cache(token)
 
-            if cached_alert_receive_channel_raw is not None:
-                try:
-                    alert_receive_channel = next(
-                        serializers.deserialize("json", cached_alert_receive_channel_raw)
-                    ).object
-                except serializers.base.DeserializationError:
-                    # cached object model is outdated
-                    alert_receive_channel = None
+        if status == CHANNEL_MOVED_PLACEHOLDER:
+            self.handle_organization_moved(token)
 
-            if alert_receive_channel is None:
-                # Trying to define channel from DB
-                try:
-                    alert_receive_channel = AlertReceiveChannel.objects_with_deleted.get(
-                        token=kwargs["alert_channel_key"]
-                    )
-                except AlertReceiveChannel.DoesNotExist:
-                    cache.set(cache_key_short_term, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER, self.CACHE_SHORT_TERM_TIMEOUT)
-                else:
-                    # Update short term cache
-                    serialized = serializers.serialize("json", [alert_receive_channel])
-                    cache.set(cache_key_short_term, serialized, self.CACHE_SHORT_TERM_TIMEOUT)
-
-                    # Update cached channels
-                    if cache.get(self.CACHE_DB_FALLBACK_OBSOLETE_KEY) is None:
-                        cache.set(self.CACHE_DB_FALLBACK_OBSOLETE_KEY, True, self.CACHE_DB_FALLBACK_REFRESH_INTERVAL)
-                        self.update_alert_receive_channel_cache()
-        except OperationalError:
-            logger.info("Cannot connect to database, using cache to consume alerts!")
-
-            # Searching for a channel in a cache
-            if cache.get(self.CACHE_KEY_DB_FALLBACK):
-                for obj in serializers.deserialize("json", cache.get(self.CACHE_KEY_DB_FALLBACK)):
-                    if obj.object.token == kwargs["alert_channel_key"]:
-                        alert_receive_channel = obj.object
-
-                if alert_receive_channel is None:
-                    logger.info(f"Integration {kwargs['alert_channel_key']} not found in fallback cache")
-                    raise PermissionDenied(INTEGRATION_PERMISSION_DENIED_MESSAGE)
-
-            else:
-                logger.info("Cache is empty!")
-                raise
-        else:
-            if not alert_receive_channel:
-                logger.info(f"Integration {kwargs['alert_channel_key']} does not exist")
-                raise PermissionDenied(INTEGRATION_PERMISSION_DENIED_MESSAGE)
-            if alert_receive_channel.organization.is_moved:
-                logger.info(
-                    f"Channel {kwargs['alert_channel_key']} in organization {alert_receive_channel.organization.public_primary_key} is moved"
-                )
-                raise OrganizationMovedException(alert_receive_channel.organization)
-            if alert_receive_channel.deleted_at or alert_receive_channel.organization.deleted_at:
-                logger.info(
-                    f"Channel {kwargs['alert_channel_key']} or organization {alert_receive_channel.organization.public_primary_key} is deleted"
-                )
-                raise PermissionDenied(INTEGRATION_PERMISSION_DENIED_MESSAGE)
+        if not alert_receive_channel or status == CHANNEL_DOES_NOT_EXIST_PLACEHOLDER:
+            logger.info(f"Integration {token} does not exist")
+            raise PermissionDenied(INTEGRATION_PERMISSION_DENIED_MESSAGE)
 
         del kwargs["alert_channel_key"]
-
         request = args[0]
         request.alert_receive_channel = alert_receive_channel
         finish = perf_counter()
         logger.info(f"AlertChannelDefiningMixin finished in {finish - start}")
         return super(AlertChannelDefiningMixin, self).dispatch(*args, **kwargs)
+
+    def get_alert_receive_channel_from_cache(self, token):
+        # Trying to define from short-term cache
+        cache_key_short_term = self.CACHE_KEY_SHORT_TERM + "_" + token
+        cached_alert_receive_channel_raw = cache.get(cache_key_short_term)
+
+        if cached_alert_receive_channel_raw == CHANNEL_DOES_NOT_EXIST_PLACEHOLDER:
+            return None, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER
+
+        if cached_alert_receive_channel_raw == CHANNEL_MOVED_PLACEHOLDER:
+            return None, CHANNEL_MOVED_PLACEHOLDER
+
+        if not cached_alert_receive_channel_raw:
+            try:
+                alert_receive_channel = next(serializers.deserialize("json", cached_alert_receive_channel_raw)).object
+                return alert_receive_channel, None
+            except serializers.base.DeserializationError:
+                # cached object model is outdated
+                pass
+
+        alert_receive_channel, db_ok = self.get_alert_receive_channel_from_db(token)
+        if not alert_receive_channel:
+            logger.info(f"Channel {token} does not exist")
+            cache.set(cache_key_short_term, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER, self.CACHE_SHORT_TERM_TIMEOUT)
+            return None, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER
+
+        if db_ok:
+            if alert_receive_channel.organization.is_moved:
+                logger.info(
+                    f"Channel {token} organization {alert_receive_channel.organization.public_primary_key} is moved"
+                )
+                cache_key_organization_short_term = self.CACHE_KEY_ORGANIZATION_SHORT_TERM + "_" + token
+                serialized_organization = serializers.serialize("json", [alert_receive_channel.organization])
+                cache.set(cache_key_organization_short_term, serialized_organization, self.CACHE_SHORT_TERM_TIMEOUT)
+                return None, CHANNEL_MOVED_PLACEHOLDER
+            if alert_receive_channel.organization.deleted_at:
+                # Needs to be checked after is_moved since is_deleted is set for moved orgs
+                logger.info(
+                    f"Channel {token} organization {alert_receive_channel.organization.public_primary_key} is deleted"
+                )
+                cache.set(cache_key_short_term, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER, self.CACHE_SHORT_TERM_TIMEOUT)
+                return None, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER
+
+            # Update short term cache
+            serialized = serializers.serialize("json", [alert_receive_channel])
+            cache.set(cache_key_short_term, serialized, self.CACHE_SHORT_TERM_TIMEOUT)
+
+            # Update cached channels
+            if cache.get(self.CACHE_DB_FALLBACK_OBSOLETE_KEY) is None:
+                cache.set(self.CACHE_DB_FALLBACK_OBSOLETE_KEY, True, self.CACHE_DB_FALLBACK_REFRESH_INTERVAL)
+                self.update_alert_receive_channel_cache()
+
+        return alert_receive_channel, None
+
+    def get_alert_receive_channel_from_db(self, token):
+        from apps.alerts.models import AlertReceiveChannel
+
+        try:
+            alert_receive_channel = AlertReceiveChannel.objects.get(token=token)
+            return alert_receive_channel, True
+        except AlertReceiveChannel.DoesNotExist:
+            return None, True
+        except OperationalError:
+            logger.info("Cannot connect to database, using cache to consume alerts!")
+            return self.get_alert_receive_channel_from_db_fallback(token), False
+
+    def get_alert_receive_channel_from_db_fallback(self, token):
+        if cache.get(self.CACHE_KEY_DB_FALLBACK):
+            for obj in serializers.deserialize("json", cache.get(self.CACHE_KEY_DB_FALLBACK)):
+                if obj.object.token == token:
+                    return obj.object
+        else:
+            logger.info("Cache is empty!")
+            raise
+        logger.info(f"Integration {token} not found in fallback cache")
+        return None
 
     def update_alert_receive_channel_cache(self):
         from apps.alerts.models import AlertReceiveChannel
@@ -114,3 +132,21 @@ class AlertChannelDefiningMixin(object):
         serialized = serializers.serialize("json", AlertReceiveChannel.objects.all())
         # Caching forever, re-caching is managed by "obsolete key"
         cache.set(self.CACHE_KEY_DB_FALLBACK, serialized, timeout=None)
+
+    def handle_organization_moved(self, token):
+        # Organization lookup still occurs here, can be optimized if common enough
+        from apps.alerts.models import AlertReceiveChannel
+
+        try:
+            alert_receive_channel = AlertReceiveChannel.objects.get(token=token)
+        except AlertReceiveChannel.DoesNotExist:
+            logger.info(f"Previously moved alert receive channel token={token} not found")
+            raise PermissionDenied(INTEGRATION_PERMISSION_DENIED_MESSAGE)
+        except OperationalError:
+            logger.info(
+                f"Moved organization for alert receive channel token={token} is not compatible with DB fallback"
+            )
+            raise
+
+        logger.info(f"Channel {token} in organization {alert_receive_channel.organization.public_primary_key} is moved")
+        raise OrganizationMovedException(alert_receive_channel.organization)

--- a/engine/apps/integrations/tests/test_views.py
+++ b/engine/apps/integrations/tests/test_views.py
@@ -527,7 +527,7 @@ def test_integration_outdated_cached_model(
 @patch("django.core.cache.cache.get", wraps=cache.get)
 @patch("django.core.cache.cache.set", wraps=cache.set)
 @patch(
-    "apps.alerts.models.AlertReceiveChannel.objects_with_deleted.get",
+    "apps.alerts.models.AlertReceiveChannel.objects.get",
     wraps=AlertReceiveChannel.objects_with_deleted.get,
 )
 @pytest.mark.parametrize(

--- a/engine/apps/integrations/tests/test_views.py
+++ b/engine/apps/integrations/tests/test_views.py
@@ -293,7 +293,7 @@ def test_integration_universal_endpoint_works_without_db(
     )
 
     # populate cache
-    AlertChannelDefiningMixin().update_alert_receive_channel_cache()
+    AlertChannelDefiningMixin().update_alert_receive_channel_fallback_cache()
 
     now = timezone.now()
     with patch("django.utils.timezone.now") as mock_now:
@@ -350,7 +350,7 @@ def test_integration_grafana_endpoint_without_db_has_alerts(
     }
 
     # populate cache
-    AlertChannelDefiningMixin().update_alert_receive_channel_cache()
+    AlertChannelDefiningMixin().update_alert_receive_channel_fallback_cache()
 
     now = timezone.now()
     with patch("django.utils.timezone.now") as mock_now:

--- a/engine/engine/tests/test_views.py
+++ b/engine/engine/tests/test_views.py
@@ -10,7 +10,7 @@ def test_detached_integrations_startupprobe_populates_integrations_cache():
     client = APIClient()
 
     with patch(
-        "apps.integrations.mixins.AlertChannelDefiningMixin.update_alert_receive_channel_cache"
+        "apps.integrations.mixins.AlertChannelDefiningMixin.update_alert_receive_channel_fallback_cache"
     ) as mock_update_cache:
         response = client.get("/startupprobe/")
 
@@ -22,7 +22,7 @@ def test_startupprobe_populates_integrations_cache():
     client = APIClient()
 
     with patch(
-        "apps.integrations.mixins.AlertChannelDefiningMixin.update_alert_receive_channel_cache"
+        "apps.integrations.mixins.AlertChannelDefiningMixin.update_alert_receive_channel_fallback_cache"
     ) as mock_update_cache:
         response = client.get("/startupprobe/")
 

--- a/engine/engine/views.py
+++ b/engine/engine/views.py
@@ -44,7 +44,7 @@ class StartupProbeView(View):
 
     def get(self, request):
         if cache.get(AlertChannelDefiningMixin.CACHE_KEY_DB_FALLBACK) is None:
-            AlertChannelDefiningMixin().update_alert_receive_channel_cache()
+            AlertChannelDefiningMixin().update_alert_receive_channel_fallback_cache()
 
         return HttpResponse("Ok")
 


### PR DESCRIPTION
# What this PR does
- Refactor alert receive channel lookup so it is easier to follow
- Remove the additional lookup that was taking place for alert receive channels that belong to a deleted organization, these can be treated as deleted for usage purposes even though the alert receive channel itself does not have `deleted_at` populated
- Organizations that have been moved will still need to be looked up everytime.  This is not optimized in favor of not maintaining a cache of Organizations.  These are not frequent requests and can be optimized later if necessary.

## Which issue(s) this PR closes

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
