### PR TITLE
Add Google privacy policy note for Google Calendar integration

### DIFF
--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/GoogleCalendar/GoogleCalendar.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/GoogleCalendar/GoogleCalendar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 
 import { css } from '@emotion/css';
-import { Button, HorizontalGroup, Switch, VerticalGroup, useStyles2 } from '@grafana/ui';
+import { Button, HorizontalGroup, Icon, Switch, VerticalGroup, useStyles2 } from '@grafana/ui';
 import { observer } from 'mobx-react';
 
 import { Block } from 'components/GBlock/Block';
@@ -122,6 +122,21 @@ const GoogleCalendar: React.FC<{ id: ApiSchemas['User']['pk'] }> = observer(({ i
               )}
             </VerticalGroup>
           )}
+
+          <HorizontalGroup spacing="sm">
+            <Icon name="info-circle" />
+            <Text type="secondary">
+              Grafana OnCall's use and transfer to any other app of information received from Google APIs will adhere to{' '}
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://developers.google.com/terms/api-services-user-data-policy#additional_requirements_for_specific_api_scopes"
+              >
+                <Text type="link">Google API Services User Data Policy</Text>
+              </a>
+              , including the Limited Use requirements.
+            </Text>
+          </HorizontalGroup>
         </VerticalGroup>
       </Block>
     </VerticalGroup>


### PR DESCRIPTION
# What this PR does
<img width="1098" alt="Screenshot 2024-04-10 at 11 36 58" src="https://github.com/grafana/oncall/assets/9406895/4ceb0479-bc3f-48e8-90c4-0c117b309d36">

This is a requirement to get our Google OAuth2 consent screen re-approved

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
