### PR TITLE
Don't consider email message limit exceeded notification failure

### DIFF
--- a/engine/apps/email/tasks.py
+++ b/engine/apps/email/tasks.py
@@ -80,7 +80,7 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
     if emails_left <= 0:
         _create_user_notification_policy_log_record(
             author=user,
-            type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED,
+            type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FINISHED,
             notification_policy=notification_policy,
             alert_group=alert_group,
             reason="Error while sending email",

--- a/engine/apps/email/tests/test_notify_user.py
+++ b/engine/apps/email/tests/test_notify_user.py
@@ -157,7 +157,7 @@ def test_notify_user_no_emails_left(
 
     assert len(mail.outbox) == 0
     log_record = notification_policy.personal_log_records.last()
-    assert log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FAILED
+    assert log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_FINISHED
     assert log_record.notification_error_code == UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_MAIL_LIMIT_EXCEEDED
 
 


### PR DESCRIPTION
# What this PR does
If an email message notification exceeds the limit and does not get sent it is expected and can be treated like other rate-limit violations, although the notification does not happen it is behaving as expected.  This change is to reduce some noise in the notification failure alerts.

An alternative would be to ignore this specific condition in the queries for `check_alert_group_personal_notifications_task` but this seemed more straight forward.

## Which issue(s) this PR closes

Closes [issue link here]

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
