### PR TITLE
Add backend plugin org sync and rework existing sync

### DIFF
--- a/engine/apps/grafana_plugin/serializers/sync_data.py
+++ b/engine/apps/grafana_plugin/serializers/sync_data.py
@@ -20,7 +20,7 @@ class SyncUserSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     name = serializers.CharField(allow_blank=True)
     login = serializers.CharField()
-    email = serializers.EmailField()
+    email = serializers.CharField()
     role = serializers.CharField()
     avatar_url = serializers.CharField()
     permissions = SyncPermissionSerializer(many=True, allow_empty=True, allow_null=True)
@@ -36,7 +36,7 @@ class SyncUserSerializer(serializers.Serializer):
 class SyncTeamSerializer(serializers.Serializer):
     team_id = serializers.IntegerField()
     name = serializers.CharField()
-    email = serializers.EmailField()
+    email = serializers.EmailField(allow_blank=True)
     avatar_url = serializers.CharField()
 
     def create(self, validated_data):

--- a/engine/apps/grafana_plugin/urls.py
+++ b/engine/apps/grafana_plugin/urls.py
@@ -8,11 +8,13 @@ from apps.grafana_plugin.views import (
     StatusV2View,
     StatusView,
     SyncOrganizationView,
+    SyncV2View,
 )
 
 app_name = "grafana-plugin"
 
 urlpatterns = [
+    re_path(r"v2/sync/?", SyncV2View().as_view(), name="sync-v2"),
     re_path(r"v2/status/?", StatusV2View().as_view(), name="status-v2"),
     re_path(r"v2/install/?", InstallV2View().as_view(), name="install-v2"),
     re_path(r"self-hosted/install/?", SelfHostedInstallView().as_view(), name="self-hosted-install"),

--- a/engine/apps/grafana_plugin/views/__init__.py
+++ b/engine/apps/grafana_plugin/views/__init__.py
@@ -5,3 +5,4 @@ from .self_hosted_install import SelfHostedInstallView  # noqa: F401
 from .status import StatusView  # noqa: F401
 from .status_v2 import StatusV2View  # noqa: F401
 from .sync_organization import SyncOrganizationView  # noqa: F401
+from .sync_v2 import SyncV2View  # noqa: F401

--- a/engine/apps/grafana_plugin/views/install_v2.py
+++ b/engine/apps/grafana_plugin/views/install_v2.py
@@ -4,31 +4,24 @@ from django.conf import settings
 from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
-from apps.grafana_plugin.serializers.sync_data import SyncDataSerializer
-from apps.user_management.sync import get_organization
-from common.api_helpers.errors import INVALID_SELF_HOSTED_ID, SELF_HOSTED_ONLY_FEATURE_ERROR
+from apps.grafana_plugin.views.sync_v2 import SyncException, SyncV2View
+from common.api_helpers.errors import SELF_HOSTED_ONLY_FEATURE_ERROR
 
 logger = logging.getLogger(__name__)
 
 
-class InstallV2View(APIView):
+class InstallV2View(SyncV2View):
     def post(self, request: Request) -> Response:
         if settings.LICENSE != settings.OPEN_SOURCE_LICENSE_NAME:
             return Response(data=SELF_HOSTED_ONLY_FEATURE_ERROR, status=status.HTTP_403_FORBIDDEN)
 
-        serializer = SyncDataSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(data=serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            organization = self.do_sync(request)
+        except SyncException as e:
+            return Response(data=e.error_data, status=status.HTTP_400_BAD_REQUEST)
 
-        sync_data = serializer.save()
-        settings_stack_id = settings.SELF_HOSTED_SETTINGS["STACK_ID"]
-        settings_org_id = settings.SELF_HOSTED_SETTINGS["ORG_ID"]
-        if sync_data.settings.org_id != settings_org_id or sync_data.settings.stack_id != settings_stack_id:
-            return Response(data=INVALID_SELF_HOSTED_ID, status=status.HTTP_400_BAD_REQUEST)
-
-        organization = get_organization(sync_data.settings.org_id, sync_data.settings.stack_id, sync_data)
         organization.revoke_plugin()
         provisioned_data = organization.provision_plugin()
+
         return Response(data=provisioned_data, status=status.HTTP_200_OK)

--- a/engine/apps/grafana_plugin/views/sync_v2.py
+++ b/engine/apps/grafana_plugin/views/sync_v2.py
@@ -1,0 +1,45 @@
+import logging
+
+from django.conf import settings
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.grafana_plugin.serializers.sync_data import SyncDataSerializer
+from apps.user_management.models import Organization
+from apps.user_management.sync import apply_sync_data, get_or_create_organization
+from common.api_helpers.errors import INVALID_SELF_HOSTED_ID
+
+logger = logging.getLogger(__name__)
+
+
+class SyncException(Exception):
+    def __init__(self, error_data):
+        self.error_data = error_data
+
+
+class SyncV2View(APIView):
+    def do_sync(self, request: Request) -> Organization:
+        serializer = SyncDataSerializer(data=request.data)
+        if not serializer.is_valid():
+            raise SyncException(serializer.errors)
+
+        sync_data = serializer.save()
+
+        settings_stack_id = settings.SELF_HOSTED_SETTINGS["STACK_ID"]
+        settings_org_id = settings.SELF_HOSTED_SETTINGS["ORG_ID"]
+        if sync_data.settings.org_id != settings_org_id or sync_data.settings.stack_id != settings_stack_id:
+            raise SyncException(INVALID_SELF_HOSTED_ID)
+
+        organization = get_or_create_organization(sync_data.settings.org_id, sync_data.settings.stack_id, sync_data)
+        apply_sync_data(organization, sync_data)
+        return organization
+
+    def post(self, request: Request) -> Response:
+        try:
+            self.do_sync(request)
+        except SyncException as e:
+            return Response(data=e.error_data, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(status=status.HTTP_200_OK)

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -1,15 +1,21 @@
 import logging
+import typing
 import uuid
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.db import transaction
 from django.utils import timezone
 
+from apps.alerts.models import AlertReceiveChannel
+from apps.api.permissions import LegacyAccessControlRole
 from apps.auth_token.exceptions import InvalidToken
+from apps.base.models import UserNotificationPolicy
 from apps.grafana_plugin.helpers.client import GcomAPIClient, GCOMInstanceInfo, GrafanaAPIClient
-from apps.grafana_plugin.sync_data import SyncData, SyncUser
+from apps.grafana_plugin.sync_data import SyncData, SyncPermission, SyncSettings, SyncTeam, SyncUser
+from apps.metrics_exporter.helpers import metrics_bulk_update_team_label_cache
+from apps.metrics_exporter.metrics_cache_manager import MetricsCacheManager
 from apps.user_management.models import Organization, Team, User
-from apps.user_management.signals import org_sync_signal
 from common.utils import task_lock
 from settings.base import CLOUD_LICENSE_NAME, OPEN_SOURCE_LICENSE_NAME
 
@@ -31,8 +37,8 @@ def sync_organization(organization: Organization) -> None:
 
 def _sync_organization(organization: Organization) -> None:
     grafana_api_client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
-    rbac_is_enabled = organization.is_rbac_permissions_enabled
 
+    rbac_is_enabled = organization.is_rbac_permissions_enabled
     # NOTE: checking whether or not RBAC is enabled depends on whether we are dealing with an open-source or cloud
     # stack. For open-source, simply make a HEAD request to the grafana instance's API and consider RBAC enabled if
     # the list RBAC permissions endpoint returns 200.
@@ -54,42 +60,42 @@ def _sync_organization(organization: Organization) -> None:
     else:
         rbac_is_enabled = grafana_api_client.is_rbac_enabled_for_organization()
 
-    organization.is_rbac_permissions_enabled = rbac_is_enabled
-    logger.info(f"RBAC status org={organization.pk} rbac_enabled={organization.is_rbac_permissions_enabled}")
+    # get incident plugin settings
+    grafana_incident_settings, _ = grafana_api_client.get_grafana_incident_plugin_settings()
+    is_grafana_incident_enabled = False
+    grafana_incident_backend_url = None
+    if grafana_incident_settings is not None:
+        is_grafana_incident_enabled = grafana_incident_settings["enabled"]
+        grafana_incident_backend_url = (grafana_incident_settings.get("jsonData") or {}).get(
+            GrafanaAPIClient.GRAFANA_INCIDENT_PLUGIN_BACKEND_URL_KEY
+        )
 
-    _sync_instance_info(organization)
+    # get labels plugin settings
+    is_grafana_labels_enabled = False
+    grafana_labels_plugin_settings, _ = grafana_api_client.get_grafana_labels_plugin_settings()
+    if grafana_labels_plugin_settings is not None:
+        is_grafana_labels_enabled = grafana_labels_plugin_settings["enabled"]
 
-    _, check_token_call_status = grafana_api_client.check_token()
-    if check_token_call_status["connected"]:
-        organization.api_token_status = Organization.API_TOKEN_STATUS_OK
-        sync_users_and_teams(grafana_api_client, organization)
-        organization.last_time_synced = timezone.now()
+    oncall_api_url = settings.BASE_URL
+    if settings.LICENSE == CLOUD_LICENSE_NAME:
+        oncall_api_url = settings.GRAFANA_CLOUD_ONCALL_API_URL
 
-        _sync_grafana_incident_plugin(organization, grafana_api_client)
-        _sync_grafana_labels_plugin(organization, grafana_api_client)
-    else:
-        organization.api_token_status = Organization.API_TOKEN_STATUS_FAILED
-        logger.warning(f"Sync not successful org={organization.pk} token_status=FAILED")
-
-    organization.save(
-        update_fields=[
-            "cluster_slug",
-            "stack_slug",
-            "org_slug",
-            "org_title",
-            "region_slug",
-            "grafana_url",
-            "last_time_synced",
-            "api_token_status",
-            "gcom_token_org_last_time_synced",
-            "is_rbac_permissions_enabled",
-            "is_grafana_incident_enabled",
-            "is_grafana_labels_enabled",
-            "grafana_incident_backend_url",
-        ]
+    sync_settings = SyncSettings(
+        stack_id=organization.stack_id,
+        org_id=organization.org_id,
+        license=settings.LICENSE,
+        oncall_api_url=oncall_api_url,
+        oncall_token=organization.gcom_token,
+        grafana_url=organization.grafana_url,
+        grafana_token=organization.api_token,
+        rbac_enabled=rbac_is_enabled,
+        incident_enabled=is_grafana_incident_enabled,
+        incident_backend_url=grafana_incident_backend_url,
+        labels_enabled=is_grafana_labels_enabled,
     )
-
-    org_sync_signal.send(sender=None, organization=organization)
+    _sync_organization_data(organization, sync_settings)
+    if organization.api_token_status == Organization.API_TOKEN_STATUS_OK:
+        sync_users_and_teams(grafana_api_client, organization)
 
 
 def _sync_instance_info(organization: Organization) -> None:
@@ -109,32 +115,6 @@ def _sync_instance_info(organization: Organization) -> None:
         organization.gcom_token_org_last_time_synced = timezone.now()
 
 
-def _sync_grafana_labels_plugin(organization: Organization, grafana_api_client) -> None:
-    """
-    _sync_grafana_labels_plugin checks if grafana-labels-app plugin is enabled and sets a flag in the organization.
-    It intended to use only inside _sync_organization. It mutates, but not saves org, it's saved in _sync_organization.
-    """
-    grafana_labels_plugin_settings, _ = grafana_api_client.get_grafana_labels_plugin_settings()
-    if grafana_labels_plugin_settings is not None:
-        organization.is_grafana_labels_enabled = grafana_labels_plugin_settings["enabled"]
-
-
-def _sync_grafana_incident_plugin(organization: Organization, grafana_api_client) -> None:
-    """
-    _sync_grafana_incident_plugin check if incident plugin is enabled and sets a flag and its url in the organization.
-    It intended to use only inside _sync_organization. It mutates, but not saves org, it's saved in _sync_organization.
-    """
-    grafana_incident_settings, _ = grafana_api_client.get_grafana_incident_plugin_settings()
-    organization.is_grafana_incident_enabled = False
-    organization.grafana_incident_backend_url = None
-
-    if grafana_incident_settings is not None:
-        organization.is_grafana_incident_enabled = grafana_incident_settings["enabled"]
-        organization.grafana_incident_backend_url = (grafana_incident_settings.get("jsonData") or {}).get(
-            GrafanaAPIClient.GRAFANA_INCIDENT_PLUGIN_BACKEND_URL_KEY
-        )
-
-
 def sync_users_and_teams(client: GrafanaAPIClient, organization: Organization) -> None:
     sync_users(client, organization)
     sync_teams(client, organization)
@@ -146,7 +126,21 @@ def sync_users(client: GrafanaAPIClient, organization: Organization, **kwargs) -
     # check if api_users are shaped correctly. e.g. for paused instance, the response is not a list.
     if not api_users or not isinstance(api_users, (tuple, list)):
         return
-    User.objects.sync_for_organization(organization=organization, api_users=api_users)
+
+    sync_users = [
+        SyncUser(
+            id=user["userId"],
+            name=user["name"],
+            login=user["login"],
+            email=user["email"],
+            role=user["role"],
+            avatar_url=user["avatarUrl"],
+            teams=None,
+            permissions=[SyncPermission(action=permission["permission"]) for permission in user["permissions"]],
+        )
+        for user in api_users
+    ]
+    _sync_users_data(organization, sync_users, delete_extra=True)
 
 
 def sync_teams(client: GrafanaAPIClient, organization: Organization, **kwargs) -> None:
@@ -154,23 +148,26 @@ def sync_teams(client: GrafanaAPIClient, organization: Organization, **kwargs) -
     if not api_teams_result:
         return
     api_teams = api_teams_result["teams"]
-    Team.objects.sync_for_organization(organization=organization, api_teams=api_teams)
+    sync_teams = [
+        SyncTeam(
+            team_id=team["id"],
+            name=team["name"],
+            email=team["email"],
+            avatar_url=team["avatarUrl"],
+        )
+        for team in api_teams
+    ]
+    _sync_teams_data(organization, sync_teams)
 
 
 def sync_team_members(client: GrafanaAPIClient, organization: Organization) -> None:
+    team_members = {}
     for team in organization.teams.all():
         members, _ = client.get_team_members(team.team_id)
         if not members:
             continue
-        User.objects.sync_for_team(team=team, api_members=members)
-
-
-def sync_users_for_teams(client: GrafanaAPIClient, organization: Organization, **kwargs) -> None:
-    api_teams_result, _ = client.get_teams(**kwargs)
-    if not api_teams_result:
-        return
-    api_teams = api_teams_result["teams"]
-    Team.objects.sync_for_organization(organization=organization, api_teams=api_teams)
+        team_members[team.team_id] = [member["userId"] for member in members]
+    _sync_teams_members_data(organization, team_members)
 
 
 def delete_organization_if_needed(organization: Organization) -> bool:
@@ -219,7 +216,7 @@ def cleanup_organization(organization_pk: int) -> None:
         logger.info(f"Organization {organization_pk} was not found")
 
 
-def create_cloud_organization(
+def _create_cloud_organization(
     org_id: int, stack_id: int, sync_data: SyncData, instance_info: GCOMInstanceInfo
 ) -> Organization:
     client = GcomAPIClient(sync_data.settings.oncall_token)
@@ -244,7 +241,7 @@ def create_cloud_organization(
     )
 
 
-def create_oss_organization(sync_data: SyncData) -> Organization:
+def _create_oss_organization(sync_data: SyncData) -> Organization:
     return Organization.objects.create(
         stack_id=settings.SELF_HOSTED_SETTINGS["STACK_ID"],
         stack_slug=settings.SELF_HOSTED_SETTINGS["STACK_SLUG"],
@@ -259,31 +256,181 @@ def create_oss_organization(sync_data: SyncData) -> Organization:
     )
 
 
-def create_organization(
+def _create_organization(
     org_id: int, stack_id: int, sync_data: SyncData, instance_info: GCOMInstanceInfo
-) -> Organization:
+) -> typing.Optional[Organization]:
     if settings.LICENSE == CLOUD_LICENSE_NAME:
-        return create_cloud_organization(org_id, stack_id, sync_data, instance_info)
+        return _create_cloud_organization(org_id, stack_id, sync_data, instance_info)
     elif settings.LICENSE == OPEN_SOURCE_LICENSE_NAME:
-        return create_oss_organization(sync_data)
+        return _create_oss_organization(sync_data)
+    return None
 
 
-def get_organization(
+def get_or_create_organization(
     org_id: int, stack_id: int, sync_data: SyncData = None, instance_info: GCOMInstanceInfo = None
 ) -> Organization:
     organization = Organization.objects.filter(org_id=org_id, stack_id=stack_id).first()
     if not organization:
-        organization = create_organization(org_id, stack_id, sync_data, instance_info)
-    if sync_data:
-        organization.grafana_url = sync_data.settings.grafana_url
-        organization.api_token = sync_data.settings.grafana_token
-        organization.save(update_fields=["api_token", "grafana_url"])
+        organization = _create_organization(org_id, stack_id, sync_data, instance_info)
     return organization
 
 
-def get_user(organization: Organization, sync_user: SyncUser) -> User:
-    pass
+def get_or_create_user(organization: Organization, sync_user: SyncUser) -> User:
+    _sync_users_data(organization, [sync_user], delete_extra=False)
+    return organization.users.get(user_id=sync_user.id)
 
 
-def apply_sync_data(organization: Organization, sync_data: SyncData, instance_info: GCOMInstanceInfo = None):
-    pass
+def _sync_organization_data(organization: Organization, sync_settings: SyncSettings):
+    organization.is_rbac_permissions_enabled = sync_settings.rbac_enabled
+    logger.info(f"RBAC status org={organization.pk} rbac_enabled={organization.is_rbac_permissions_enabled}")
+
+    organization.is_grafana_labels_enabled = sync_settings.labels_enabled
+    organization.is_grafana_incident_enabled = sync_settings.incident_enabled
+    organization.grafana_incident_backend_url = sync_settings.incident_backend_url
+    organization.last_time_synced = timezone.now()
+
+    _sync_instance_info(organization)
+
+    grafana_api_client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
+    _, check_token_call_status = grafana_api_client.check_token()
+    if check_token_call_status["connected"]:
+        organization.api_token_status = Organization.API_TOKEN_STATUS_OK
+        organization.last_time_synced = timezone.now()
+    else:
+        organization.api_token_status = Organization.API_TOKEN_STATUS_FAILED
+        logger.warning(f"Sync not successful org={organization.pk} token_status=FAILED")
+
+    organization.save(
+        update_fields=[
+            "cluster_slug",
+            "stack_slug",
+            "org_slug",
+            "org_title",
+            "region_slug",
+            "grafana_url",
+            "last_time_synced",
+            "gcom_token_org_last_time_synced",
+            "is_rbac_permissions_enabled",
+            "is_grafana_incident_enabled",
+            "is_grafana_labels_enabled",
+            "grafana_incident_backend_url",
+        ]
+    )
+
+
+def _sync_users_data(organization: Organization, sync_users: list[SyncUser], delete_extra=False):
+    users_to_sync = (
+        User(
+            organization_id=organization.pk,
+            user_id=user.id,
+            email=user.email,
+            name=user.name,
+            username=user.login,
+            role=getattr(LegacyAccessControlRole, user.role.upper(), LegacyAccessControlRole.NONE),
+            avatar_url=user.avatar_url,
+            permissions=user.permissions or [],
+        )
+        for user in sync_users
+    )
+
+    existing_user_ids = set(organization.users.all().values_list("user_id", flat=True))
+    with transaction.atomic():
+        kwargs = {}
+        if settings.DATABASE_TYPE in ("sqlite3", "postgresql"):
+            # unique_fields is required for sqlite and postgresql setups
+            kwargs["unique_fields"] = ("organization_id", "user_id", "is_active")
+        organization.users.bulk_create(
+            users_to_sync,
+            update_conflicts=True,
+            update_fields=("email", "name", "username", "role", "avatar_url", "permissions"),
+            batch_size=5000,
+            **kwargs,
+        )
+
+        # Retrieve primary keys for the newly created users
+        #
+        # If the model’s primary key is an AutoField, the primary key attribute can only be retrieved
+        # on certain databases (currently PostgreSQL, MariaDB 10.5+, and SQLite 3.35+).
+        # On other databases, it will not be set.
+        # https://docs.djangoproject.com/en/4.1/ref/models/querysets/#django.db.models.query.QuerySet.bulk_create
+        created_users = organization.users.exclude(user_id__in=existing_user_ids)
+
+        policies_to_create = ()
+        for user in created_users:
+            policies_to_create = policies_to_create + user.default_notification_policies_defaults
+            policies_to_create = policies_to_create + user.important_notification_policies_defaults
+        UserNotificationPolicy.objects.bulk_create(policies_to_create, ignore_conflicts=True, batch_size=5000)
+
+    if delete_extra:
+        # delete removed users
+        existing_user_ids |= set(u.user_id for u in created_users)
+        user_ids_to_delete = existing_user_ids - {user.id for user in sync_users}
+        organization.users.filter(user_id__in=user_ids_to_delete).delete()
+
+
+def _sync_teams_data(organization: Organization, sync_teams: list[SyncTeam]):
+    # keep existing team names mapping to check for possible metrics cache updates
+    existing_team_names = {team.team_id: team.name for team in organization.teams.all()}
+    teams_to_sync = tuple(
+        Team(
+            organization_id=organization.pk,
+            team_id=team.team_id,
+            name=team.name,
+            email=team.email,
+            avatar_url=team.avatar_url,
+        )
+        for team in sync_teams
+    )
+    # create entries, update if team_id already exists in the organization
+    kwargs = {}
+    if settings.DATABASE_TYPE in ("sqlite3", "postgresql"):
+        # unique_fields is required for sqlite and postgresql setups
+        kwargs["unique_fields"] = ("organization_id", "team_id")
+    organization.teams.bulk_create(
+        teams_to_sync,
+        batch_size=5000,
+        update_conflicts=True,
+        update_fields=("name", "email", "avatar_url"),
+        **kwargs,
+    )
+
+    # create missing direct paging integrations
+    AlertReceiveChannel.objects.create_missing_direct_paging_integrations(organization)
+
+    # delete removed teams and their direct paging integrations
+    existing_team_ids = set(organization.teams.all().values_list("team_id", flat=True))
+    team_ids_to_delete = existing_team_ids - set(t.team_id for t in sync_teams)
+    organization.alert_receive_channels.filter(
+        team__team_id__in=team_ids_to_delete, integration=AlertReceiveChannel.INTEGRATION_DIRECT_PAGING
+    ).delete()
+    organization.teams.filter(team_id__in=team_ids_to_delete).delete()
+
+    # collect teams diffs to update metrics cache
+    metrics_teams_to_update: MetricsCacheManager.TeamsDiffMap = {}
+    for team_id in team_ids_to_delete:
+        metrics_teams_to_update = MetricsCacheManager.update_team_diff(metrics_teams_to_update, team_id, deleted=True)
+    for team in sync_teams:
+        previous_name = existing_team_names.get(team.team_id)
+        if previous_name and previous_name != team.name:
+            metrics_teams_to_update = MetricsCacheManager.update_team_diff(
+                metrics_teams_to_update, team.team_id, new_name=team.name
+            )
+    metrics_bulk_update_team_label_cache(metrics_teams_to_update, organization.id)
+
+
+def _sync_teams_members_data(organization: Organization, team_members: dict[int, list[int]]):
+    # set team members
+    for team_id, members_ids in team_members.items():
+        team = organization.teams.get(team_id=team_id)
+        team.users.set(organization.users.filter(user_id__in=members_ids))
+
+
+def apply_sync_data(organization: Organization, sync_data: SyncData):
+    # update org + settings
+    _sync_organization_data(organization, sync_data.settings)
+    # update or create users
+    _sync_users_data(organization, sync_data.users, delete_extra=True)
+    # update or create teams + direct paging integrations
+    _sync_teams_data(organization, sync_data.teams)
+    # update team members
+    _sync_teams_members_data(organization, sync_data.team_members)

--- a/engine/apps/user_management/tests/test_sync.py
+++ b/engine/apps/user_management/tests/test_sync.py
@@ -9,14 +9,8 @@ from django.test import override_settings
 
 from apps.alerts.models import AlertReceiveChannel
 from apps.api.permissions import LegacyAccessControlRole
-from apps.grafana_plugin.helpers.client import GrafanaAPIClient
-from apps.user_management.models import Team, User
-from apps.user_management.sync import (
-    _sync_grafana_incident_plugin,
-    _sync_grafana_labels_plugin,
-    cleanup_organization,
-    sync_organization,
-)
+from apps.user_management.models import User
+from apps.user_management.sync import cleanup_organization, sync_organization, sync_team_members, sync_teams, sync_users
 
 MOCK_GRAFANA_INCIDENT_BACKEND_URL = "https://grafana-incident.test"
 
@@ -96,8 +90,9 @@ def test_sync_users_for_organization(make_organization, make_user_for_organizati
         }
         for user_id in (2, 3)
     )
-
-    User.objects.sync_for_organization(organization, api_users=api_users)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.get_users.return_value = api_users
+        sync_users(mock_grafana_api_client, organization)
 
     assert organization.users.count() == 2
 
@@ -149,7 +144,9 @@ def test_sync_users_for_organization_role_none(make_organization, make_user_for_
         for user_id in (2, 3)
     )
 
-    User.objects.sync_for_organization(organization, api_users=api_users)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.get_users.return_value = api_users
+        sync_users(mock_grafana_api_client, organization)
 
     assert organization.users.count() == 2
 
@@ -182,7 +179,9 @@ def test_sync_teams_for_organization(make_organization, make_team, make_alert_re
         for team_id in (2, 3, 4)
     )
 
-    Team.objects.sync_for_organization(organization, api_teams=api_teams)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.get_teams.return_value = ({"teams": api_teams}, None)
+        sync_teams(mock_grafana_api_client, organization)
 
     assert organization.teams.count() == 3
 
@@ -236,15 +235,16 @@ def test_sync_users_for_team(make_organization, make_user_for_organization, make
         },
     )
 
-    User.objects.sync_for_team(team, api_members=api_members)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.get_team_members.return_value = (api_members, None)
+        sync_team_members(mock_grafana_api_client, organization)
 
     assert team.users.count() == 1
     assert team.users.get() == users[0]
 
 
 @pytest.mark.django_db
-@patch("apps.user_management.sync.org_sync_signal")
-def test_sync_organization(mocked_org_sync_signal, make_organization):
+def test_sync_organization(make_organization):
     organization = make_organization()
 
     with patched_grafana_api_client(organization):
@@ -270,8 +270,6 @@ def test_sync_organization(mocked_org_sync_signal, make_organization):
 
     # check that is_grafana_labels_enabled flag is set
     assert organization.is_grafana_labels_enabled is True
-
-    mocked_org_sync_signal.send.assert_called_once_with(sender=None, organization=organization)
 
 
 @pytest.mark.parametrize("is_rbac_enabled_for_organization", [False, True])
@@ -334,15 +332,26 @@ def test_duplicate_user_ids(make_organization, make_user_for_organization):
     organization = make_organization()
 
     user = make_user_for_organization(organization, user_id=1)
-    api_users = []
-
-    User.objects.sync_for_organization(organization, api_users=api_users)
+    api_users = [
+        {
+            "userId": 2,
+            "email": "other@test.test",
+            "name": "Other",
+            "login": "other",
+            "role": "admin",
+            "avatarUrl": "other.test/test",
+            "permissions": [],
+        }
+    ]
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.get_users.return_value = api_users
+        sync_users(mock_grafana_api_client, organization)
 
     user.refresh_from_db()
 
     assert user.is_active is None
-    assert organization.users.count() == 0
-    assert User.objects.filter_with_deleted().count() == 1
+    assert organization.users.count() == 1
+    assert User.objects.filter_with_deleted(organization=organization).count() == 2
 
     api_users = [
         {
@@ -356,11 +365,13 @@ def test_duplicate_user_ids(make_organization, make_user_for_organization):
         }
     ]
 
-    User.objects.sync_for_organization(organization, api_users=api_users)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.get_users.return_value = api_users
+        sync_users(mock_grafana_api_client, organization)
 
     assert organization.users.count() == 1
     assert organization.users.get().email == "newtest@test.test"
-    assert User.objects.filter_with_deleted().count() == 2
+    assert User.objects.filter_with_deleted(organization=organization).count() == 3
 
 
 @pytest.mark.django_db
@@ -411,7 +422,9 @@ def test_sync_organization_lock(
     mock_task_lock.assert_called_once_with(lock_cache_key, "random")
 
     if task_lock_acquired:
-        mock_grafana_api_client.assert_called_once()
+        # 2 calls: get client to fetch organization data,
+        # and then another one to check token in the refactored sync function
+        assert mock_grafana_api_client.call_count == 2
     else:
         # task lock could not be acquired
         mock_grafana_api_client.assert_not_called()
@@ -439,13 +452,10 @@ def test_sync_grafana_labels_plugin(make_organization, test_params: TestSyncGraf
     organization = make_organization()
     organization.is_grafana_labels_enabled = False  # by default in tests it's true, so setting to false
 
-    with patch.object(
-        GrafanaAPIClient,
-        "get_grafana_labels_plugin_settings",
-        return_value=test_params.response,
-    ):
-        grafana_api_client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
-        _sync_grafana_labels_plugin(organization, grafana_api_client)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.return_value.get_grafana_labels_plugin_settings.return_value = test_params.response
+        sync_organization(organization)
+    organization.refresh_from_db()
     assert organization.is_grafana_labels_enabled is test_params.expected_result
 
 
@@ -476,12 +486,9 @@ class TestSyncGrafanaIncidentParams:
 @pytest.mark.django_db
 def test_sync_grafana_incident_plugin(make_organization, test_params: TestSyncGrafanaIncidentParams):
     organization = make_organization()
-    with patch.object(
-        GrafanaAPIClient,
-        "get_grafana_incident_plugin_settings",
-        return_value=test_params.response,
-    ):
-        grafana_api_client = GrafanaAPIClient(api_url=organization.grafana_url, api_token=organization.api_token)
-        _sync_grafana_incident_plugin(organization, grafana_api_client)
+    with patched_grafana_api_client(organization) as mock_grafana_api_client:
+        mock_grafana_api_client.return_value.get_grafana_incident_plugin_settings.return_value = test_params.response
+        sync_organization(organization)
+    organization.refresh_from_db()
     assert organization.is_grafana_incident_enabled is test_params.expected_flag
-    assert organization.grafana_incident_backend_url is test_params.expected_url
+    assert organization.grafana_incident_backend_url == test_params.expected_url

--- a/grafana-plugin/pkg/plugin/resources.go
+++ b/grafana-plugin/pkg/plugin/resources.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"net/http"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
 type OnCallSync struct {
@@ -86,6 +87,7 @@ func (a *App) handleLegacyInstall(w *responseWriter, req *http.Request) {
 func (a *App) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/plugin/install", a.handleInstall)
 	mux.HandleFunc("/plugin/status", a.handleStatus)
+	mux.HandleFunc("/plugin/sync", a.handleSync)
 
 	mux.Handle("/plugin/self-hosted/install", afterRequest(http.HandlerFunc(a.handleInternalApi), a.handleLegacyInstall))
 

--- a/grafana-plugin/pkg/plugin/sync.go
+++ b/grafana-plugin/pkg/plugin/sync.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/url"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+
+	"net/http"
+)
+
+func (a *App) handleSync(w http.ResponseWriter, req *http.Request) {
+	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
+	if err != nil {
+		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		return
+	}
+
+	onCallSync, err := a.GetSyncData(req.Context(), onCallPluginSettings)
+	if err != nil {
+		log.DefaultLogger.Error("Error getting sync data: ", err)
+		return
+	}
+
+	onCallSyncJsonData, err := json.Marshal(onCallSync)
+	if err != nil {
+		log.DefaultLogger.Error("Error marshalling JSON: ", err)
+		return
+	}
+
+	syncURL, err := url.JoinPath(onCallPluginSettings.OnCallAPIURL, "api/internal/v1/plugin/v2/sync")
+	if err != nil {
+		log.DefaultLogger.Error("Error joining path: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	parsedSyncURL, err := url.Parse(syncURL)
+	if err != nil {
+		log.DefaultLogger.Error("Error parsing path: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	syncReq, err := http.NewRequest("POST", parsedSyncURL.String(), bytes.NewBuffer(onCallSyncJsonData))
+	if err != nil {
+		log.DefaultLogger.Error("Error creating request: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	syncReq.Header.Set("Content-Type", "application/json")
+
+	res, err := a.httpClient.Do(syncReq)
+	if err != nil {
+		log.DefaultLogger.Error("Error request to oncall: ", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer res.Body.Close()
+
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
- Implement organization sync on install
- Expose sync endpoint to post org data from backend plugin
  (sync can be manually triggered by
   `curl http://oncall:oncall@localhost:3000/api/plugins/grafana-oncall-app/resources/plugin/sync`)
- Setup OnCall user if missing on first plugin interaction
- Reworked previous existing sync logic to use the updated one (atm periodic sync tasks are still running)