### PR TITLE
Optimize GET /users internal api endpoint

### DIFF
--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -137,7 +137,13 @@ class CurrentUserView(APIView, CachedSchedulesContextMixin):
         context = self.get_serializer_context()
         context.update({"request": self.request, "format": self.format_kwarg, "view": self})
 
-        if settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED:
+        is_open_source_with_cloud_notifications = (
+            settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED
+        )
+        # set context to avoid additional requests to db
+        context["is_open_source_with_cloud_notifications"] = is_open_source_with_cloud_notifications
+
+        if is_open_source_with_cloud_notifications:
             from apps.oss_installation.models import CloudConnector, CloudUserIdentity
 
             connector = CloudConnector.objects.first()
@@ -368,10 +374,13 @@ class UserView(
         context = self.get_serializer_context()
 
         if paginate_results and (page := self.paginate_queryset(queryset)) is not None:
-            if settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED:
-                # set context to avoid additional requests to db
-                context["is_open_source_with_cloud_notifications"] = True
+            is_open_source_with_cloud_notifications = (
+                settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED
+            )
+            # set context to avoid additional requests to db
+            context["is_open_source_with_cloud_notifications"] = is_open_source_with_cloud_notifications
 
+            if is_open_source_with_cloud_notifications:
                 from apps.oss_installation.models import CloudConnector, CloudUserIdentity
 
                 if (connector := CloudConnector.objects.first()) is not None:
@@ -380,8 +389,6 @@ class UserView(
                     cloud_identities = {cloud_identity.email: cloud_identity for cloud_identity in cloud_identities}
                     context["cloud_identities"] = cloud_identities
                     context["connector"] = connector
-            else:
-                context["is_open_source_with_cloud_notifications"] = False
 
             serializer = self.get_serializer(page, many=True, context=context)
             return self.get_paginated_response(serializer.data)
@@ -398,7 +405,13 @@ class UserView(
         except NotFound:
             return self.wrong_team_response()
 
-        if settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED:
+        is_open_source_with_cloud_notifications = (
+            settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED
+        )
+        # set context to avoid additional requests to db
+        context["is_open_source_with_cloud_notifications"] = is_open_source_with_cloud_notifications
+
+        if is_open_source_with_cloud_notifications:
             from apps.oss_installation.models import CloudConnector, CloudUserIdentity
 
             connector = CloudConnector.objects.first()

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -369,6 +369,9 @@ class UserView(
 
         if paginate_results and (page := self.paginate_queryset(queryset)) is not None:
             if settings.IS_OPEN_SOURCE and live_settings.GRAFANA_CLOUD_NOTIFICATIONS_ENABLED:
+                # set context to avoid additional requests to db
+                context["is_open_source_with_cloud_notifications"] = True
+
                 from apps.oss_installation.models import CloudConnector, CloudUserIdentity
 
                 if (connector := CloudConnector.objects.first()) is not None:
@@ -377,6 +380,8 @@ class UserView(
                     cloud_identities = {cloud_identity.email: cloud_identity for cloud_identity in cloud_identities}
                     context["cloud_identities"] = cloud_identities
                     context["connector"] = connector
+            else:
+                context["is_open_source_with_cloud_notifications"] = False
 
             serializer = self.get_serializer(page, many=True, context=context)
             return self.get_paginated_response(serializer.data)

--- a/engine/apps/mobile_app/backend.py
+++ b/engine/apps/mobile_app/backend.py
@@ -42,9 +42,7 @@ class MobileAppBackend(BaseMessagingBackend):
             user_active_device.delete()
 
     def serialize_user(self, user):
-        from apps.mobile_app.models import MobileAppAuthToken
-
-        return {"connected": MobileAppAuthToken.objects.filter(user=user).exists()}
+        return {"connected": getattr(user, "mobileappauthtoken", None) is not None}
 
     def notify_user(self, user, alert_group, notification_policy, critical=False):
         notify_user_about_new_alert_group.delay(


### PR DESCRIPTION
# What this PR does
Speed up `GET /users` internal api endpoint by reducing number of calls to database 

## Which issue(s) this PR closes
Related to slow schedules page issue - https://github.com/grafana/oncall-private/issues/1552
## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
