### PR TITLE
Fix missing filtering term type 1 when editing jinja route template

### DIFF
--- a/grafana-plugin/src/pages/integration/Integration.tsx
+++ b/grafana-plugin/src/pages/integration/Integration.tsx
@@ -186,7 +186,7 @@ class _IntegrationPage extends React.Component<IntegrationProps, IntegrationStat
             }}
             channelFilterId={channelFilterIdForEdit}
             onUpdateTemplates={this.onUpdateTemplatesCallback}
-            onUpdateRoute={this.onUpdateRoutesCallback}
+            onUpdateRoute={(values, channelFilterId) => this.onUpdateRoutesCallback(values, channelFilterId, 1)}
             template={selectedTemplate}
             templateBody={
               selectedTemplate?.name === 'route_template'


### PR DESCRIPTION
# What this PR does
When editing a jinja route template the filtering_term_type was not being provided so it was being validated as regex instead.  This adds the missing flag so that the route will use the correct validation.  The reason this was not being hit in the past is most jinja templates were still passing regex validation.

## Which issue(s) this PR closes

Closes #4259 

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
