### PR TITLE
Rework alert group search filter query

### DIFF
--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -67,8 +67,8 @@ class AlertGroupFilter(DateRangeFilterMixin, ModelFieldFilterMixin, filters.Filt
 
     FILTER_BY_INVOLVED_USERS_ALERT_GROUPS_CUTOFF = 1000
 
-    is_root = filters.BooleanFilter(field_name="root_alert_group", lookup_expr="isnull")
     status = filters.MultipleChoiceFilter(choices=AlertGroup.STATUS_CHOICES, method="filter_status")
+    is_root = filters.BooleanFilter(field_name="root_alert_group", lookup_expr="isnull")
     started_at = filters.CharFilter(
         field_name="started_at",
         method=DateRangeFilterMixin.filter_date_range.__name__,
@@ -230,7 +230,7 @@ class AlertGroupTeamFilteringMixin(TeamFilteringMixin):
 
 
 class AlertGroupSearchFilter(SearchFilter):
-    SEARCH_CUTOFF_DAYS = 30
+    SEARCH_CUTOFF_DAYS = 365
 
     def filter_queryset(self, request, queryset, view):
         search_fields = self.get_search_fields(view, request)
@@ -292,7 +292,7 @@ class AlertGroupView(
 
     pagination_class = AlertGroupCursorPaginator
 
-    filter_backends = [AlertGroupSearchFilter, filters.DjangoFilterBackend]
+    filter_backends = [filters.DjangoFilterBackend, AlertGroupSearchFilter]
     search_fields = ["=public_primary_key", "=inside_organization_number", "web_title_cache"]
     filterset_class = AlertGroupFilter
 


### PR DESCRIPTION
Reviewing the queries and explains, it seems MySQL optimizer is not choosing the best index for the query (in my tests for the current query it is using the `alerts_alertgroup_root_alert_group_id_f327f122_fk_alerts_al` index).
In MySQL it would be possible to hint (or [force](https://planetscale.com/blog/why-isnt-mysql-using-my-index#forcing-an-index)) to use an index, but there [isn't](https://code.djangoproject.com/ticket/11003) an easy [way](https://django-mysql.readthedocs.io/en/latest/queryset_extensions.html#query-hints) to do it through the Django ORM. Since hinting seems tricky, I have been experimenting with reordering filters to get a set of WHERE conditions so that the `alert_group_list_index` index is preferred (which seems to perform much better for our query purpose).

See (using our own example query)
```
+----+-------------+-------------------+------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+---------+------+----------+----------+---------------------------------------------------------+
| id | select_type | table             | partitions | type  | possible_keys                                                                                                                                                                                        | key                                                         | key_len | ref  | rows     | filtered | Extra                                                   |
+----+-------------+-------------------+------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+---------+------+----------+----------+---------------------------------------------------------+
|  1 | SIMPLE      | alerts_alertgroup | NULL       | range | public_primary_key,alerts_alertgroup_channel_id_channel_filte_2d808f58_uniq,alerts_alertgroup_root_alert_group_id_f327f122_fk_alerts_al,alerts_alertgroup_started_at_85b1dcc7,alert_group_list_index | alerts_alertgroup_root_alert_group_id_f327f122_fk_alerts_al | 9       | NULL | 13003311 |     0.03 | Using index condition; Using where; Backward index scan |
+----+-------------+-------------------+------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------+---------+------+----------+----------+---------------------------------------------------------+
```

vs

```
+----+-------------+-------------------+------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------+------+------+----------+----------------------------------------------------+
| id | select_type | table             | partitions | type  | possible_keys                                                                                                                                                                                        | key                    | key_len | ref  | rows | filtered | Extra                                              |
+----+-------------+-------------------+------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------+------+------+----------+----------------------------------------------------+
|  1 | SIMPLE      | alerts_alertgroup | NULL       | range | public_primary_key,alerts_alertgroup_channel_id_channel_filte_2d808f58_uniq,alerts_alertgroup_root_alert_group_id_f327f122_fk_alerts_al,alerts_alertgroup_started_at_85b1dcc7,alert_group_list_index | alert_group_list_index | 28      | NULL |    4 |    29.76 | Using index condition; Using where; Using filesort |
+----+-------------+-------------------+------------+-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------+---------+------+------+----------+----------------------------------------------------+
```
