### PR TITLE
Jinja2 template helper filter datetimeparse

### DIFF
--- a/docs/sources/configure/jinja2-templating/index.md
+++ b/docs/sources/configure/jinja2-templating/index.md
@@ -219,9 +219,10 @@ Built-in functions:
 - `tojson` - dumps a structure to JSON
 - `tojson_pretty` - same as tojson, but prettified
 - `iso8601_to_time` - converts time from iso8601 (`2015-02-17T18:30:20.000Z`) to datetime
-- `datetimeformat` - converts time from datetime to the given format (`%H:%M / %d-%m-%Y` by default)
+- `datetimeformat` - converts datetime to string according to strftime format codes (`%H:%M / %d-%m-%Y` by default)
 - `datetimeformat_as_timezone` - same as `datetimeformat`, with the inclusion of timezone conversion (`UTC` by default)
   - Usage example: `{{ payload.alerts.startsAt | iso8601_to_time | datetimeformat_as_timezone('%Y-%m-%dT%H:%M:%S%z', 'America/Chicago') }}`
+- `datetimeparse` - converts string to datetime according to strftime format codes (`%H:%M / %d-%m-%Y` by default)
 - `regex_replace` - performs a regex find and replace
 - `regex_match` - performs a regex match, returns `True` or `False`
   - Usage example: `{{ payload.ruleName | regex_match(".*") }}`

--- a/engine/common/jinja_templater/filters.py
+++ b/engine/common/jinja_templater/filters.py
@@ -1,9 +1,17 @@
 import base64
 import json
 import re
+from datetime import datetime
 
 from django.utils.dateparse import parse_datetime
 from pytz import timezone
+
+
+def datetimeparse(value, format="%H:%M / %d-%m-%Y"):
+    try:
+        return datetime.strptime(value, format)
+    except (ValueError, AttributeError, TypeError):
+        return None
 
 
 def datetimeformat(value, format="%H:%M / %d-%m-%Y"):

--- a/engine/common/jinja_templater/jinja_template_env.py
+++ b/engine/common/jinja_templater/jinja_template_env.py
@@ -7,6 +7,7 @@ from .filters import (
     b64decode,
     datetimeformat,
     datetimeformat_as_timezone,
+    datetimeparse,
     iso8601_to_time,
     json_dumps,
     parse_json,
@@ -25,6 +26,7 @@ jinja_template_env = SandboxedEnvironment(loader=BaseLoader())
 
 jinja_template_env.filters["datetimeformat"] = datetimeformat
 jinja_template_env.filters["datetimeformat_as_timezone"] = datetimeformat_as_timezone
+jinja_template_env.filters["datetimeparse"] = datetimeparse
 jinja_template_env.filters["iso8601_to_time"] = iso8601_to_time
 jinja_template_env.filters["tojson_pretty"] = to_pretty_json
 jinja_template_env.globals["time"] = timezone.now

--- a/grafana-plugin/src/components/CheatSheet/CheatSheet.config.ts
+++ b/grafana-plugin/src/components/CheatSheet/CheatSheet.config.ts
@@ -84,7 +84,7 @@ export const genericTemplateCheatSheet: CheatSheetInterface = {
         { listItemName: 'labels - labels assigned to the last alert in the group' },
         { listItemName: 'web_title, web_mesage, web_image_url - templates from Web' },
         { listItemName: 'payload, grafana_oncall_link, grafana_oncall_incident_id, integration_name, source_link' },
-        { listItemName: 'time(), datetimeformat, datetimeformat_as_timezone, iso8601_to_time' },
+        { listItemName: 'time(), datetimeformat, datetimeformat_as_timezone, datetimeparse, iso8601_to_time' },
         { listItemName: 'to_pretty_json' },
         { listItemName: 'regex_replace, regex_match' },
         { listItemName: 'b64decode' },


### PR DESCRIPTION
# What this PR does
Jinja2 filter to parse strings into datetime objects. Previously, only a limited set of strings could be parsed into datetime objects ([datetime_re](https://docs.djangoproject.com/en/2.2/_modules/django/utils/dateparse/)).

The addition of this filter allows for strings of any format to be converted into datetime.

## Which issue(s) this PR closes


<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [*] Unit, integration, and e2e (if applicable) tests updated
- [*] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
