### PR TITLE
run `mage buildAll || true` when building the plugin 

### DIFF
--- a/.github/actions/build-sign-and-package-plugin/action.yml
+++ b/.github/actions/build-sign-and-package-plugin/action.yml
@@ -42,7 +42,7 @@ runs:
       run: |
         jq --arg v "${{ inputs.plugin_version_number }}" '.version=$v' package.json > package.new && mv package.new package.json && jq '.version' package.json;
         yarn build
-        mage buildAll
+        mage buildAll || true
         yarn sign
         if [ ! -f dist/MANIFEST.txt ]; then echo "Sign failed, MANIFEST.txt not created, aborting." && exit 1; fi
         mv dist grafana-oncall-app

--- a/.github/actions/build-sign-and-package-plugin/action.yml
+++ b/.github/actions/build-sign-and-package-plugin/action.yml
@@ -27,6 +27,13 @@ runs:
       # yamllint disable rule:line-length
       run: |
         echo filename="grafana-oncall${{ inputs.is_enterprise == 'true' && '-ee' || '' }}-app-${{ inputs.plugin_version_number }}.zip" >> $GITHUB_OUTPUT
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: "1.21.5"
+    - name: Install Mage
+      shell: bash
+      run: go install github.com/magefile/mage@v1.15.0
     - name: Build, sign, and package plugin
       shell: bash
       working-directory: ${{ inputs.working_directory }}
@@ -35,6 +42,7 @@ runs:
       run: |
         jq --arg v "${{ inputs.plugin_version_number }}" '.version=$v' package.json > package.new && mv package.new package.json && jq '.version' package.json;
         yarn build
+        mage buildAll
         yarn sign
         if [ ! -f dist/MANIFEST.txt ]; then echo "Sign failed, MANIFEST.txt not created, aborting." && exit 1; fi
         mv dist grafana-oncall-app

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -40,7 +40,11 @@ jobs:
         run: go install github.com/magefile/mage@v1.15.0
       - name: Build, lint and test frontend
         working-directory: grafana-plugin
-        run: mage buildAll && yarn lint && yarn test && yarn build
+        run: |
+          mage buildAll || true
+          yarn lint
+          yarn test
+          yarn build
 
   test-technical-documentation:
     name: "Test technical documentation"

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -32,9 +32,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Install frontend dependencies
         uses: ./.github/actions/install-frontend-dependencies
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.5"
+      - name: Install Mage
+        run: go install github.com/magefile/mage@v1.15.0
       - name: Build, lint and test frontend
         working-directory: grafana-plugin
-        run: yarn lint && yarn test && yarn build
+        run: mage buildAll && yarn lint && yarn test && yarn build
 
   test-technical-documentation:
     name: "Test technical documentation"

--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -32,19 +32,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install frontend dependencies
         uses: ./.github/actions/install-frontend-dependencies
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.21.5"
-      - name: Install Mage
-        run: go install github.com/magefile/mage@v1.15.0
       - name: Build, lint and test frontend
         working-directory: grafana-plugin
-        run: |
-          mage buildAll || true
-          yarn lint
-          yarn test
-          yarn build
+        run: yarn lint && yarn test && yarn build
 
   test-technical-documentation:
     name: "Test technical documentation"


### PR DESCRIPTION
# What this PR does

`oncall-private` is using [actions/build-sign-and-package-plugin/action.yml](https://github.com/grafana/oncall/pull/4658/files#diff-6200ac63c387869ca55bc34d1b343a96c667daef428602f910d696836cb09f84) from the dev branch of this repo when doing the deployment. In order to deploy new OnCall initialization which has Go backend component, we need this action to install Go, Mage and do the `mage buildAll`. For other branches where there are no Go files yet, it would just swallow the error thanks to the `|| true` part

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
