### PR TITLE
Fix deleting integration with connected webhooks

### DIFF
--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -780,6 +780,11 @@ def listen_for_alertreceivechannel_model_save(
         # delete alert receive channel connections
         instance.connected_alert_receive_channels.all().delete()
         instance.source_alert_receive_channels.all().delete()
+        # delete connected webhooks
+        if instance.additional_settings is not None:
+            for webhook in instance.webhooks.filter(is_from_connected_integration=True):
+                if webhook.get_source_alert_receive_channel() == instance:
+                    webhook.delete()
         # delete connected auth tokens
         instance.auth_tokens.all().delete()
 

--- a/engine/apps/webhooks/tests/test_webhook.py
+++ b/engine/apps/webhooks/tests/test_webhook.py
@@ -323,6 +323,30 @@ def test_webhook_not_deleted_with_team(make_organization, make_team, make_custom
 
 
 @pytest.mark.django_db
+def test_delete_alert_receive_channel_webhooks_deleted(
+    make_organization, make_alert_receive_channel, make_custom_webhook
+):
+    organization = make_organization()
+    channel = make_alert_receive_channel(organization=organization, additional_settings={})
+
+    webhook_from_connected_integration = make_custom_webhook(
+        organization=organization,
+        is_from_connected_integration=True,
+    )
+    other_webhook = make_custom_webhook(organization=organization)
+    webhook_from_connected_integration.filtered_integrations.add(channel)
+    other_webhook.filtered_integrations.add(channel)
+
+    channel.delete()
+
+    webhook_from_connected_integration.refresh_from_db()
+    assert webhook_from_connected_integration.deleted_at is not None
+
+    other_webhook.refresh_from_db()
+    assert other_webhook.deleted_at is None
+
+
+@pytest.mark.django_db
 def test_get_source_alert_receive_channel(make_organization, make_alert_receive_channel, make_custom_webhook):
     organization = make_organization()
     channel1 = make_alert_receive_channel(organization=organization, additional_settings={})


### PR DESCRIPTION
It makes it so webhooks are deleted when a "connected" integration is deleted. Related to https://github.com/grafana/oncall-private/issues/2615.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
