### PR TITLE
Update escalation auditor logs to expose succeeding count

### DIFF
--- a/engine/apps/alerts/tasks/check_escalation_finished.py
+++ b/engine/apps/alerts/tasks/check_escalation_finished.py
@@ -229,8 +229,9 @@ def check_escalation_finished_task() -> None:
         if total_alert_groups_count == 0
         else (total_alert_groups_count - failed_alert_groups_count) / total_alert_groups_count * 100
     )
-    task_logger.info(f"Alert groups that failed escalation: {failed_alert_groups_count}")
-    task_logger.info(f"Alert groups total: {total_alert_groups_count}")
+    task_logger.info(f"Alert groups failing escalation: {failed_alert_groups_count}")
+    task_logger.info(f"Alert groups succeeding escalation: {total_alert_groups_count - failed_alert_groups_count}")
+    task_logger.info(f"Alert groups total escalations: {total_alert_groups_count}")
     task_logger.info(f"Alert group notifications success ratio: {success_ratio:.2f}")
 
     if alert_group_ids_that_failed_audit:


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2619
(we need the succeeding number to make the SLO query happy with cluster/namespace filtering)