### PR TITLE
Fix escalation chain webhooks executing when disabled

### DIFF
--- a/engine/apps/alerts/models/alert_group_log_record.py
+++ b/engine/apps/alerts/models/alert_group_log_record.py
@@ -160,7 +160,8 @@ class AlertGroupLogRecord(models.Model):
         ERROR_ESCALATION_NOTIFY_IF_NUM_ALERTS_IN_WINDOW_STEP_IS_NOT_CONFIGURED,
         ERROR_ESCALATION_TRIGGER_CUSTOM_WEBHOOK_ERROR,
         ERROR_ESCALATION_NOTIFY_TEAM_MEMBERS_STEP_IS_NOT_CONFIGURED,
-    ) = range(19)
+        ERROR_ESCALATION_TRIGGER_WEBHOOK_IS_DISABLED,
+    ) = range(20)
 
     type = models.IntegerField(choices=TYPE_CHOICES)
 
@@ -590,6 +591,8 @@ class AlertGroupLogRecord(models.Model):
                         usergroup_handle = self.escalation_policy.notify_to_group.handle
                     usergroup_handle_text = f" @{usergroup_handle}" if usergroup_handle else ""
                     result += f"failed to notify User Group{usergroup_handle_text} in Slack"
+            elif self.escalation_error_code == AlertGroupLogRecord.ERROR_ESCALATION_TRIGGER_WEBHOOK_IS_DISABLED:
+                result += 'skipped escalation step "Trigger Outgoing Webhook" because it is disabled'
         return result
 
     def get_step_specific_info(self):


### PR DESCRIPTION
# What this PR does
Fixes issue where custom webhooks that are part of an escalation chain were still being executed even though they were disabled.  Now the attempt will be logged in the escalation log and noted that the webhook was disabled.

## Which issue(s) this PR closes

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
