### PR TITLE
Remove kwargs from celery logging

### DIFF
--- a/engine/engine/celery.py
+++ b/engine/engine/celery.py
@@ -104,8 +104,8 @@ if settings.LOG_CELERY_TASK_ARGUMENTS:
 
     @celery.signals.task_prerun.connect
     def log_started_task_arguments(sender=None, task_id=None, task=None, args=None, kwargs=None, **extras):
-        logger.info(f"task started args={args} kwargs={kwargs}")
+        logger.info(f"task started args={args}")
 
     @celery.signals.task_postrun.connect
     def log_finished_task_arguments(sender=None, task_id=None, task=None, args=None, kwargs=None, **extras):
-        logger.info(f"task finished args={args} kwargs={kwargs}")
+        logger.info(f"task finished args={args}")


### PR DESCRIPTION
# What this PR does
Follow-up to #4314. Remove kwargs from celery logging as it included more information than needed.

## Which issue(s) this PR closes

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
