### PR TITLE
Sync teams on user creation during first login

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @grafana/grafana-oncall-backend
 /grafana-plugin @grafana/grafana-oncall-frontend
+/grafana-plugin/pkg @grafana/grafana-oncall-backend
 /docs @grafana/docs-gops @grafana/grafana-oncall
 
 # `make docs` procedure is owned by @jdbaldry of @grafana/docs-squad.

--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -175,7 +175,6 @@ class PluginAuthentication(BasePluginAuthentication):
                     permissions=user_data["permissions"] or [],
                     teams=user_data.get("teams", None),
                 )
-                # TODO: should we trigger an async sync at this point?
                 return get_or_create_user(organization, user_sync_data)
             else:
                 logger.debug("Could not get user from grafana request.")

--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -173,7 +173,7 @@ class PluginAuthentication(BasePluginAuthentication):
                     role=user_data["role"],
                     avatar_url=user_data["avatar_url"],
                     permissions=user_data["permissions"] or [],
-                    teams=None,  # TODO: we don't have teams data here
+                    teams=user_data.get("teams", None),
                 )
                 # TODO: should we trigger an async sync at this point?
                 return get_or_create_user(organization, user_sync_data)

--- a/engine/apps/auth_token/tests/test_plugin_auth.py
+++ b/engine/apps/auth_token/tests/test_plugin_auth.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
@@ -75,3 +77,73 @@ def test_plugin_authentication_fail(authorization, instance_context):
 
     with pytest.raises(AuthenticationFailed):
         PluginAuthentication().authenticate(request)
+
+
+@pytest.mark.django_db
+def test_plugin_authentication_gcom_setup_new_user(make_organization):
+    # Setting gcom_token_org_last_time_synced to now, so it doesn't try to sync with gcom
+    organization = make_organization(
+        stack_id=42, org_id=24, gcom_token="123", gcom_token_org_last_time_synced=timezone.now()
+    )
+    assert organization.users.count() == 0
+    # user = make_user(organization=organization, user_id=12)
+
+    # logged in user data available through header
+    user_data = {
+        "id": 12,
+        "name": "Test User",
+        "login": "test_user",
+        "email": "test@test.com",
+        "role": "Admin",
+        "avatar_url": "http://test.com/avatar.png",
+        "permissions": None,
+        "teams": None,
+    }
+
+    headers = {
+        "HTTP_AUTHORIZATION": "gcom:123",
+        "HTTP_X-Instance-Context": '{"stack_id": 42, "org_id": 24}',
+        "HTTP_X-Grafana-Context": '{"UserId": 12}',
+        "HTTP_X-Oncall-User-Context": json.dumps(user_data),
+    }
+    request = APIRequestFactory().get("/", **headers)
+
+    ret_user, ret_token = PluginAuthentication().authenticate(request)
+
+    assert ret_user.user_id == 12
+    assert ret_token.organization == organization
+    assert organization.users.count() == 1
+
+
+@pytest.mark.django_db
+def test_plugin_authentication_self_hosted_setup_new_user(make_organization, make_token_for_organization):
+    # Setting gcom_token_org_last_time_synced to now, so it doesn't try to sync with gcom
+    organization = make_organization(stack_id=42, org_id=24)
+    token, token_string = make_token_for_organization(organization)
+    assert organization.users.count() == 0
+
+    # logged in user data available through header
+    user_data = {
+        "id": 12,
+        "name": "Test User",
+        "login": "test_user",
+        "email": "test@test.com",
+        "role": "Admin",
+        "avatar_url": "http://test.com/avatar.png",
+        "permissions": None,
+        "teams": None,
+    }
+
+    headers = {
+        "HTTP_AUTHORIZATION": token_string,
+        "HTTP_X-Instance-Context": '{"stack_id": 42, "org_id": 24}',
+        "HTTP_X-Grafana-Context": '{"UserId": 12}',
+        "HTTP_X-Oncall-User-Context": json.dumps(user_data),
+    }
+    request = APIRequestFactory().get("/", **headers)
+
+    ret_user, ret_token = PluginAuthentication().authenticate(request)
+
+    assert ret_user.user_id == 12
+    assert ret_token.organization == organization
+    assert organization.users.count() == 1

