### PR TITLE
remove unnecessary CI step `bash` command

### DIFF
--- a/.github/workflows/expensive-e2e-tests.yml
+++ b/.github/workflows/expensive-e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
   post-status-to-slack:
     runs-on: ubuntu-latest
     needs: end-to-end-tests
-    if: failure
+    if: failure()
     steps:
       # Useful references
       # https://stackoverflow.com/questions/59073850/github-actions-get-url-of-test-build

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -143,9 +143,7 @@ jobs:
         uses: ./.github/actions/setup-python
       - name: Unit Test Backend
         working-directory: engine
-        run: |
-          apt-get update && apt-get install -y netcat-traditional
-          ./wait_for_test_mysql_start.sh && pytest -x
+        run: ./wait_for_test_mysql_start.sh && pytest -x
 
   unit-test-backend-postgresql-rabbitmq:
     name: "Backend Tests: PostgreSQL + RabbitMQ (RBAC enabled: ${{ matrix.rbac_enabled }})"
@@ -214,9 +212,7 @@ jobs:
         uses: ./.github/actions/setup-python
       - name: Unit Test Backend
         working-directory: engine
-        run: |
-          apt-get update && apt-get install -y netcat-traditional
-          pytest -x
+        run: pytest -x
 
   unit-test-migrators:
     name: "Unit tests - Migrators"

--- a/engine/apps/grafana_plugin/tests/test_app_config.py
+++ b/engine/apps/grafana_plugin/tests/test_app_config.py
@@ -19,6 +19,7 @@ app_name = "grafana_plugin"
 )
 @patch.object(sys, "exit")
 @override_settings(LICENSE=settings.OPEN_SOURCE_LICENSE_NAME)
+@override_settings(IS_OPEN_SOURCE=True)
 @override_settings(SELF_HOSTED_SETTINGS={"GRAFANA_API_URL": None})
 @pytest.mark.django_db
 def test_it_crashes_the_app_if_the_env_var_is_not_present_for_oss_installations_and_an_org_does_not_exist(


### PR DESCRIPTION
# What this PR does

This command is no longer necessary. Currently it doesn't seem to be working (see screenshot 👇). Presumably `netcat-traditional` is installed on the `ubuntu-latest-8-cores` runner.

![Screenshot 2024-05-24 at 14 42 23](https://github.com/grafana/oncall/assets/9406895/dcb80711-6168-4885-a7b8-a05e323c03bf)
