### PR TITLE
Allow skipping the who-resolved info in slack posts

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py
@@ -1,6 +1,7 @@
 import json
 import typing
 
+from django.conf import settings
 from django.utils.text import Truncator
 
 from apps.alerts.incident_appearance.renderers.base_renderer import AlertBaseRenderer, AlertGroupBaseRenderer
@@ -133,12 +134,13 @@ class AlertGroupSlackRenderer(AlertGroupBaseRenderer):
 
         # Attaching resolve information
         if self.alert_group.resolved:
-            resolve_attachment = {
-                "fallback": "Resolved...",
-                "text": self.alert_group.get_resolve_text(mention_user=True),
-                "callback_id": "alert",
-            }
-            attachments.append(resolve_attachment)
+            if not settings.FEATURE_SKIP_SLACK_RESOLVED_BY:
+                resolve_attachment = {
+                    "fallback": "Resolved...",
+                    "text": self.alert_group.get_resolve_text(mention_user=True),
+                    "callback_id": "alert",
+                }
+                attachments.append(resolve_attachment)
         else:
             if self.alert_group.acknowledged:
                 ack_attachment = {

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -56,6 +56,7 @@ DOCS_URL = "https://grafana.com/docs/oncall/latest/"
 BASE_URL = os.environ.get("BASE_URL")  # Root URL of OnCall backend
 
 # Feature toggles
+FEATURE_SKIP_SLACK_RESOLVED_BY = getenv_boolean("FEATURE_SKIP_SLACK_RESOLVED_BY", default=False)
 FEATURE_LIVE_SETTINGS_ENABLED = getenv_boolean("FEATURE_LIVE_SETTINGS_ENABLED", default=True)
 FEATURE_TELEGRAM_INTEGRATION_ENABLED = getenv_boolean("FEATURE_TELEGRAM_INTEGRATION_ENABLED", default=True)
 FEATURE_TELEGRAM_LONG_POLLING_ENABLED = getenv_boolean("FEATURE_TELEGRAM_LONG_POLLING_ENABLED", default=False)


### PR DESCRIPTION
# What this PR does

All resolved alerts currently get an extra line of to say what resolved the alert (for us usually the alert source rather than a person), which I think not normally needed, and anyway repeated in the Plugin UI or the message log inside the Slack thread.  So to save scroll-space on the Slack UI I'm proposing to remove the it.  Implemented as a `FEATURE_SKIP_SLACK_RESOLVED_BY` for now, but TBH I'd prefer it to default True as I can't see it's that useful.

There is one problem though - when combined with #4206 this means resolved alerts have no buttons or other Slack Attachments, so there is no green coloured sidebar to highlight this is a resolved alert group.  Only the _lack_ of buttons & a red sidebar, which might be enough but not perfect.  In our home-grown equivalent to OnCall we post slack messages as all Attachments and no Blocks to solve this, as AFAIK Slack do not allow adding a coloured sidebar to Blocks.

I'd obviously be happy to switch the [existing Slack title/message Blocks over to Attachments](https://github.com/grafana/oncall/blob/64bca2a2c0360f3fdbb896e12fb7ab4f91faaca6/engine/apps/alerts/incident_appearance/renderers/slack_renderer.py#L26-L66) in this or another PR.

## Which issue(s) this PR closes

Further work towards #4165

## Checklist

I've not added any extra tests/docs yet, awaiting feedback on whether this feature is acceptable & in what form you'd like extra work before doing so.

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