--- a/engine/apps/grafana_plugin/tests/test_sync_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_sync_v2.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.api.permissions import LegacyAccessControlRole
+
+
+@pytest.mark.django_db
+def test_auth_success(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    client = APIClient()
+
+    auth_headers = make_user_auth_headers(user, token)
+
+    with patch("apps.grafana_plugin.views.sync_v2.SyncV2View.do_sync", return_value=organization) as mock_sync:
+        response = client.post(reverse("grafana-plugin:sync-v2"), format="json", **auth_headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert mock_sync.called
+
+
+@pytest.mark.django_db
+def test_invalid_auth(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    organization, user, token = make_organization_and_user_with_plugin_token(role=LegacyAccessControlRole.EDITOR)
+    client = APIClient()
+
+    auth_headers = make_user_auth_headers(user, "invalid-token")
+
+    with patch("apps.grafana_plugin.views.sync_v2.SyncV2View.do_sync", return_value=organization) as mock_sync:
+        response = client.post(reverse("grafana-plugin:sync-v2"), format="json", **auth_headers)
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert not mock_sync.called
+
+    auth_headers = make_user_auth_headers(user, token)
+    with patch("apps.grafana_plugin.views.sync_v2.SyncV2View.do_sync", return_value=organization) as mock_sync:
+        response = client.post(reverse("grafana-plugin:sync-v2"), format="json", **auth_headers)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert not mock_sync.called

--- a/engine/apps/grafana_plugin/views/install_v2.py
+++ b/engine/apps/grafana_plugin/views/install_v2.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 
 
 class InstallV2View(SyncV2View):
+    authentication_classes = ()
+    permission_classes = ()
+
     def post(self, request: Request) -> Response:
         if settings.LICENSE != settings.OPEN_SOURCE_LICENSE_NAME:
             return Response(data=SELF_HOSTED_ONLY_FEATURE_ERROR, status=status.HTTP_403_FORBIDDEN)

--- a/engine/apps/grafana_plugin/views/sync_v2.py
+++ b/engine/apps/grafana_plugin/views/sync_v2.py
@@ -36,9 +36,14 @@ class SyncV2View(APIView):
 
         sync_data = serializer.save()
 
-        settings_stack_id = settings.SELF_HOSTED_SETTINGS["STACK_ID"]
-        settings_org_id = settings.SELF_HOSTED_SETTINGS["ORG_ID"]
-        if sync_data.settings.org_id != settings_org_id or sync_data.settings.stack_id != settings_stack_id:
+        if settings.LICENSE == settings.OPEN_SOURCE_LICENSE_NAME:
+            stack_id = settings.SELF_HOSTED_SETTINGS["STACK_ID"]
+            org_id = settings.SELF_HOSTED_SETTINGS["ORG_ID"]
+        else:
+            org_id = request.auth.organization
+            stack_id = request.auth.organization.stack_id
+
+        if sync_data.settings.org_id != org_id or sync_data.settings.stack_id != stack_id:
             raise SyncException(INVALID_SELF_HOSTED_ID)
 
         organization = get_or_create_organization(sync_data.settings.org_id, sync_data.settings.stack_id, sync_data)

--- a/engine/apps/grafana_plugin/views/sync_v2.py
+++ b/engine/apps/grafana_plugin/views/sync_v2.py
@@ -2,10 +2,13 @@ import logging
 
 from django.conf import settings
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.api.permissions import RBACPermission
+from apps.auth_token.auth import PluginAuthentication
 from apps.grafana_plugin.serializers.sync_data import SyncDataSerializer
 from apps.user_management.models import Organization
 from apps.user_management.sync import apply_sync_data, get_or_create_organization
@@ -20,6 +23,12 @@ class SyncException(Exception):
 
 
 class SyncV2View(APIView):
+    authentication_classes = (PluginAuthentication,)
+    permission_classes = [IsAuthenticated, RBACPermission]
+    rbac_permissions = {
+        "post": [RBACPermission.Permissions.USER_SETTINGS_ADMIN],
+    }
+
     def do_sync(self, request: Request) -> Organization:
         serializer = SyncDataSerializer(data=request.data)
         if not serializer.is_valid():

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -298,6 +298,8 @@ def _sync_organization_data(organization: Organization, sync_settings: SyncSetti
     organization.is_grafana_labels_enabled = sync_settings.labels_enabled
     organization.is_grafana_incident_enabled = sync_settings.incident_enabled
     organization.grafana_incident_backend_url = sync_settings.incident_backend_url
+    organization.grafana_url = sync_settings.grafana_url
+    organization.api_token = sync_settings.grafana_token
     organization.last_time_synced = timezone.now()
 
     _sync_instance_info(organization)
@@ -313,6 +315,7 @@ def _sync_organization_data(organization: Organization, sync_settings: SyncSetti
 
     organization.save(
         update_fields=[
+            "api_token",
             "cluster_slug",
             "stack_slug",
             "org_slug",

--- a/engine/apps/user_management/sync.py
+++ b/engine/apps/user_management/sync.py
@@ -4,13 +4,11 @@ import uuid
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from django.db import transaction
 from django.utils import timezone
 
 from apps.alerts.models import AlertReceiveChannel
 from apps.api.permissions import LegacyAccessControlRole
 from apps.auth_token.exceptions import InvalidToken
-from apps.base.models import UserNotificationPolicy
 from apps.grafana_plugin.helpers.client import GcomAPIClient, GCOMInstanceInfo, GrafanaAPIClient
 from apps.grafana_plugin.sync_data import SyncData, SyncPermission, SyncSettings, SyncTeam, SyncUser
 from apps.metrics_exporter.helpers import metrics_bulk_update_team_label_cache
@@ -348,32 +346,25 @@ def _sync_users_data(organization: Organization, sync_users: list[SyncUser], del
     )
 
     existing_user_ids = set(organization.users.all().values_list("user_id", flat=True))
-    with transaction.atomic():
-        kwargs = {}
-        if settings.DATABASE_TYPE in ("sqlite3", "postgresql"):
-            # unique_fields is required for sqlite and postgresql setups
-            kwargs["unique_fields"] = ("organization_id", "user_id", "is_active")
-        organization.users.bulk_create(
-            users_to_sync,
-            update_conflicts=True,
-            update_fields=("email", "name", "username", "role", "avatar_url", "permissions"),
-            batch_size=5000,
-            **kwargs,
-        )
+    kwargs = {}
+    if settings.DATABASE_TYPE in ("sqlite3", "postgresql"):
+        # unique_fields is required for sqlite and postgresql setups
+        kwargs["unique_fields"] = ("organization_id", "user_id", "is_active")
+    organization.users.bulk_create(
+        users_to_sync,
+        update_conflicts=True,
+        update_fields=("email", "name", "username", "role", "avatar_url", "permissions"),
+        batch_size=5000,
+        **kwargs,
+    )
 
-        # Retrieve primary keys for the newly created users
-        #
-        # If the model’s primary key is an AutoField, the primary key attribute can only be retrieved
-        # on certain databases (currently PostgreSQL, MariaDB 10.5+, and SQLite 3.35+).
-        # On other databases, it will not be set.
-        # https://docs.djangoproject.com/en/4.1/ref/models/querysets/#django.db.models.query.QuerySet.bulk_create
-        created_users = organization.users.exclude(user_id__in=existing_user_ids)
-
-        policies_to_create = ()
-        for user in created_users:
-            policies_to_create = policies_to_create + user.default_notification_policies_defaults
-            policies_to_create = policies_to_create + user.important_notification_policies_defaults
-        UserNotificationPolicy.objects.bulk_create(policies_to_create, ignore_conflicts=True, batch_size=5000)
+    # Retrieve primary keys for the newly created users
+    #
+    # If the model’s primary key is an AutoField, the primary key attribute can only be retrieved
+    # on certain databases (currently PostgreSQL, MariaDB 10.5+, and SQLite 3.35+).
+    # On other databases, it will not be set.
+    # https://docs.djangoproject.com/en/4.1/ref/models/querysets/#django.db.models.query.QuerySet.bulk_create
+    created_users = organization.users.exclude(user_id__in=existing_user_ids)
 
     if delete_extra:
         # delete removed users

--- a/grafana-plugin/pkg/plugin/proxy.go
+++ b/grafana-plugin/pkg/plugin/proxy.go
@@ -91,7 +91,7 @@ func SetOnCallUserHeader(onCallUser *OnCallUser, req *http.Request) error {
 
 func (a *App) SetupRequestHeadersForOnCall(ctx context.Context, settings *OnCallPluginSettings, req *http.Request) error {
 	user := httpadapter.UserFromContext(ctx)
-	onCallUser, err := a.GetUser(settings, user)
+	onCallUser, err := a.GetUserForHeader(settings, user)
 	if err != nil {
 		log.DefaultLogger.Error("Error getting user: %v", err)
 		return err

--- a/grafana-plugin/pkg/plugin/sync.go
+++ b/grafana-plugin/pkg/plugin/sync.go
@@ -49,6 +49,13 @@ func (a *App) handleSync(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	err = a.SetupRequestHeadersForOnCall(req.Context(), onCallPluginSettings, syncReq)
+	if err != nil {
+		log.DefaultLogger.Error("Error setting up headers: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	syncReq.Header.Set("Content-Type", "application/json")
 
 	res, err := a.httpClient.Do(syncReq)


### PR DESCRIPTION
Include teams membership details in user header (allowing teams setup during first login user creation).
Add authentication bits for sync endpoint.