### PR TITLE
Fix Slack user group warning false positives

### DIFF
--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -126,7 +126,7 @@ class ScheduleView(
         if slack_team_identity is None:
             return False
 
-        user_group = slack_team_identity.usergroups.first()
+        user_group = slack_team_identity.usergroups.filter(is_active=True).first()
         if user_group is None:
             return False
 


### PR DESCRIPTION
# What this PR does

Fixes Slack user group warning false positives on the schedule detail page

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
