### PR TITLE
patch default user notification policy changes

### DIFF
--- a/engine/apps/base/models/user_notification_policy.py
+++ b/engine/apps/base/models/user_notification_policy.py
@@ -129,6 +129,19 @@ class UserNotificationPolicy(OrderedModel):
 
         return default, important
 
+    @staticmethod
+    def get_default_fallback_policy(user: User) -> "UserNotificationPolicy":
+        return UserNotificationPolicy(
+            user=user,
+            step=UserNotificationPolicy.Step.NOTIFY,
+            notify_by=settings.EMAIL_BACKEND_INTERNAL_ID,
+            # The important flag doesn't really matter here.. since we're just using this as a transient/fallacbk
+            # in-memory object (important is really only used for allowing users to group their
+            # notification policy steps)
+            important=False,
+            order=0,
+        )
+
     @property
     def short_verbal(self) -> str:
         if self.step == UserNotificationPolicy.Step.NOTIFY:

--- a/engine/apps/email/backend.py
+++ b/engine/apps/email/backend.py
@@ -1,5 +1,12 @@
+import typing
+
 from apps.base.messaging import BaseMessagingBackend
 from apps.email.tasks import notify_user_async
+
+if typing.TYPE_CHECKING:
+    from apps.alerts.models import AlertGroup
+    from apps.base.models import UserNotificationPolicy
+    from apps.user_management.models import User
 
 
 class EmailBackend(BaseMessagingBackend):
@@ -11,10 +18,17 @@ class EmailBackend(BaseMessagingBackend):
     templater = "apps.email.alert_rendering.AlertEmailTemplater"
     template_fields = ("title", "message")
 
-    def serialize_user(self, user):
+    def serialize_user(self, user: "User"):
         return {"email": user.email}
 
-    def notify_user(self, user, alert_group, notification_policy):
+    def notify_user(self, user: "User", alert_group: "AlertGroup",
+                    notification_policy: typing.Optional["UserNotificationPolicy"]):
+        """
+        NOTE: `notification_policy` may be None if the user has no notification policies defined, as
+        email is the default backend used
+        """
         notify_user_async.delay(
-            user_pk=user.pk, alert_group_pk=alert_group.pk, notification_policy_pk=notification_policy.pk
+            user_pk=user.pk,
+            alert_group_pk=alert_group.pk,
+            notification_policy_pk=notification_policy.pk if notification_policy else None,
         )

--- a/engine/apps/email/tasks.py
+++ b/engine/apps/email/tasks.py
@@ -43,15 +43,26 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
         logger.warning(f"Alert group {alert_group_pk} does not exist")
         return
 
-    try:
-        notification_policy = UserNotificationPolicy.objects.get(pk=notification_policy_pk)
-    except UserNotificationPolicy.DoesNotExist:
-        logger.warning(f"User notification policy {notification_policy_pk} does not exist")
-        return
+    using_fallback_default_notification_policy_step = False
+
+    if notification_policy_pk is None:
+        # NOTE: `notification_policy_pk` may be None if the user has no notification policies defined, as
+        # email is the default backend used. see `UserNotificationPolicy.get_default_fallback_policy` for more details
+        notification_policy = UserNotificationPolicy.get_default_fallback_policy(user)
+        using_fallback_default_notification_policy_step = True
+    else:
+        try:
+            notification_policy = UserNotificationPolicy.objects.get(pk=notification_policy_pk)
+        except UserNotificationPolicy.DoesNotExist:
+            logger.warning(f"User notification policy {notification_policy_pk} does not exist")
+            return
+
+    def _create_user_notification_policy_log_record(**kwargs):
+        return UserNotificationPolicyLogRecord.objects.create(**kwargs, using_fallback_default_notification_policy_step=using_fallback_default_notification_policy_step)
 
     # create an error log in case EMAIL_HOST is not specified
     if not live_settings.EMAIL_HOST:
-        UserNotificationPolicyLogRecord.objects.create(
+        _create_user_notification_policy_log_record(
             author=user,
             type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED,
             notification_policy=notification_policy,
@@ -65,7 +76,7 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
 
     emails_left = user.organization.emails_left(user)
     if emails_left <= 0:
-        UserNotificationPolicyLogRecord.objects.create(
+        _create_user_notification_policy_log_record(
             author=user,
             type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED,
             notification_policy=notification_policy,

--- a/grafana-plugin/e2e-tests/utils/userSettings.ts
+++ b/grafana-plugin/e2e-tests/utils/userSettings.ts
@@ -49,14 +49,15 @@ export const verifyUserPhoneNumber = async (page: Page): Promise<void> => {
   await closeModal(page);
 };
 
+const getDefaultNotificationSettingsSectionByTestId = (page: Page): Locator =>
+  page.getByTestId('default-personal-notification-settings');
+
 /**
  * gets the first row of our default notification settings
  * and then gets the notification type dropdown
  */
 const getFirstDefaultNotificationSettingTypeDropdown = async (page: Page): Promise<Locator> => {
-  const firstDefaultNotificationSettingRow = page
-    .getByTestId('default-personal-notification-settings')
-    .locator('li >> nth=0');
+  const firstDefaultNotificationSettingRow = getDefaultNotificationSettingsSectionByTestId(page).locator('li >> nth=0');
 
   // get the notification type dropdown specifically
   return firstDefaultNotificationSettingRow.locator('div[class*="input-wrapper"] >> nth=1');
@@ -66,7 +67,19 @@ export const configureUserNotificationSettings = async (page: Page, notifyBy: No
   // open the user settings modal
   await openUserSettingsModal(page);
 
-  // select our notification type
+  // select our notification type, first check if we have any already defined, if so, click the
+  // "Add Notification Step" button
+  const defaultNotificationSettingsSection = getDefaultNotificationSettingsSectionByTestId(page);
+  const addNotificationStepText = 'Add Notification Step';
+
+  if (!(await defaultNotificationSettingsSection.locator(`button >> text=${addNotificationStepText}`).isVisible())) {
+    await clickButton({
+      page,
+      buttonText: addNotificationStepText,
+      startingLocator: defaultNotificationSettingsSection,
+    });
+  }
+
   const firstDefaultNotificationTypeDropdopdown = await getFirstDefaultNotificationSettingTypeDropdown(page);
   await selectDropdownValue({
     page,


### PR DESCRIPTION
# What this PR does

This is a follow-up PR to https://github.com/grafana/oncall/pull/4628. As @Ferril pointed out, there was a slight issue in `apps.alerts.tasks.notify_user.perform_notification` method when using a "fallback"/default user notification policy. This is because the `log_record_pk` arg passed into `perform_notification` will fetch the `UserNotificationPolicyLogRecord` object, but that object will have a `notification_policy` set to `None` (because there's no persistent `UserNotificationPolicy` object to refer to).

Instead we now pass in a second argument to `perform_notification`, `use_default_notification_policy_fallback`. If this is true, simply grab the transient/in-memory `UserNotificationPolicy` and use that inside of this task

Related to https://github.com/grafana/oncall/issues/4410

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
