### PR TITLE
only validate existing settings

### DIFF
--- a/engine/apps/base/models/live_setting.py
+++ b/engine/apps/base/models/live_setting.py
@@ -240,7 +240,7 @@ class LiveSetting(models.Model):
 
     @classmethod
     def validate_settings(cls):
-        settings_to_validate = cls.objects.all()
+        settings_to_validate = cls.objects.filter(name__in=cls.AVAILABLE_NAMES)
         for setting in settings_to_validate:
             setting.error = LiveSettingValidator(live_setting=setting).get_error()
             setting.save(update_fields=["error"])


### PR DESCRIPTION
# What this PR does

Only validate live settings in `AVAILABLE_NAMES` to avoid issues when a live setting is renamed (one of the settings was renamed in https://github.com/grafana/oncall/pull/4287 earlier)

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
