### PR TITLE
Read useBackendPlugin from jsonData

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -82,7 +82,7 @@ if not is_ci:
     )
 
 local_resource(
-    'build-plugin-backend',
+    'build-oncall-plugin-backend',
     labels=["OnCallPluginBackend"],
     dir="./grafana-plugin",
     cmd="mage buildAll",
@@ -90,7 +90,7 @@ local_resource(
 )
 
 local_resource(
-    'restart-plugin-backend',
+    'restart-oncall-plugin-backend',
     labels=["OnCallPluginBackend"],
     dir="./dev/scripts",
     cmd="chmod +x ./restart_backend_plugin.sh && ./restart_backend_plugin.sh",

--- a/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
+++ b/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
@@ -5,5 +5,5 @@ apps:
     jsonData:
       stackId: 5
       orgId: 100
-      onCallApiUrl: orgId
+      onCallApiUrl: http://oncall-dev-engine:8080
       useBackendPlugin: false

--- a/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
+++ b/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
@@ -5,4 +5,5 @@ apps:
     jsonData:
       stackId: 5
       orgId: 100
-      onCallApiUrl: http://oncall-dev-engine:8080
+      onCallApiUrl: orgId
+      useBackendPlugin: false

--- a/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
+++ b/grafana-plugin/src/plugin/GrafanaPluginRootPage.tsx
@@ -68,6 +68,9 @@ export const Root = observer((props: AppRootProps) => {
   const location = useLocation();
 
   useEffect(() => {
+    // TODO: remove once backend plugin is enabled by default
+    window.pluginMeta = props.meta;
+
     loadBasicData();
     // defer loading master data as it's not used in first sec by user in order to prioritize fetching base data
     const timeout = setTimeout(() => {

--- a/grafana-plugin/src/state/plugin/plugin.ts
+++ b/grafana-plugin/src/state/plugin/plugin.ts
@@ -321,19 +321,14 @@ export class PluginState {
   };
 
   static resetPlugin = (): Promise<void> => {
-    /**
-     * mark both of these objects as Required.. this will ensure that we are resetting every attribute back to null
-     * and throw a type error in the event that OnCallPluginMetaJSONData or OnCallPluginMetaSecureJSONData is updated
-     * but we forget to add the attribute here
-     */
-    const jsonData: Required<OnCallPluginMetaJSONData> = {
+    const jsonData: OnCallPluginMetaJSONData = {
       stackId: null,
       orgId: null,
       onCallApiUrl: null,
       insightsDatasource: undefined,
       license: null,
     };
-    const secureJsonData: Required<OnCallPluginMetaSecureJSONData> = {
+    const secureJsonData: OnCallPluginMetaSecureJSONData = {
       grafanaToken: null,
       onCallApiToken: null,
     };

--- a/grafana-plugin/src/types.ts
+++ b/grafana-plugin/src/types.ts
@@ -6,6 +6,7 @@ export type OnCallPluginMetaJSONData = {
   onCallApiUrl: string;
   insightsDatasource?: string;
   license: string;
+  useBackendPlugin?: boolean;
 };
 
 export type OnCallPluginMetaSecureJSONData = {
@@ -35,6 +36,7 @@ declare global {
         unifiedAlerting: { minInterval: string };
       };
     };
+    pluginMeta: OnCallAppPluginMeta;
     RECAPTCHA_SITE_KEY: string;
     grecaptcha: any;
     dataLayer: any;

--- a/grafana-plugin/src/utils/consts.ts
+++ b/grafana-plugin/src/utils/consts.ts
@@ -1,4 +1,4 @@
-import { OnCallAppPluginMeta } from 'types';
+import { OnCallAppPluginMeta, OnCallPluginMetaJSONData } from 'types';
 
 //@ts-ignore
 import plugin from '../../package.json'; // eslint-disable-line
@@ -54,11 +54,12 @@ export const getOnCallApiUrl = (meta?: OnCallAppPluginMeta) => {
   return undefined;
 };
 
-export const getOnCallApiPath = (subpath = '') =>
-  // This flag will be eventually removed once new OnCall initialization is implemented
-  getProcessEnvVarSafely('USE_BACKEND_PLUGIN') === 'true'
+export const getOnCallApiPath = (subpath = '') => {
+  // TODO: remove flag check once backend plugin is enabled by default
+  return window?.pluginMeta?.jsonData?.useBackendPlugin
     ? `/api/plugins/grafana-oncall-app/resources${subpath}`
     : `api/plugin-proxy/grafana-oncall-app/api/internal/v1${subpath}`;
+};
 
 // If the plugin has never been configured, onCallApiUrl will be undefined in the plugin's jsonData
 export const hasPluginBeenConfigured = (meta?: OnCallAppPluginMeta) => Boolean(meta?.jsonData?.onCallApiUrl);

--- a/grafana-plugin/src/utils/consts.ts
+++ b/grafana-plugin/src/utils/consts.ts
@@ -1,4 +1,4 @@
-import { OnCallAppPluginMeta, OnCallPluginMetaJSONData } from 'types';
+import { OnCallAppPluginMeta } from 'types';
 
 //@ts-ignore
 import plugin from '../../package.json'; // eslint-disable-line


### PR DESCRIPTION
Read useBackendPlugin from jsonData. Passing meta to window object is done to avoid unnecessary changes in http interceptors and requests. This hack will be removed once we enable backend plugin by default - it's just for development purposes

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
