### PR TITLE
Only generate random OnCall secrets value when it is not provided

### DIFF
--- a/helm/oncall/templates/secrets.yaml
+++ b/helm/oncall/templates/secrets.yaml
@@ -12,8 +12,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{ include "snippet.oncall.secret.secretKey" . }}: {{ randAlphaNum 40 | b64enc | quote }}
-  {{ include "snippet.oncall.secret.mirageSecretKey" . }}: {{ randAlphaNum 40 | b64enc | quote }}
+  {{ include "snippet.oncall.secret.secretKey" . }}: {{ (.Values.oncall.secrets.secretKey | default (randAlphaNum 40)) | b64enc | quote }}
+  {{ include "snippet.oncall.secret.mirageSecretKey" . }}: {{ (.Values.oncall.secrets.mirageSecretKey | default (randAlphaNum 40)) | b64enc | quote }}
 ---
 {{- end }}
 {{- if and (eq .Values.database.type "mysql") (not .Values.mariadb.enabled) (not .Values.externalMysql.existingSecret) }}


### PR DESCRIPTION
# What this PR does
New secret values were being generated for OnCall secrets `secretKey` and `mirageSecretKey` even when a fixed value was provided in the `values.yaml` file. This causes encryption of tokens to break in the DB through inconsistency when things are redeployed. This PR fixes it so that the value will only be generated if it is not set and the values in `values.yaml` are used.

## Which issue(s) this PR closes

Closes [issue link here]

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
