### PR TITLE
Make team selects searchable

### DIFF
--- a/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
+++ b/grafana-plugin/src/components/Policy/EscalationPolicy.tsx
@@ -457,6 +457,7 @@ class _EscalationPolicy extends React.Component<EscalationPolicyProps, any> {
     return (
       <WithPermissionControlTooltip key="notify_to_team_members" userAction={UserActions.EscalationChainsWrite}>
         <GSelect<GrafanaTeam>
+          showSearch
           disabled={isDisabled}
           items={grafanaTeamStore.items}
           fetchItemsFn={grafanaTeamStore.updateItems}

--- a/grafana-plugin/src/containers/ScheduleForm/ScheduleForm.tsx
+++ b/grafana-plugin/src/containers/ScheduleForm/ScheduleForm.tsx
@@ -222,6 +222,7 @@ const ScheduleCommonFields = () => {
         render={({ field }) => (
           <Field label="Assign to team" invalid={!!errors.team} error={errors.team?.message}>
             <GSelect<GrafanaTeam>
+              showSearch
               items={grafanaTeamStore.items}
               fetchItemsFn={grafanaTeamStore.updateItems}
               fetchItemFn={grafanaTeamStore.fetchItemById}


### PR DESCRIPTION
# What this PR does

Make team selects searchable

## Which issue(s) this PR closes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
