### PR TITLE
show datasource dropdown on cloud

### DIFF
--- a/grafana-plugin/src/dashboards/oncall_metrics_dashboard.json
+++ b/grafana-plugin/src/dashboards/oncall_metrics_dashboard.json
@@ -1392,6 +1392,7 @@
         "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": true,
           "text": ["All"],
@@ -1419,6 +1420,7 @@
         "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": true,
           "text": ["All"],
@@ -1446,6 +1448,7 @@
         "type": "query"
       },
       {
+        "allValue": ".+",
         "current": {
           "selected": true,
           "text": ["All"],

--- a/grafana-plugin/src/pages/insights/variables.ts
+++ b/grafana-plugin/src/pages/insights/variables.ts
@@ -5,6 +5,7 @@ import { InsightsConfig } from './Insights.types';
 const DEFAULT_VARIABLE_CONFIG: Partial<ConstructorParameters<typeof QueryVariable>[0]> = {
   hide: 0,
   includeAll: true,
+  allValue: `.+`,
   isMulti: true,
   options: [],
   refresh: 1,
@@ -14,18 +15,13 @@ const DEFAULT_VARIABLE_CONFIG: Partial<ConstructorParameters<typeof QueryVariabl
   type: 'query',
 };
 
-const getVariables = ({ isOpenSource, datasource, stack }: InsightsConfig) => ({
-  // Selectable
-  ...(isOpenSource
-    ? {
-        datasource: new DataSourceVariable({
-          name: 'datasource',
-          label: 'Data source',
-          pluginId: 'prometheus',
-          value: 'grafanacloud-usage',
-        }),
-      }
-    : {}),
+const getVariables = ({ datasource, stack }: InsightsConfig) => ({
+  datasource: new DataSourceVariable({
+    name: 'datasource',
+    label: 'Data source',
+    pluginId: 'prometheus',
+    value: 'grafanacloud-usage',
+  }),
   team: new QueryVariable({
     ...DEFAULT_VARIABLE_CONFIG,
     name: 'team',


### PR DESCRIPTION
# What this PR does

- show data source filter also on cloud
- use custom All option value to prevent invalid queries when there are too many values

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
