### PR TITLE
Inject chatops-proxy metadata into direct paging user dropdown

### DIFF
--- a/engine/apps/slack/scenarios/paging.py
+++ b/engine/apps/slack/scenarios/paging.py
@@ -706,6 +706,13 @@ def _create_user_option_groups(
             }
         )
 
+    # Only inject chatops-proxy metadata into the first dropdown option to reduce payload size
+    # so the 250kb Slack limit is not exceeded for orgs with many users
+    if option_groups:
+        option_groups[0]["options"][0]["value"] = make_value(
+            json.loads(option_groups[0]["options"][0]["value"]), organization
+        )
+
     return option_groups
 
 


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-gateway/issues/240

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
