### PR TITLE
add support for logging in to mobile using deep links

### DIFF
--- a/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.module.scss
+++ b/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.module.scss
@@ -16,6 +16,22 @@
   }
 }
 
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+  
+    &__box:first-child {
+      margin-right: 0px;
+      margin-bottom: 8px;
+    }
+  
+    &__box:last-child {
+      margin-left: 0px;
+      margin-top: 8px;
+    }
+  } 
+}
+
 .notification-buttons {
   width: 100%;
   padding-top: 12px;

--- a/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.tsx
+++ b/grafana-plugin/src/containers/MobileAppConnection/MobileAppConnection.tsx
@@ -20,6 +20,7 @@ import styles from './MobileAppConnection.module.scss';
 import { DisconnectButton } from './parts/DisconnectButton/DisconnectButton';
 import { DownloadIcons } from './parts/DownloadIcons/DownloadIcons';
 import { QRCode } from './parts/QRCode/QRCode';
+import { LinkLoginButton } from './parts/LinkLoginButton/LinkLoginButton';
 
 const cx = cn.bind(styles);
 
@@ -143,6 +144,7 @@ export const MobileAppConnection = observer(({ userPk }: Props) => {
   }
 
   let content: React.ReactNode = null;
+  const QRCodeDataParsed = QRCodeValue && getParsedQRCodeValue();
 
   if (fetchingQRCode || disconnectingMobileApp || !userPk || !basicDataLoaded) {
     content = <LoadingPlaceholder text="Loading..." />;
@@ -165,8 +167,6 @@ export const MobileAppConnection = observer(({ userPk }: Props) => {
       </VerticalGroup>
     );
   } else if (QRCodeValue) {
-    const QRCodeDataParsed = getParsedQRCodeValue();
-
     content = (
       <VerticalGroup spacing="lg">
         <Text type="primary" strong>
@@ -192,12 +192,19 @@ export const MobileAppConnection = observer(({ userPk }: Props) => {
     );
   }
 
+  const isMobile = window.matchMedia('(max-width: 768px)').matches;
+
   return (
     <VerticalGroup>
       <div className={cx('container')}>
         <Block shadowed bordered withBackground className={cx('container__box')}>
           <DownloadIcons />
         </Block>
+        {QRCodeValue && isMobile &&
+          (<Block shadowed bordered withBackground className={cx('container__box')}>
+            <LinkLoginButton baseUrl={QRCodeDataParsed.oncall_api_url} token={QRCodeDataParsed.token}/>
+          </Block>
+          )}
         <Block shadowed bordered withBackground className={cx('container__box')}>
           {content}
         </Block>

--- a/grafana-plugin/src/containers/MobileAppConnection/parts/LinkLoginButton/LinkLoginButton.test.tsx
+++ b/grafana-plugin/src/containers/MobileAppConnection/parts/LinkLoginButton/LinkLoginButton.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+
+import { LinkLoginButton } from './LinkLoginButton';
+
+describe('DownloadIcons', () => {
+  test('it renders properly', () => {
+    const component = render(<LinkLoginButton baseUrl='http://test.url' token='test1213'/>);
+    expect(component.container).toMatchSnapshot();
+  });
+});

--- a/grafana-plugin/src/containers/MobileAppConnection/parts/LinkLoginButton/LinkLoginButton.tsx
+++ b/grafana-plugin/src/containers/MobileAppConnection/parts/LinkLoginButton/LinkLoginButton.tsx
@@ -1,0 +1,32 @@
+import React, { FC } from 'react';
+
+import { Button, VerticalGroup } from '@grafana/ui';
+import { Text } from 'components/Text/Text';
+
+type Props = {
+  baseUrl: string;
+  token: string;
+};
+
+export const LinkLoginButton: FC<Props> = (props: Props) => {
+  const {baseUrl, token} = props;
+  const mobileDeepLink = `grafana://mobile/login/link-login?oncall_api_url=${baseUrl}&token=${token}`;
+
+  return (
+    <VerticalGroup spacing="lg">
+      <Text type="primary" strong>
+        Sign in via deeplink
+      </Text>
+      <Text type="primary">Make sure to have the app installed</Text>
+      <Button
+        variant="primary"
+        onClick={() => {
+          window.open(mobileDeepLink, '_blank');
+        }}
+      >
+        Sign in
+      </Button>
+
+    </VerticalGroup>
+  );
+};


### PR DESCRIPTION
# What this PR does

Optimize mobile app connection layout for smaller screens and add LinkLoginButton component

## Which issue(s) this PR closes

https://github.com/grafana/oncall-private/issues/2528

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
