### PR TITLE
Fix tabs navigation on the settings page

### DIFF
--- a/grafana-plugin/src/pages/settings/SettingsPage.tsx
+++ b/grafana-plugin/src/pages/settings/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { AppRootProps } from '@grafana/data';
 import { Tab, TabsBar } from '@grafana/ui';
 import cn from 'classnames/bind';
 import { observer } from 'mobx-react';
@@ -8,8 +9,9 @@ import { ChatOpsPage } from 'pages/settings/tabs/ChatOps/ChatOps';
 import { MainSettings } from 'pages/settings/tabs/MainSettings/MainSettings';
 import { isTopNavbar } from 'plugin/GrafanaPluginRootPage.helpers';
 import { AppFeature } from 'state/features';
-import { RootBaseStore } from 'state/rootBaseStore/RootBaseStore';
+import { WithStoreProps } from 'state/types';
 import { withMobXProviderContext } from 'state/withStore';
+import { LocationHelper } from 'utils/LocationHelper';
 import { isUserActionAllowed, UserActions } from 'utils/authorization/authorization';
 
 import { SettingsPageTab } from './SettingsPage.types';
@@ -21,18 +23,23 @@ import styles from './SettingsPage.module.css';
 
 const cx = cn.bind(styles);
 
-interface SettingsPageProps {
-  store: RootBaseStore;
-}
+interface SettingsPageProps extends AppRootProps, WithStoreProps {}
 interface SettingsPageState {
   activeTab: string;
 }
 
 @observer
 class Settings extends React.Component<SettingsPageProps, SettingsPageState> {
-  state: SettingsPageState = {
-    activeTab: SettingsPageTab.MainSettings.key, // should read from route instead
-  };
+  constructor(props: SettingsPageProps) {
+    super(props);
+    const {
+      query: { tab }, // eslint-disable-line
+    } = props;
+
+    this.state = {
+      activeTab: tab || SettingsPageTab.MainSettings.key,
+    };
+  }
 
   render() {
     return <div className={cx('root')}>{this.renderContent()}</div>;
@@ -44,6 +51,7 @@ class Settings extends React.Component<SettingsPageProps, SettingsPageState> {
 
     const onTabChange = (tab: string) => {
       this.setState({ activeTab: tab });
+      LocationHelper.update({ tab: tab }, 'partial');
     };
 
     const hasLiveSettings = store.hasFeature(AppFeature.LiveSettings);

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/ChatOps.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/ChatOps.tsx
@@ -38,7 +38,7 @@ export class _ChatOpsPage extends React.Component<ChatOpsProps, ChatOpsState> {
   componentDidMount() {
     const { query } = this.props; // eslint-disable-line
 
-    this.handleChatopsTabChange(query?.tab || ChatOpsTab.Slack);
+    this.handleChatopsTabChange(query?.chatOpsTab || ChatOpsTab.Slack);
   }
 
   componentWillUnmount() {
@@ -94,7 +94,7 @@ export class _ChatOpsPage extends React.Component<ChatOpsProps, ChatOpsState> {
 
   handleChatopsTabChange(tab: ChatOpsTab) {
     this.setState({ activeTab: tab });
-    LocationHelper.update({ tab: tab }, 'partial');
+    LocationHelper.update({ chatOpsTab: tab }, 'partial');
   }
 }
 

--- a/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
+++ b/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
@@ -147,7 +147,7 @@ export const Root = observer((props: AppRootProps) => {
                 <OutgoingWebhooksPage query={query} />
               </Route>
               <Route path={getRoutesForPage('settings')} exact>
-                <SettingsPage />
+                <SettingsPage query={query} />
               </Route>
               <Route path={getRoutesForPage('chat-ops')} exact>
                 <ChatOpsPage query={query} />


### PR DESCRIPTION
# What this PR does

Fix tabs navigation on the settings page

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2563

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
