### PR TITLE
add `X-Grafana-User` header in proxied mobile app proxy gateway requests

### DIFF
--- a/engine/apps/mobile_app/tests/test_mobile_app_gateway.py
+++ b/engine/apps/mobile_app/tests/test_mobile_app_gateway.py
@@ -300,7 +300,7 @@ def test_mobile_app_gateway_proxies_headers(
 ):
     mock_requests.post.return_value = MockResponse()
 
-    _, _, auth_token = make_organization_and_user_with_mobile_app_auth_token()
+    _, user, auth_token = make_organization_and_user_with_mobile_app_auth_token()
 
     client = APIClient()
     url = reverse("mobile_app:gateway", kwargs={"downstream_backend": DOWNSTREAM_BACKEND, "downstream_path": "test"})
@@ -313,7 +313,11 @@ def test_mobile_app_gateway_proxies_headers(
         MOCK_DOWNSTREAM_URL,
         data=b"",
         params={},
-        headers={"Authorization": f"Bearer {MOCK_AUTH_TOKEN}", "Content-Type": content_type_header},
+        headers={
+            "Authorization": f"Bearer {MOCK_AUTH_TOKEN}",
+            "X-Grafana-User": f"email:{user.email}",
+            "Content-Type": content_type_header,
+        },
     )
 
 

--- a/engine/apps/mobile_app/views.py
+++ b/engine/apps/mobile_app/views.py
@@ -174,6 +174,7 @@ class MobileAppGatewayView(APIView):
     ) -> typing.Dict[str, str]:
         headers = {
             "Authorization": f"Bearer {cls._get_auth_token(downstream_backend, user)}",
+            "X-Grafana-User": f"email:{user.email}",
         }
 
         if (v := request.META.get("CONTENT_TYPE", None)) is not None:


### PR DESCRIPTION
# What this PR does

Adds `X-Grafana-User` header in proxied mobile app proxy gateway requests. This is required by the Grafana Incident backend to be able to properly resolve the currently authenticated user.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
