### PR TITLE
Improve query performance when fetching alert payload for templating

### DIFF
--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -574,7 +574,7 @@ class AlertReceiveChannelTemplatesSerializer(EagerLoadingMixin, serializers.Mode
                 raise serializers.ValidationError("Unable to retrieve example payload for this alert group")
         else:
             try:
-                return obj.alert_groups.last().alerts.first().raw_request_data
+                return obj.alert_groups.only("id").last().alerts.first().raw_request_data
             except AttributeError:
                 return None
 


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/10505
(getting only `id` is enough here and the query performs **much** better)