### PR TITLE
Add retry queue to helm chart

### DIFF
--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -176,7 +176,7 @@ detached_integrations:
 # Celery workers pods configuration
 celery:
   replicaCount: 1
-  worker_queue: "default,critical,long,slack,telegram,webhook,celery,grafana"
+  worker_queue: "default,critical,long,slack,telegram,webhook,celery,grafana,retry"
   worker_concurrency: "1"
   worker_max_tasks_per_child: "100"
   worker_beat_enabled: "True"


### PR DESCRIPTION
# What this PR does
Fixes https://github.com/grafana/oncall/issues/4178

## Which issue(s) this PR closes

Closes https://github.com/grafana/oncall/issues/4178

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
