### PR TITLE
Fix incident error handling

### DIFF
--- a/engine/apps/integrations/tests/test_views.py
+++ b/engine/apps/integrations/tests/test_views.py
@@ -528,7 +528,7 @@ def test_integration_outdated_cached_model(
 @patch("django.core.cache.cache.set", wraps=cache.set)
 @patch(
     "apps.alerts.models.AlertReceiveChannel.objects.get",
-    wraps=AlertReceiveChannel.objects_with_deleted.get,
+    wraps=AlertReceiveChannel.objects.get,
 )
 @pytest.mark.parametrize(
     "integration_type",
@@ -558,3 +558,53 @@ def test_non_existent_integration_does_not_repeat_access_db(
         cache_key, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER, AlertChannelDefiningMixin.CACHE_SHORT_TERM_TIMEOUT
     )
     mock_db_get.assert_called_once_with(token=non_existent_integration_token)
+
+
+@patch("django.core.cache.cache.get", wraps=cache.get)
+@patch("django.core.cache.cache.set", wraps=cache.set)
+@patch(
+    "apps.alerts.models.AlertReceiveChannel.objects.get",
+    wraps=AlertReceiveChannel.objects.get,
+)
+@pytest.mark.parametrize(
+    "integration_type",
+    [arc_type for arc_type in INTEGRATION_TYPES],
+)
+@pytest.mark.django_db
+def test_deleted_integration_does_not_repeat_access_db(
+    mock_db_get,
+    mock_cache_set,
+    mock_cache_get,
+    make_organization_and_user,
+    make_alert_receive_channel,
+    integration_type,
+):
+    attempts = 5
+    organization, user = make_organization_and_user()
+    alert_receive_channel = make_alert_receive_channel(
+        organization=organization,
+        author=user,
+        integration=integration_type,
+    )
+
+    cache_key = AlertChannelDefiningMixin.CACHE_KEY_SHORT_TERM + "_" + alert_receive_channel.token
+    alert_receive_channel.delete()
+
+    client = APIClient()
+    url = reverse(
+        "integrations:universal",
+        kwargs={"integration_type": integration_type, "alert_channel_key": alert_receive_channel.token},
+    )
+
+    mock_cache_get.reset_mock()
+    for _ in range(attempts):
+        data = {"foo": "bar"}
+        response = client.post(url, data, format="json")
+        mock_cache_get.assert_called_with(cache_key)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    assert mock_cache_get.call_count == attempts
+    mock_cache_set.assert_called_once_with(
+        cache_key, CHANNEL_DOES_NOT_EXIST_PLACEHOLDER, AlertChannelDefiningMixin.CACHE_SHORT_TERM_TIMEOUT
+    )
+    mock_db_get.assert_called_once_with(token=alert_receive_channel.token)

--- a/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.helpers.tsx
+++ b/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.helpers.tsx
@@ -4,7 +4,7 @@ export function initErrorDataState(): Partial<PageErrorData> {
   return { isUnknownError: false, isWrongTeamError: false, wrongTeamNoPermissions: false };
 }
 
-export function getWrongTeamResponseInfo({ response }): Partial<PageErrorData> {
+export function getWrongTeamResponseInfo(response): Partial<PageErrorData> {
   if (response) {
     if (response.status === 404) {
       return { isNotFoundError: true };

--- a/grafana-plugin/src/network/oncall-api/http-client.test.ts
+++ b/grafana-plugin/src/network/oncall-api/http-client.test.ts
@@ -28,7 +28,7 @@ const REQUEST_CONFIG = {
 };
 const URL = 'https://someurl.com';
 const SUCCESSFUL_RESPONSE_MOCK = { ok: true };
-const ERROR_MOCK = 'error';
+const FAILING_RESPONSE_MOCK = { ok: false, json: () => 'ERROR' };
 const customFetch = getCustomFetchFn({ withGlobalErrorHandler: true });
 
 describe('customFetch', () => {
@@ -53,10 +53,10 @@ describe('customFetch', () => {
     describe('if response is not successful', () => {
       it('should push event and error to faro', async () => {
         (FaroHelper.faro.api.getOTEL as unknown as jest.Mock).mockReturnValueOnce(undefined);
-        fetchMock.mockResolvedValueOnce({ ok: false, json: () => ERROR_MOCK });
-        await expect(customFetch(URL, REQUEST_CONFIG)).rejects.toEqual(ERROR_MOCK);
+        fetchMock.mockResolvedValueOnce(FAILING_RESPONSE_MOCK);
+        await expect(customFetch(URL, REQUEST_CONFIG)).rejects.toEqual(FAILING_RESPONSE_MOCK);
         expect(FaroHelper.faro.api.pushEvent).toHaveBeenCalledWith('Request failed', { url: URL });
-        expect(FaroHelper.faro.api.pushError).toHaveBeenCalledWith(ERROR_MOCK);
+        expect(FaroHelper.faro.api.pushError).toHaveBeenCalledWith(FAILING_RESPONSE_MOCK.json());
       });
     });
   });
@@ -108,10 +108,10 @@ describe('customFetch', () => {
 
     describe('if response is not successful', () => {
       it('should reject Promise, push event to faro, set span status to error and end span', async () => {
-        fetchMock.mockResolvedValueOnce({ ok: false, json: () => ERROR_MOCK });
-        await expect(customFetch(URL, REQUEST_CONFIG)).rejects.toEqual(ERROR_MOCK);
+        fetchMock.mockResolvedValueOnce(FAILING_RESPONSE_MOCK);
+        await expect(customFetch(URL, REQUEST_CONFIG)).rejects.toEqual(FAILING_RESPONSE_MOCK);
         expect(FaroHelper.faro.api.pushEvent).toHaveBeenCalledWith('Request failed', { url: URL });
-        expect(FaroHelper.faro.api.pushError).toHaveBeenCalledWith(ERROR_MOCK);
+        expect(FaroHelper.faro.api.pushError).toHaveBeenCalledWith(FAILING_RESPONSE_MOCK.json());
         expect(spanEndMock).toHaveBeenCalledTimes(1);
       });
     });

--- a/grafana-plugin/src/network/oncall-api/http-client.ts
+++ b/grafana-plugin/src/network/oncall-api/http-client.ts
@@ -62,7 +62,7 @@ export const getCustomFetchFn =
             if (withGlobalErrorHandler) {
               showApiError(res);
             }
-            reject(errorData);
+            reject(res);
           }
         });
       });
@@ -78,7 +78,7 @@ export const getCustomFetchFn =
         if (withGlobalErrorHandler) {
           showApiError(res);
         }
-        throw errorData;
+        throw res;
       }
     }
   };


### PR DESCRIPTION
# What this PR does

Throw full fetch response to allow existing error handlers to work properly

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
