### PR TITLE
Prevent calling contact point endpoint for other integrations

### DIFF
--- a/grafana-plugin/src/containers/IntegrationForm/IntegrationForm.tsx
+++ b/grafana-plugin/src/containers/IntegrationForm/IntegrationForm.tsx
@@ -445,13 +445,15 @@ export const IntegrationForm = observer(
           return;
         }
 
-        if (!IntegrationHelper.isSpecificIntegration(selectedIntegration.value, 'grafana_alerting')) {
-          pushHistory(response.id);
+        if (IntegrationHelper.isSpecificIntegration(selectedIntegration.value, 'grafana_alerting')) {
+          await (formData.is_existing
+            ? AlertReceiveChannelHelper.connectContactPoint
+            : AlertReceiveChannelHelper.createContactPoint)(
+            response.id,
+            formData.alert_manager,
+            formData.contact_point
+          );
         }
-
-        await (formData.is_existing
-          ? AlertReceiveChannelHelper.connectContactPoint
-          : AlertReceiveChannelHelper.createContactPoint)(response.id, formData.alert_manager, formData.contact_point);
 
         pushHistory(response.id);
       }


### PR DESCRIPTION
# What this PR does

Right now there's an issue where we call the contact point endpoint upon integration creation, even though the integration is not grafana_alerting. The PR addresses this issue