### PR TITLE
Fix update slack group to not raise if group is not found

### DIFF
--- a/engine/apps/slack/models/slack_usergroup.py
+++ b/engine/apps/slack/models/slack_usergroup.py
@@ -143,7 +143,12 @@ class SlackUserGroup(models.Model):
         sc = SlackClient(slack_team_identity)
         usergroups = sc.usergroups_list()["usergroups"]
 
-        usergroup = [ug for ug in usergroups if ug["id"] == slack_id][0]
+        try:
+            usergroup = [ug for ug in usergroups if ug["id"] == slack_id][0]
+        except IndexError:
+            # user group not found
+            return
+
         try:
             members = sc.usergroups_users_list(usergroup=usergroup["id"])["users"]
         except SlackAPIError:

--- a/engine/apps/slack/tests/test_user_group.py
+++ b/engine/apps/slack/tests/test_user_group.py
@@ -170,6 +170,27 @@ def test_update_or_create_slack_usergroup_from_slack(
 
 @patch.object(
     SlackClient,
+    "usergroups_list",
+    return_value=build_slack_response(
+        {
+            "ok": True,
+            "usergroups": [{"id": "test_slack_id", "name": "test_name", "handle": "test_handle", "date_delete": 0}],
+        }
+    ),
+)
+@pytest.mark.django_db
+def test_update_or_create_slack_usergroup_from_slack_group_not_found(
+    mock_usergroups_list, make_organization_with_slack_team_identity
+):
+    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    SlackUserGroup.update_or_create_slack_usergroup_from_slack("other_id", slack_team_identity)
+
+    # no group is created, no error is raised
+    assert SlackUserGroup.objects.count() == 0
+
+
+@patch.object(
+    SlackClient,
     "usergroups_users_list",
     return_value=build_slack_response({"ok": True, "users": ["test_user_1", "test_user_2"]}),
 )


### PR DESCRIPTION
Fixes https://github.com/grafana/oncall-private/issues/2664