### PR TITLE
fix incorrect args passed to `apps.webhooks.tasks.trigger_webhook.execute_webhook`

### DIFF
--- a/engine/apps/webhooks/tasks/trigger_webhook.py
+++ b/engine/apps/webhooks/tasks/trigger_webhook.py
@@ -290,7 +290,8 @@ def execute_webhook(webhook_pk, alert_group_id, user_id, escalation_policy_id, t
             retry_num = manual_retry_num + 1
             logger.warning(f"Manually retrying execute_webhook for {msg_details} manual_retry_num={retry_num}")
             execute_webhook.apply_async(
-                (webhook_pk, alert_group_id, user_id, escalation_policy_id, retry_num),
+                (webhook_pk, alert_group_id, user_id, escalation_policy_id),
+                kwargs={"trigger_type": trigger_type, "manual_retry_num": retry_num},
                 countdown=10,
             )
         else:

--- a/engine/apps/webhooks/tests/test_trigger_webhook.py
+++ b/engine/apps/webhooks/tests/test_trigger_webhook.py
@@ -688,7 +688,9 @@ def test_manually_retried_exceptions(
     execute_webhook(*execute_webhook_args)
 
     mock_requests.post.assert_called_once_with("https://test/", timeout=TIMEOUT, headers={})
-    spy_execute_webhook.apply_async.assert_called_once_with((*execute_webhook_args, 1), countdown=10)
+    spy_execute_webhook.apply_async.assert_called_once_with(
+        execute_webhook_args, kwargs={"trigger_type": None, "manual_retry_num": 1}, countdown=10
+    )
 
     mock_requests.reset_mock()
     spy_execute_webhook.reset_mock()


### PR DESCRIPTION
## Which issue(s) this PR closes

fix incorrect args passed to `apps.webhooks.tasks.trigger_webhook.execute_webhook`

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
