### PR TITLE
Fix misleading placeholder when creating a new Alerting Integration Contact Point

### DIFF
--- a/grafana-plugin/src/components/IntegrationContactPoint/IntegrationContactPoint.tsx
+++ b/grafana-plugin/src/components/IntegrationContactPoint/IntegrationContactPoint.tsx
@@ -225,7 +225,7 @@ export const IntegrationContactPoint: React.FC<{
         ) : (
           <Input
             value={selectedContactPoint}
-            placeholder="Choose Contact Point"
+            placeholder="Enter New Contact Point Name"
             onChange={({ target }) => {
               const value = (target as HTMLInputElement).value;
               setState({ selectedContactPoint: value });


### PR DESCRIPTION
# What this PR does
It was not clear that the user was expected to enter a name for the new contact point. Changed "Choose Contact Point" to "Enter New Contact Point Name"
<img width="625" alt="Screenshot 2024-05-09 at 3 42 50 PM" src="https://github.com/grafana/oncall/assets/2262529/dd2ba427-d009-4858-a509-3c46d349eb60">


## Which issue(s) this PR closes

Closes [issue link here]

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
