### PR TITLE
Fix calculating metrics from different services in metrics collector

### DIFF
--- a/engine/apps/metrics_exporter/tests/conftest.py
+++ b/engine/apps/metrics_exporter/tests/conftest.py
@@ -118,6 +118,12 @@ def mock_cache_get_metrics_for_collector_mixed_versions(monkeypatch):
                             "acknowledged": 3,
                             "resolved": 5,
                         },
+                        "test_service": {
+                            "firing": 10,
+                            "silenced": 10,
+                            "acknowledged": 10,
+                            "resolved": 10,
+                        },
                     },
                 },
             },
@@ -138,9 +144,7 @@ def mock_cache_get_metrics_for_collector_mixed_versions(monkeypatch):
                     "org_id": 1,
                     "slug": "Test stack",
                     "id": 1,
-                    "services": {
-                        NO_SERVICE_VALUE: [2, 10, 200, 650],
-                    },
+                    "services": {NO_SERVICE_VALUE: [2, 10, 200, 650], "test_service": [4, 8, 12]},
                 },
             },
             USER_WAS_NOTIFIED_OF_ALERT_GROUPS: {

--- a/engine/apps/metrics_exporter/tests/test_metrics_collectors.py
+++ b/engine/apps/metrics_exporter/tests/test_metrics_collectors.py
@@ -62,9 +62,13 @@ def test_application_metrics_collector_mixed_cache(
         if metric.name == ALERT_GROUPS_TOTAL:
             # integration with labels for each alert group state
             assert len(metric.samples) == len(AlertGroupState) * 2
+            # check that values from different services were combined to one sample
+            assert {2, 3, 4, 5, 12, 13, 14, 15} == set(sample.value for sample in metric.samples)
         elif metric.name == ALERT_GROUPS_RESPONSE_TIME:
             # integration with labels for each value in collector's bucket + _count and _sum histogram values
             assert len(metric.samples) == (len(collector._buckets) + 2) * 2
+            # check that values from different services were combined to one sample
+            assert 7.0 in set(sample.value for sample in metric.samples)
         elif metric.name == USER_WAS_NOTIFIED_OF_ALERT_GROUPS:
             # metric with labels for each notified user
             assert len(metric.samples) == 1


### PR DESCRIPTION
# What this PR does
Fix calculating metric values per integration from different services

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
