### PR TITLE
 Tweak chatops-proxy sync

### DIFF
--- a/engine/apps/chatops_proxy/tasks.py
+++ b/engine/apps/chatops_proxy/tasks.py
@@ -152,7 +152,7 @@ def start_sync_org_with_chatops_proxy():
     organization_qs = Organization.objects.all()
     organization_pks = organization_qs.values_list("pk", flat=True)
 
-    max_countdown = 60 * 30  # 30 minutes, feel free to adjust
+    max_countdown = 12 * 60 * 60  # 12 hours, feel free to adjust
     for idx, organization_pk in enumerate(organization_pks):
         countdown = idx % max_countdown
         sync_org_with_chatops_proxy.apply_async(kwargs={"org_id": organization_pk}, countdown=countdown)

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -91,8 +91,6 @@ CELERY_TASK_ROUTES = {
     "apps.chatops_proxy.tasks.unlink_slack_team_async": {"queue": "default"},
     "apps.chatops_proxy.tasks.register_oncall_tenant_async": {"queue": "default"},
     "apps.chatops_proxy.tasks.unregister_oncall_tenant_async": {"queue": "default"},
-    "apps.chatops_proxy.tasks.start_sync_org_with_chatops_proxy": {"queue": "default"},
-    "apps.chatops_proxy.tasks.sync_org_with_chatops_proxy": {"queue": "default"},
     # CRITICAL
     "apps.alerts.tasks.acknowledge_reminder.acknowledge_reminder_task": {"queue": "critical"},
     "apps.alerts.tasks.acknowledge_reminder.unacknowledge_timeout_task": {"queue": "critical"},
@@ -141,6 +139,8 @@ CELERY_TASK_ROUTES = {
     "apps.alerts.tasks.check_escalation_finished.check_escalation_finished_task": {"queue": "long"},
     "apps.alerts.tasks.check_escalation_finished.check_alert_group_personal_notifications_task": {"queue": "long"},
     "apps.alerts.tasks.check_escalation_finished.check_personal_notifications_task": {"queue": "long"},
+    "apps.chatops_proxy.tasks.start_sync_org_with_chatops_proxy": {"queue": "long"},
+    "apps.chatops_proxy.tasks.sync_org_with_chatops_proxy": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.cleanup_organization_async": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.cleanup_empty_deleted_integrations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_cleanup_organizations": {"queue": "long"},


### PR DESCRIPTION
# What this PR does

Fix for https://raintank-corp.slack.com/archives/C04JCU51NF8/p1719452618841629.
* Move chatops-proxy sync tasks to the long queue
* Batch tasks slower (12 hours instead of 30 minutes)

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
