### PR TITLE
Add spacing between words in notifications.

### DIFF
--- a/engine/apps/phone_notifications/phone_backend.py
+++ b/engine/apps/phone_notifications/phone_backend.py
@@ -377,7 +377,7 @@ class PhoneBackend:
 
     def _notify_connected_number(self, user):
         text = (
-            f"This phone number has been connected to Grafana OnCall team"
+            f"This phone number has been connected to Grafana OnCall team "
             f'"{user.organization.stack_slug}"\nYour Grafana OnCall <3'
         )
         try:
@@ -392,7 +392,7 @@ class PhoneBackend:
 
     def _notify_disconnected_number(self, user, number):
         text = (
-            f"This phone number has been disconnected from Grafana OnCall team"
+            f"This phone number has been disconnected from Grafana OnCall team "
             f'"{user.organization.stack_slug}"\nYour Grafana OnCall <3'
         )
         try:


### PR DESCRIPTION


# What this PR does

Add a space between "team" and the quoted team name. Currently this renders as:

```
This phone number has been connected to Grafana OnCall team"ops"
```

(which is an SMS I just received on my phone.)

## Which issue(s) this PR closes

Closes [issue link here]

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
