### PR TITLE
Avoid creating a webhook response if request is not triggered

### DIFF
--- a/engine/apps/webhooks/tasks/trigger_webhook.py
+++ b/engine/apps/webhooks/tasks/trigger_webhook.py
@@ -240,12 +240,16 @@ def execute_webhook(webhook_pk, alert_group_id, user_id, escalation_policy_id, t
     data = _build_payload(webhook, alert_group, user, trigger_type)
     triggered, status, error, exception = make_request(webhook, alert_group, data)
 
-    # create response entry
-    WebhookResponse.objects.create(
-        alert_group=alert_group,
-        trigger_type=trigger_type or webhook.trigger_type,
-        **status,
-    )
+    # create response entry only if webhook was triggered
+    if triggered:
+        WebhookResponse.objects.create(
+            alert_group=alert_group,
+            trigger_type=trigger_type or webhook.trigger_type,
+            **status,
+        )
+    else:
+        reason = status.get("request_trigger", "Unknown")
+        logger.info(f"Webhook {webhook_pk} was not triggered: {reason}")
 
     escalation_policy = step = None
     if escalation_policy_id:


### PR DESCRIPTION
Only create a response object if the request is triggered, otherwise log the reason.
Avoid creating multiple/unneeded responses, which can be also confusing when displaying response objects. If there is no response, the webhook/request wasn't triggered (possible reasons: integrations are filtered, or the trigger template evaluates to False).

Related to https://github.com/grafana/oncall-private/issues/2615