### PR TITLE
Fix changing recurrence for weekday masked shifts

### DIFF
--- a/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
+++ b/grafana-plugin/src/containers/RotationForm/RotationForm.tsx
@@ -337,7 +337,7 @@ export const RotationForm = observer((props: RotationFormProps) => {
     setShiftPeriodDefaultValue(undefined);
     setRecurrenceNum(value);
 
-    if (!isLimitShiftEnabled) {
+    if (!isLimitShiftEnabled && !isMaskedByWeekdays) {
       setShiftEnd(
         dayJSAddWithDSTFixed({
           baseDate: rotationStart,


### PR DESCRIPTION
# What this PR does

Fixes a bug when changing recurrence period for shifts with "Mask by weekdays" setting enabled breaks the schedule.


https://github.com/grafana/oncall/assets/20116910/396359c5-4ba6-47d7-b003-fea9db709bea



## Which issue(s) this PR closes

Related to https://github.com/grafana/support-escalations/issues/11374

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
