### PR TITLE
duplicate health endpoint into internal api

### DIFF
--- a/engine/engine/urls.py
+++ b/engine/engine/urls.py
@@ -23,6 +23,7 @@ from .views import HealthCheckView, MaintenanceModeStatusView, ReadinessCheckVie
 paths_to_work_even_when_maintenance_mode_is_active: list[URLPattern | URLResolver] = [
     path("", HealthCheckView.as_view()),
     path("health/", HealthCheckView.as_view()),
+    path("api/internal/v1/health/", HealthCheckView.as_view()),
     path("ready/", ReadinessCheckView.as_view()),
     path("startupprobe/", StartupProbeView.as_view()),
     path("api/internal/v1/maintenance-mode-status", MaintenanceModeStatusView.as_view()),

--- a/grafana-plugin/pkg/plugin/app.go
+++ b/grafana-plugin/pkg/plugin/app.go
@@ -71,7 +71,7 @@ func (a *App) CheckHealth(_ context.Context, _ *backend.CheckHealthRequest) (*ba
 
 // Check OnCallApi health
 func (a *App) CheckOnCallApiHealthStatus(onCallPluginSettings *OnCallPluginSettings) (int, error) {
-	healthURL, err := url.JoinPath(onCallPluginSettings.OnCallAPIURL, "/health/")
+	healthURL, err := url.JoinPath(onCallPluginSettings.OnCallAPIURL, "/api/internal/v1/health/")
 	if err != nil {
 		log.DefaultLogger.Error("Error joining path: %v", err)
 		return http.StatusInternalServerError, err


### PR DESCRIPTION
# What this PR does

duplicate health endpoint into internal api + use it in backend plugin oncall api url check

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
