### PR TITLE
Fix reported errors by Faro

### DIFF
--- a/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.helpers.tsx
+++ b/grafana-plugin/src/components/PageErrorHandlingWrapper/PageErrorHandlingWrapper.helpers.tsx
@@ -8,7 +8,7 @@ export function getWrongTeamResponseInfo(response): Partial<PageErrorData> {
   if (response) {
     if (response.status === 404) {
       return { isNotFoundError: true };
-    } else if (response.status === 403 && response.data.error_code === 'wrong_team') {
+    } else if (response.status === 403 && response.data?.error_code === 'wrong_team') {
       let res = response.data;
       if (res.owner_team) {
         return { isWrongTeamError: true, switchToTeam: { name: res.owner_team.name, id: res.owner_team.id } };

--- a/grafana-plugin/src/containers/DefaultPageLayout/DefaultPageLayout.helpers.tsx
+++ b/grafana-plugin/src/containers/DefaultPageLayout/DefaultPageLayout.helpers.tsx
@@ -4,18 +4,22 @@ import { PluginLink } from 'components/PluginLink/PluginLink';
 import { Organization } from 'models/organization/organization.types';
 
 import { SlackError } from './DefaultPageLayout.types';
+import { RenderConditionally } from 'components/RenderConditionally/RenderConditionally';
 
 export function getSlackMessage(slackError: SlackError, organization: Organization, hasLiveSettingsFeature: boolean) {
   if (slackError === SlackError.WRONG_WORKSPACE) {
     return (
       <>
         Couldn't connect Slack.
-        {Boolean(organization?.slack_team_identity) && (
-          <>
-            {' '}
-            Select <b>{organization.slack_team_identity.cached_name}</b> workspace when connecting please
-          </>
-        )}
+        <RenderConditionally
+          shouldRender={Boolean(organization?.slack_team_identity)}
+          render={() => (
+            <>
+              {' '}
+              Select <b>{organization.slack_team_identity.cached_name}</b> workspace when connecting please
+            </>
+          )}
+        />
       </>
     );
   }

--- a/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookForm.tsx
+++ b/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookForm.tsx
@@ -74,7 +74,7 @@ function prepareDataForEdit(
 
 function prepareForSave(rawData: Partial<ApiSchemas['Webhook']>, selectedPreset: OutgoingWebhookPreset) {
   const data = { ...rawData };
-  selectedPreset.controlled_fields.forEach((field) => {
+  selectedPreset?.controlled_fields.forEach((field) => {
     delete data[field];
   });
 

--- a/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookFormFields.tsx
+++ b/grafana-plugin/src/containers/OutgoingWebhookForm/OutgoingWebhookFormFields.tsx
@@ -354,7 +354,7 @@ export const OutgoingWebhookFormFields = ({
   return (
     <>
       {React.Children.toArray(controls.props.children).filter(
-        (child) => !preset || !preset.controlled_fields.includes((child as React.ReactElement).props.name)
+        (child) => !preset?.controlled_fields.includes((child as React.ReactElement).props.name)
       )}
     </>
   );

--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -202,9 +202,11 @@ export const RotationForm = observer((props: RotationFormProps) => {
     }
   };
 
-  const onError = useCallback((error) => {
-    setErrors(error.response.data);
-  }, []);
+  const onError = (error) => {
+    if (error.response?.data) {
+      setErrors(error.response.data);
+    }
+  };
 
   const handleChange = useDebouncedCallback(updatePreview, 200);
 

--- a/grafana-plugin/src/containers/UsersTimezones/ScheduleUserDetails/ScheduleUserDetails.tsx
+++ b/grafana-plugin/src/containers/UsersTimezones/ScheduleUserDetails/ScheduleUserDetails.tsx
@@ -43,7 +43,7 @@ export const ScheduleUserDetails: FC<ScheduleUserDetailsProps> = observer((props
 
   const { organizationStore } = store;
   const slackWorkspaceName =
-    organizationStore.currentOrganization.slack_team_identity?.cached_name?.replace(/[^0-9a-z]/gi, '') || '';
+    organizationStore.currentOrganization?.slack_team_identity?.cached_name?.replace(/[^0-9a-z]/gi, '') || '';
 
   return (
     <div className={cx('root')} data-testid="schedule-user-details">

--- a/grafana-plugin/src/models/escalation_chain/escalation_chain.ts
+++ b/grafana-plugin/src/models/escalation_chain/escalation_chain.ts
@@ -86,7 +86,7 @@ export class EscalationChainStore extends BaseStore {
     try {
       escalationChain = await this.getById(id, skipErrorHandling);
     } catch (error) {
-      if (error.response.data.error_code === 'wrong_team') {
+      if (error.response.data?.error_code === 'wrong_team') {
         escalationChain = {
           id,
           name: '🔒 Private escalation chain',

--- a/grafana-plugin/src/models/label/label.helpers.ts
+++ b/grafana-plugin/src/models/label/label.helpers.ts
@@ -1,7 +1,7 @@
 import { ApiSchemas } from 'network/oncall-api/api.types';
 
 export const splitToGroups = (labels: Array<ApiSchemas['LabelKey']> | Array<ApiSchemas['LabelValue']>) => {
-  return labels.reduce(
+  return labels?.reduce(
     (memo, option) => {
       memo.find(({ name }) => name === (option.prescribed ? 'System' : 'User added')).options.push(option);
 

--- a/grafana-plugin/src/models/schedule/schedule.ts
+++ b/grafana-plugin/src/models/schedule/schedule.ts
@@ -189,7 +189,7 @@ export class ScheduleStore extends BaseStore {
       try {
         schedule = await this.getById(id, true, fromOrganization);
       } catch (error) {
-        if (error.response.data.error_code === 'wrong_team') {
+        if (error.response.data?.error_code === 'wrong_team') {
           schedule = {
             id,
             name: '🔒 Private schedule',

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
@@ -118,7 +118,7 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
       <div className={cx('root')}>
         <Legend>Slack App settings</Legend>
         <InlineField label="Slack Workspace" grow disabled>
-          <Input value={currentOrganization.slack_team_identity?.cached_name} />
+          <Input value={currentOrganization?.slack_team_identity?.cached_name} />
         </InlineField>
         <InlineField
           label="Default channel for Slack notifications"
@@ -201,11 +201,6 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
         </InlineField>
       </div>
     );
-  };
-
-  renderSlackWorkspace = () => {
-    const { store } = this.props;
-    return <Text>{store.organizationStore.currentOrganization.slack_team_identity?.cached_name}</Text>;
   };
 
   renderSlackChannels = () => {

--- a/grafana-plugin/src/pages/users/Users.tsx
+++ b/grafana-plugin/src/pages/users/Users.tsx
@@ -367,7 +367,7 @@ class Users extends React.Component<UsersProps, UsersState> {
       warnings.push('Phone not verified');
     }
 
-    if (organizationStore.currentOrganization.slack_team_identity && !user.slack_user_identity) {
+    if (organizationStore.currentOrganization?.slack_team_identity && !user.slack_user_identity) {
       warnings.push('Slack profile is not connected');
     }
 


### PR DESCRIPTION
# What this PR does

Fixes the following reported errors by Faro
- Cannot read properties of undefined (reading 'error_code') - found in Page Error Handling wrapper
- Cannot read properties of undefined (reading 'slack_team_identity') - Found in DefaultPageLayout helpers
- Cannot read properties of undefined (reading 'reduce') - undefined passed labels in labels helpers
- Cannot read properties of undefined (reading 'controlled_fields') - webhooks

The following needs to be further investigated  to see if the response miss whole body
- Cannot read properties of undefined (reading 'config') - happening in Faro. I assume it's when an exception is thrown and the ex doesn't have the `config` field

## Which issue(s) this PR closes

Closes #4403 