### PR TITLE
Add endpoint to get a single user group

### DIFF
--- a/engine/apps/api/tests/test_user_groups.py
+++ b/engine/apps/api/tests/test_user_groups.py
@@ -72,3 +72,30 @@ def test_usergroup_permissions(
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
 
     assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+def test_get_usergroup(
+    make_slack_team_identity,
+    make_slack_user_group,
+    make_organization,
+    make_user_for_organization,
+    make_token_for_organization,
+    make_user_auth_headers,
+):
+    team_identity = make_slack_team_identity()
+    user_group = make_slack_user_group(
+        slack_team_identity=team_identity, name="Test User Group", handle="test-user-group"
+    )
+
+    organization = make_organization(slack_team_identity=team_identity)
+    _, token = make_token_for_organization(organization=organization)
+    user = make_user_for_organization(organization=organization)
+
+    client = APIClient()
+    url = reverse("api-internal:user_group-detail", kwargs={"pk": user_group.public_primary_key})
+    response = client.get(url, format="json", **make_user_auth_headers(user, token))
+    expected_data = {"id": user_group.public_primary_key, "name": "Test User Group", "handle": "test-user-group"}
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == expected_data

--- a/engine/apps/api/views/user_group.py
+++ b/engine/apps/api/views/user_group.py
@@ -6,9 +6,12 @@ from apps.api.permissions import RBACPermission
 from apps.api.serializers.user_group import UserGroupSerializer
 from apps.auth_token.auth import PluginAuthentication
 from apps.slack.models import SlackUserGroup
+from common.api_helpers.mixins import PublicPrimaryKeyMixin
 
 
-class UserGroupViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
+class UserGroupViewSet(
+    PublicPrimaryKeyMixin[SlackUserGroup], mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet
+):
     authentication_classes = (PluginAuthentication,)
     permission_classes = (IsAuthenticated, RBACPermission)
     serializer_class = UserGroupSerializer


### PR DESCRIPTION
# What this PR does
Add endpoint to return slack user group from public primary key

## Which issue(s) this PR closes

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
