### PR TITLE
Handle empty values in convertFiltersToBackendFormat

### DIFF
--- a/grafana-plugin/src/models/filters/filters.helpers.ts
+++ b/grafana-plugin/src/models/filters/filters.helpers.ts
@@ -12,7 +12,7 @@ export const getApiPathByPage = (page: string) => {
   );
 };
 
-export const convertFiltersToBackendFormat = (filters: FiltersValues, filterOptions: FilterOption[]) => {
+export const convertFiltersToBackendFormat = (filters: FiltersValues = {}, filterOptions: FilterOption[] = []) => {
   const newFilters = { ...filters };
   filterOptions.forEach((filterOption) => {
     if (filterOption.type === 'daterange' && newFilters[filterOption.name]) {


### PR DESCRIPTION
# What this PR does
Handle empty values in convertFiltersToBackendFormat

## Which issue(s) this PR closes
Broken Insights page


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
