### PR TITLE
Fix monthly masked rotation bug

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -351,19 +351,15 @@ export const RotationForm = observer((props: RotationFormProps) => {
     setRotationStart(value);
     setShiftStart(value);
 
-    setShiftEnd(
-      isLimitShiftEnabled
-        ? dayJSAddWithDSTFixed({
-            baseDate: value,
-            addParams: [activePeriod, 'seconds'],
-          })
-        : isMaskedByWeekdays
-        ? dayJSAddWithDSTFixed({ baseDate: value, addParams: [24, 'hours'] })
-        : dayJSAddWithDSTFixed({
-            baseDate: value,
-            addParams: [recurrenceNum, repeatEveryPeriodToUnitName[recurrencePeriod]],
-          })
-    );
+    let addParams;
+    if (isLimitShiftEnabled) {
+      addParams = [activePeriod, 'seconds'];
+    } else if (isMaskedByWeekdays) {
+      addParams = [24, 'hours'];
+    } else {
+      addParams = [recurrenceNum, repeatEveryPeriodToUnitName[recurrencePeriod]];
+    }
+    setShiftEnd(dayJSAddWithDSTFixed({ baseDate: value, addParams }));
   };
 
   const handleActivePeriodChange = useCallback(

--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -357,6 +357,8 @@ export const RotationForm = observer((props: RotationFormProps) => {
             baseDate: value,
             addParams: [activePeriod, 'seconds'],
           })
+        : isMaskedByWeekdays
+        ? dayJSAddWithDSTFixed({ baseDate: value, addParams: [24, 'hours'] })
         : dayJSAddWithDSTFixed({
             baseDate: value,
             addParams: [recurrenceNum, repeatEveryPeriodToUnitName[recurrencePeriod]],
@@ -422,7 +424,7 @@ export const RotationForm = observer((props: RotationFormProps) => {
       setIsLimitShiftEnabled(value);
 
       if (!value) {
-        if (isMaskedByWeekdays && shiftEnd.diff(shiftStart, 'hours') > 24) {
+        if (isMaskedByWeekdays) {
           setShiftEnd(
             dayJSAddWithDSTFixed({
               baseDate: shiftStart,
@@ -477,7 +479,9 @@ export const RotationForm = observer((props: RotationFormProps) => {
 
       const isMonthlyRecurrence = shift.frequency === RepeatEveryPeriod.MONTHS;
       const activeOnSelectedPartOfDay =
-        repeatEveryInSeconds(shift.frequency, shift.interval) !== shiftEnd.diff(shiftStart, 'seconds') &&
+        ((!isMaskedByWeekdays &&
+          repeatEveryInSeconds(shift.frequency, shift.interval) !== shiftEnd.diff(shiftStart, 'seconds')) ||
+          (isMaskedByWeekdays && shiftEnd.diff(shiftStart, 'hour') < 24)) &&
         // Disallow for Monthly view, except if it's masked by week days
         (!isMonthlyRecurrence || (isMonthlyRecurrence && isMaskedByWeekdays));
 


### PR DESCRIPTION
# What this PR does

Fixes a bug when changing the start date of a monthly masked rotation breaks the rotation.

## Which issue(s) this PR closes

Related to https://github.com/grafana/support-escalations/issues/11374

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
