### PR TITLE
Make docs clearer for "Notify users one by one" policy

### DIFF
--- a/docs/sources/configure/escalation-chains-and-routes/index.md
+++ b/docs/sources/configure/escalation-chains-and-routes/index.md
@@ -91,7 +91,7 @@ via the method configured in their user profile.
 * `Notify users one by one (round robin)` - notify users sequentially, cycling through users for **different alert groups**.
 Example: if users A, B, and C are in the list, the first alert group notifies A, the second alert group notifies B, and
 the third alert group notifies C. Note: users are sorted alphabetically by their username.
-To notify multiple users within the same alert group until someone acknowledges, instead use `Notify users` policies with
+To notify multiple users **within the same alert group** until someone acknowledges, instead use `Notify users` policies with
 `Wait` policies between them in the escalation chain.
 * `Continue escalation if current time is in range` - continue escalation only if current
 time is in specified range. It will wait for the specfied time to continue escalation.

--- a/docs/sources/configure/escalation-chains-and-routes/index.md
+++ b/docs/sources/configure/escalation-chains-and-routes/index.md
@@ -90,8 +90,8 @@ via the method configured in their user profile.
 * `Trigger outgoing webhook` - trigger an [outgoing webhook].
 * `Notify users one by one (round robin)` - notify users sequentially, cycling through users for **different alert groups**.
 Example: if users A, B, and C are in the list, the first alert group notifies A, the second alert group notifies B, and
-the third alert group notifies C.
-To notify multiple users within the same alert group until someone acknowledges, use `Notify users` policies with
+the third alert group notifies C. Note: users are sorted alphabetically by their username.
+To notify multiple users within the same alert group until someone acknowledges, instead use `Notify users` policies with
 `Wait` policies between them in the escalation chain.
 * `Continue escalation if current time is in range` - continue escalation only if current
 time is in specified range. It will wait for the specfied time to continue escalation.

--- a/docs/sources/configure/escalation-chains-and-routes/index.md
+++ b/docs/sources/configure/escalation-chains-and-routes/index.md
@@ -88,8 +88,11 @@ via the method configured in their user profile.
 * `Notify Slack User Group` - send a notification to each member of a slack user group. These users will be notified
 via the method configured in their user profile.
 * `Trigger outgoing webhook` - trigger an [outgoing webhook].
-* `Notify users one by one (round robin)` - each notification will be sent to a group of
-users one by one, in sequential order in [round robin fashion](https://en.wikipedia.org/wiki/Round-robin_item_allocation).
+* `Notify users one by one (round robin)` - notify users sequentially, cycling through users for **different alert groups**.
+Example: if users A, B, and C are in the list, the first alert group notifies A, the second alert group notifies B, and
+the third alert group notifies C.
+To notify multiple users within the same alert group until someone acknowledges, use `Notify users` policies with
+`Wait` policies between them in the escalation chain.
 * `Continue escalation if current time is in range` - continue escalation only if current
 time is in specified range. It will wait for the specfied time to continue escalation.
 Useful when you want to get escalation only during working hours


### PR DESCRIPTION
# What this PR does

Clarifies how the `Notify users one by one (round robin)` escalation policy works.

## Which issue(s) this PR closes

Related to https://github.com/grafana/support-escalations/issues/11449

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
