### PR TITLE
Update deep link URL for Slack messages

### DIFF
--- a/engine/apps/slack/models/slack_message.py
+++ b/engine/apps/slack/models/slack_message.py
@@ -98,7 +98,7 @@ class SlackMessage(models.Model):
 
     @property
     def deep_link(self) -> str:
-        return f"slack://channel?team={self.slack_team_identity.slack_id}&id={self.channel_id}&message={self.slack_id}"
+        return f"https://slack.com/app_redirect?channel={self.channel_id}&team={self.slack_team_identity.slack_id}&message={self.slack_id}"
 
     def send_slack_notification(self, user, alert_group, notification_policy):
         from apps.base.models import UserNotificationPolicyLogRecord

--- a/engine/apps/slack/tests/test_slack_message.py
+++ b/engine/apps/slack/tests/test_slack_message.py
@@ -56,5 +56,5 @@ def test_slack_message_deep_link(
     slack_channel = make_slack_channel(slack_team_identity)
     slack_message = make_slack_message(alert_group=alert_group, channel_id=slack_channel.slack_id)
 
-    expected = f"slack://channel?team={slack_team_identity.slack_id}&id={slack_channel.slack_id}&message={slack_message.slack_id}"
+    expected = f"https://slack.com/app_redirect?channel={slack_team_identity.channel_id}&team={slack_team_identity.slack_team_identity.slack_id}&message={slack_team_identity.slack_id}"
     assert slack_message.deep_link == expected

--- a/engine/apps/slack/tests/test_slack_message.py
+++ b/engine/apps/slack/tests/test_slack_message.py
@@ -56,6 +56,8 @@ def test_slack_message_deep_link(
     slack_channel = make_slack_channel(slack_team_identity)
     slack_message = make_slack_message(alert_group=alert_group, channel_id=slack_channel.slack_id)
 
-    expected = f"https://slack.com/app_redirect?channel={slack_channel.slack_id}"\
-               f"&team={slack_team_identity.slack_id}&message={slack_message.slack_id}"
+    expected = (
+        f"https://slack.com/app_redirect?channel={slack_channel.slack_id}"
+        f"&team={slack_team_identity.slack_id}&message={slack_message.slack_id}"
+    )
     assert slack_message.deep_link == expected

--- a/engine/apps/slack/tests/test_slack_message.py
+++ b/engine/apps/slack/tests/test_slack_message.py
@@ -56,6 +56,6 @@ def test_slack_message_deep_link(
     slack_channel = make_slack_channel(slack_team_identity)
     slack_message = make_slack_message(alert_group=alert_group, channel_id=slack_channel.slack_id)
 
-    expected = f"""https://slack.com/app_redirect?channel={slack_channel.slack_id}\
-    &team={slack_team_identity.slack_id}&message={slack_message.slack_id}"""
+    expected = f"https://slack.com/app_redirect?channel={slack_channel.slack_id}"\
+               f"&team={slack_team_identity.slack_id}&message={slack_message.slack_id}"
     assert slack_message.deep_link == expected

--- a/engine/apps/slack/tests/test_slack_message.py
+++ b/engine/apps/slack/tests/test_slack_message.py
@@ -56,6 +56,6 @@ def test_slack_message_deep_link(
     slack_channel = make_slack_channel(slack_team_identity)
     slack_message = make_slack_message(alert_group=alert_group, channel_id=slack_channel.slack_id)
 
-    expected = f"""https://slack.com/app_redirect?channel={slack_channel.slack_id}
+    expected = f"""https://slack.com/app_redirect?channel={slack_channel.slack_id}\
     &team={slack_team_identity.slack_id}&message={slack_message.slack_id}"""
     assert slack_message.deep_link == expected

--- a/engine/apps/slack/tests/test_slack_message.py
+++ b/engine/apps/slack/tests/test_slack_message.py
@@ -56,6 +56,6 @@ def test_slack_message_deep_link(
     slack_channel = make_slack_channel(slack_team_identity)
     slack_message = make_slack_message(alert_group=alert_group, channel_id=slack_channel.slack_id)
 
-    expected = f"""https://slack.com/app_redirect?channel={slack_message.channel_id}
-    &team={slack_message.slack_team_identity.slack_id}&message={slack_message.slack_id}"""
+    expected = f"""https://slack.com/app_redirect?channel={slack_channel.slack_id}
+    &team={slack_team_identity.slack_id}&message={slack_message.slack_id}"""
     assert slack_message.deep_link == expected

--- a/engine/apps/slack/tests/test_slack_message.py
+++ b/engine/apps/slack/tests/test_slack_message.py
@@ -56,5 +56,6 @@ def test_slack_message_deep_link(
     slack_channel = make_slack_channel(slack_team_identity)
     slack_message = make_slack_message(alert_group=alert_group, channel_id=slack_channel.slack_id)
 
-    expected = f"https://slack.com/app_redirect?channel={slack_team_identity.channel_id}&team={slack_team_identity.slack_team_identity.slack_id}&message={slack_team_identity.slack_id}"
+    expected = f"""https://slack.com/app_redirect?channel={slack_message.channel_id}
+    &team={slack_message.slack_team_identity.slack_id}&message={slack_message.slack_id}"""
     assert slack_message.deep_link == expected


### PR DESCRIPTION
# What this PR does

It updates the slack deep link url to respect the [correct format](https://api.slack.com/reference/deep-linking#app_or_bot) requested [here](https://github.com/grafana/oncall/issues/4122)

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
