### PR TITLE
Avoid generating response time value metrics for empty integrations

### DIFF
--- a/engine/apps/metrics_exporter/metrics_collectors.py
+++ b/engine/apps/metrics_exporter/metrics_collectors.py
@@ -156,8 +156,11 @@ class ApplicationMetricsCollector:
                         response_time_values.extend(response_time)
                 else:
                     response_time_values = integration_data["response_time"]
-                    if not response_time_values:
-                        continue
+
+                if not response_time_values:
+                    # ignore empty response_time_values
+                    continue
+
                 # todo:metrics: with enabling service_name label move "add_metric" under
                 #  "for service_name, response_time..." iteration
                 buckets, sum_value = self.get_buckets_with_sum(response_time_values)

--- a/engine/apps/metrics_exporter/tests/conftest.py
+++ b/engine/apps/metrics_exporter/tests/conftest.py
@@ -47,6 +47,22 @@ def mock_cache_get_metrics_for_collector(monkeypatch):
                         },
                     },
                 },
+                2: {
+                    "integration_name": "Empty integration",
+                    "team_name": "Test team",
+                    "team_id": 1,
+                    "org_id": 1,
+                    "slug": "Test stack",
+                    "id": 2,
+                    "services": {
+                        NO_SERVICE_VALUE: {
+                            "firing": 0,
+                            "silenced": 0,
+                            "acknowledged": 0,
+                            "resolved": 0,
+                        },
+                    },
+                },
             },
             ALERT_GROUPS_RESPONSE_TIME: {
                 1: {
@@ -59,7 +75,19 @@ def mock_cache_get_metrics_for_collector(monkeypatch):
                     "services": {
                         NO_SERVICE_VALUE: [2, 10, 200, 650],
                     },
-                }
+                },
+                2: {
+                    "integration_name": "Empty integration",
+                    "team_name": "Test team",
+                    "team_id": 1,
+                    "org_id": 1,
+                    "slug": "Test stack",
+                    "id": 2,
+                    "services": {
+                        # if there are no response times available, this integration will be ignored
+                        NO_SERVICE_VALUE: [],
+                    },
+                },
             },
             USER_WAS_NOTIFIED_OF_ALERT_GROUPS: {
                 1: {

--- a/engine/apps/metrics_exporter/tests/test_metrics_collectors.py
+++ b/engine/apps/metrics_exporter/tests/test_metrics_collectors.py
@@ -31,7 +31,7 @@ def test_application_metrics_collector(
         for metric in test_metrics_registry.collect():
             if metric.name == ALERT_GROUPS_TOTAL:
                 # integration with labels for each alert group state
-                assert len(metric.samples) == len(AlertGroupState)
+                assert len(metric.samples) == len(AlertGroupState) * 2
             elif metric.name == ALERT_GROUPS_RESPONSE_TIME:
                 # integration with labels for each value in collector's bucket + _count and _sum histogram values
                 assert len(metric.samples) == len(collector._buckets) + 2


### PR DESCRIPTION
This should help with ongoing issue generating too big metrics payloads (issue introduced when including service name labels).