### PR TITLE
Add alert groups external URLs information to details API

### DIFF
--- a/grafana-plugin/src/network/oncall-api/autogenerated-api.types.d.ts
+++ b/grafana-plugin/src/network/oncall-api/autogenerated-api.types.d.ts
@@ -1411,6 +1411,12 @@ export interface components {
         avatar_full: string;
         important: boolean;
       }[];
+      readonly external_urls: {
+        integration: string;
+        integration_type: string;
+        external_id: string;
+        url: string;
+      }[];
     };
     AlertGroupAttach: {
       root_alert_group_pk: string;


### PR DESCRIPTION
Alert groups connected to an external source will return external URLs information, eg.

```
{
  "external_urls": [
    {
      "integration": "C2IFSTV93NQUW",
      "integration_type": "servicenow",
      "external_id": "4c686e1e83d1021075feb3a6feaad3a8",
      "url": "https://some.service-now.com/incident.do?sys_id=4c686e1e83d1021075feb3a6feaad3a8"
    }
  ]
}

```
Related to https://github.com/grafana/oncall-private/issues/2615