### PR TITLE
Fix AG date range based filters default values

### DIFF
--- a/grafana-plugin/src/pages/incidents/Incidents.tsx
+++ b/grafana-plugin/src/pages/incidents/Incidents.tsx
@@ -307,8 +307,6 @@ class _IncidentsPage extends React.Component<IncidentsPageProps, IncidentsPageSt
 
   renderIncidentFilters() {
     const { query, store } = this.props;
-    const defaultStart = moment().subtract(7, 'days');
-    const defaultEnd = moment().add(1, 'days');
     return (
       <div className={cx('filters')}>
         <RemoteFilters
@@ -323,7 +321,6 @@ class _IncidentsPage extends React.Component<IncidentsPageProps, IncidentsPageSt
             team: [],
             status: [IncidentStatus.Firing, IncidentStatus.Acknowledged],
             mine: false,
-            started_at: `${defaultStart.format('YYYY-MM-DDTHH:mm:ss')}_${defaultEnd.format('YYYY-MM-DDTHH:mm:ss')}`,
           }}
         />
       </div>


### PR DESCRIPTION
# What this PR does

Fix AG date range based filters default values

## Which issue(s) this PR closes


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
