### PR TITLE
Handle webhooks update on source integration settings update

### DIFF
--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -429,9 +429,15 @@ class AlertReceiveChannelSerializer(
         )
 
         try:
-            return super().update(instance, validated_data)
+            updated_instance = super().update(instance, validated_data)
         except AlertReceiveChannel.DuplicateDirectPagingError:
             raise BadRequest(detail=AlertReceiveChannel.DuplicateDirectPagingError.DETAIL)
+
+        # update webhooks if needed, using updated instance
+        if hasattr(instance.config, "update_default_webhooks"):
+            instance.config.update_default_webhooks(updated_instance)
+
+        return updated_instance
 
     def get_instructions(self, obj: "AlertReceiveChannel") -> str:
         # Deprecated, kept for api-backward compatibility

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -1874,6 +1874,8 @@ def test_update_additional_settings_integration(
 
     # set up additional settings for an integration
     integration_config = setup_additional_settings_for_integration
+    integration_config.update_default_webhooks = Mock()
+
     alert_receive_channel = make_alert_receive_channel(
         organization, integration=integration_config.slug, additional_settings=settings
     )
@@ -1916,6 +1918,7 @@ def test_update_additional_settings_integration(
 
     alert_receive_channel.refresh_from_db()
     assert alert_receive_channel.additional_settings == data["additional_settings"]
+    integration_config.update_default_webhooks.assert_called_once_with(alert_receive_channel)
 
 
 @pytest.mark.django_db

--- a/engine/apps/webhooks/models/webhook.py
+++ b/engine/apps/webhooks/models/webhook.py
@@ -181,6 +181,20 @@ class Webhook(models.Model):
     def hard_delete(self):
         super().delete()
 
+    def get_source_alert_receive_channel(self):
+        """Return the webhook source channel if it is connected to an integration."""
+        result = None
+        if self.is_from_connected_integration:
+            filtered_integration = (
+                Webhook.filtered_integrations.through.objects.filter(
+                    alertreceivechannel__additional_settings__isnull=False, webhook=self
+                )
+                .order_by("id")
+                .first()
+            )
+            result = filtered_integration.alertreceivechannel if filtered_integration else None
+        return result
+
     def build_request_kwargs(self, event_data, raise_data_errors=False):
         request_kwargs = {}
         if self.username and self.password:
@@ -346,16 +360,6 @@ def webhook_response_post_save(sender, instance, created, *args, **kwargs):
     if not created:
         return
 
-    filtered_integrations_entry = (
-        instance.webhook.filtered_integrations.through.objects.filter(
-            alertreceivechannel__additional_settings__isnull=False
-        )
-        .order_by("id")
-        .first()
-    )  # get the first source integration
-    source_alert_receive_channel = (
-        filtered_integrations_entry.alertreceivechannel if filtered_integrations_entry else None
-    )
-
+    source_alert_receive_channel = instance.webhook.get_source_alert_receive_channel()
     if source_alert_receive_channel and hasattr(source_alert_receive_channel.config, "on_webhook_response_created"):
         source_alert_receive_channel.config.on_webhook_response_created(instance, source_alert_receive_channel)

--- a/engine/apps/webhooks/tests/test_trigger_webhook.py
+++ b/engine/apps/webhooks/tests/test_trigger_webhook.py
@@ -737,6 +737,7 @@ def test_execute_webhook_integration_config(
         http_method="POST",
         trigger_type=Webhook.TRIGGER_ALERT_GROUP_CREATED,
         forward_all=True,
+        is_from_connected_integration=True,
     )
     webhook.filtered_integrations.set([source_alert_receive_channel, alert_receive_channel])
 

--- a/engine/apps/webhooks/tests/test_webhook.py
+++ b/engine/apps/webhooks/tests/test_webhook.py
@@ -320,3 +320,29 @@ def test_webhook_not_deleted_with_team(make_organization, make_team, make_custom
 
     webhook = Webhook.objects.get(pk=webhook_pk)
     assert webhook.team is None
+
+
+@pytest.mark.django_db
+def test_get_source_alert_receive_channel(make_organization, make_alert_receive_channel, make_custom_webhook):
+    organization = make_organization()
+    channel1 = make_alert_receive_channel(organization=organization, additional_settings={})
+    channel2 = make_alert_receive_channel(organization=organization, additional_settings={})
+
+    w1 = make_custom_webhook(
+        organization=organization,
+        is_from_connected_integration=True,
+    )
+    # source integration is the first added channel
+    w1.filtered_integrations.add(channel2)
+    w1.filtered_integrations.add(channel1)
+
+    w2 = make_custom_webhook(
+        organization=organization,
+        is_from_connected_integration=True,
+    )
+    # source integration is the first added channel
+    w2.filtered_integrations.add(channel1)
+    w2.filtered_integrations.add(channel2)
+
+    assert w1.get_source_alert_receive_channel() == channel2
+    assert w2.get_source_alert_receive_channel() == channel1

--- a/engine/apps/webhooks/utils.py
+++ b/engine/apps/webhooks/utils.py
@@ -187,15 +187,7 @@ def serialize_event(event, alert_group, user, webhook, responses=None):
         data["alert_group"]["labels"] = get_alert_group_labels_dict(alert_group)
 
     # Add additional webhook data if the integration has it
-    filtered_integrations_entry = (
-        webhook.filtered_integrations.through.objects.filter(alertreceivechannel__additional_settings__isnull=False)
-        .order_by("id")
-        .first()
-    )  # get the first source integration
-    source_alert_receive_channel = (
-        filtered_integrations_entry.alertreceivechannel if filtered_integrations_entry else None
-    )
-
+    source_alert_receive_channel = webhook.get_source_alert_receive_channel()
     if source_alert_receive_channel and hasattr(source_alert_receive_channel.config, "additional_webhook_data"):
         data.update(source_alert_receive_channel.config.additional_webhook_data(source_alert_receive_channel))
 


### PR DESCRIPTION
Also, some refactoring on the way we get the source integration from a connected webhook.

Related to https://github.com/grafana/oncall-private/issues/2615