### PR TITLE
Plugin.json: update with extensions info

### DIFF
--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -592,5 +592,13 @@
   "dependencies": {
     "grafanaDependency": ">=9.2.0",
     "plugins": []
-  }
+  },
+  "extensions": [
+    {
+      "extensionPointId": "grafana/user/profile/tab",
+      "title": "IRM",
+      "description": "IRM settings",
+      "type": "component"
+    }
+  ]
 }


### PR DESCRIPTION
### What changed?

- Manually added ui-extensions metadata to the plugin.json (to be able to lazy-load plugins in Grafana, based on [this PR](https://github.com/grafana/grafana/pull/88288)