### PR TITLE
improve frontend dev exp

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -11,6 +11,7 @@ Related: [How to develop integrations](/engine/config_integrations/README.md)
 - [Tilt | Kubernetes for Prod, Tilt for Dev](https://tilt.dev/)
 - [tilt-dev/ctlptl: Making local Kubernetes clusters fun and easy to set up](https://github.com/tilt-dev/ctlptl)
 - [Kind](https://kind.sigs.k8s.io)
+- [Node.js v18.x](https://nodejs.org/en/download)
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
 
 ### Launch the environment

--- a/grafana-plugin/Dockerfile.dev
+++ b/grafana-plugin/Dockerfile.dev
@@ -1,0 +1,6 @@
+FROM node:18.16.0-alpine
+
+WORKDIR /etc/app
+ENV PATH /etc/app/node_modules/.bin:$PATH
+
+CMD ["yarn", "start"]

--- a/grafana-plugin/Dockerfile.dev
+++ b/grafana-plugin/Dockerfile.dev
@@ -1,6 +1,0 @@
-FROM node:18.16.0-alpine
-
-WORKDIR /etc/app
-ENV PATH /etc/app/node_modules/.bin:$PATH
-
-CMD ["yarn", "start"]


### PR DESCRIPTION
# What this PR does

- Add `yarn install` to Tiltfile when running locally
- Build prod bundle of the frontend without watch mode on CI
- Remove `engine` from Tilt deps of grafana and oncall provisioning config map so grafana can be built in parallel to engine to speed up things
- Update dev/README.md with Node.js requirement

## Which issue(s) this PR closes

Closes https://github.com/grafana/oncall/issues/4295 

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
