### PR TITLE
No-op sync when no changes detected + other misc. improvements

### DIFF
--- a/grafana-plugin/go.mod
+++ b/grafana-plugin/go.mod
@@ -57,10 +57,13 @@ require (
 	github.com/prometheus/common v0.53.0 // indirect
 	github.com/prometheus/procfs v0.14.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/unknwon/bra v0.0.0-20200517080246-1e3013ecaff8 // indirect
 	github.com/unknwon/com v1.0.1 // indirect
 	github.com/unknwon/log v0.0.0-20150304194804-e617c87089d3 // indirect
 	github.com/urfave/cli v1.22.15 // indirect
+	github.com/yudai/gojsondiff v1.0.0 // indirect
+	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.51.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.51.0 // indirect

--- a/grafana-plugin/go.sum
+++ b/grafana-plugin/go.sum
@@ -94,8 +94,11 @@ github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGC
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
@@ -150,6 +153,8 @@ github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
+github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304 h1:Jpy1PXuP99tXNrhbq2BaPz9B+jNAvH1JPQQpG/9GCXY=
 github.com/smartystreets/assertions v0.0.0-20190116191733-b6c0e53d7304/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -160,6 +165,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -177,6 +183,10 @@ github.com/unknwon/log v0.0.0-20150304194804-e617c87089d3/go.mod h1:1xEUf2abjfP9
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.15 h1:nuqt+pdC/KqswQKhETJjo7pvn/k4xMUxgW6liI7XpnM=
 github.com/urfave/cli v1.22.15/go.mod h1:wSan1hmo5zeyLGBjRJbzRTNk8gwoYa2B9n4q9dmRIc0=
+github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
+github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
+github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
+github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
@@ -270,6 +280,7 @@ google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDom
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/fsnotify/fsnotify.v1 v1.4.7 h1:XNNYLJHt73EyYiCZi6+xjupS9CpvmiDgjPTAjrBlQbo=

--- a/grafana-plugin/pkg/plugin/debug.go
+++ b/grafana-plugin/pkg/plugin/debug.go
@@ -10,14 +10,14 @@ import (
 func (a *App) handleDebugUser(w http.ResponseWriter, req *http.Request) {
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
-		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		log.DefaultLogger.Error("Error getting settings from context", "error", err)
 		return
 	}
 
 	user := httpadapter.UserFromContext(req.Context())
 	onCallUser, err := a.GetUserForHeader(onCallPluginSettings, user)
 	if err != nil {
-		log.DefaultLogger.Error("Error getting user: ", err)
+		log.DefaultLogger.Error("Error getting user", "error", err)
 		return
 	}
 
@@ -32,13 +32,13 @@ func (a *App) handleDebugUser(w http.ResponseWriter, req *http.Request) {
 func (a *App) handleDebugSync(w http.ResponseWriter, req *http.Request) {
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
-		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		log.DefaultLogger.Error("Error getting settings from context", "error", err)
 		return
 	}
 
 	onCallSync, err := a.GetSyncData(req.Context(), onCallPluginSettings)
 	if err != nil {
-		log.DefaultLogger.Error("Error getting sync data: ", err)
+		log.DefaultLogger.Error("Error getting sync data", "error", err)
 		return
 	}
 
@@ -53,7 +53,7 @@ func (a *App) handleDebugSync(w http.ResponseWriter, req *http.Request) {
 func (a *App) handleDebugSettings(w http.ResponseWriter, req *http.Request) {
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
-		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		log.DefaultLogger.Error("Error getting settings from context", "error", err)
 		return
 	}
 

--- a/grafana-plugin/pkg/plugin/install.go
+++ b/grafana-plugin/pkg/plugin/install.go
@@ -15,50 +15,56 @@ type OnCallInstall struct {
 	OnCallError `json:"onCallError,omitempty"`
 }
 
-// TODO: Lock so that multiple installs do not revoke each others tokens
 func (a *App) handleInstall(w http.ResponseWriter, req *http.Request) {
+	locked := a.installMutex.TryLock()
+	if !locked {
+		http.Error(w, "Install is already in progress", http.StatusBadRequest)
+		return
+	}
+	defer a.installMutex.Unlock()
+
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
-		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		log.DefaultLogger.Error("Error getting settings from context", "error", err)
 		return
 	}
 
 	healthStatus, err := a.CheckOnCallApiHealthStatus(onCallPluginSettings)
 	if err != nil {
-		log.DefaultLogger.Error("Error checking on-call API health: ", err)
+		log.DefaultLogger.Error("Error checking on-call API health", "error", err)
 		http.Error(w, err.Error(), healthStatus)
 		return
 	}
 
 	onCallSync, err := a.GetSyncData(req.Context(), onCallPluginSettings)
 	if err != nil {
-		log.DefaultLogger.Error("Error getting sync data: ", err)
+		log.DefaultLogger.Error("Error getting sync data", "error", err)
 		return
 	}
 
 	onCallSyncJsonData, err := json.Marshal(onCallSync)
 	if err != nil {
-		log.DefaultLogger.Error("Error marshalling JSON: ", err)
+		log.DefaultLogger.Error("Error marshalling JSON", "error", err)
 		return
 	}
 
 	installURL, err := url.JoinPath(onCallPluginSettings.OnCallAPIURL, "api/internal/v1/plugin/v2/install")
 	if err != nil {
-		log.DefaultLogger.Error("Error joining path: %v", err)
+		log.DefaultLogger.Error("Error joining path", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	parsedInstallURL, err := url.Parse(installURL)
 	if err != nil {
-		log.DefaultLogger.Error("Error parsing path: %v", err)
+		log.DefaultLogger.Error("Error parsing path", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	installReq, err := http.NewRequest("POST", parsedInstallURL.String(), bytes.NewBuffer(onCallSyncJsonData))
 	if err != nil {
-		log.DefaultLogger.Error("Error creating request: ", err)
+		log.DefaultLogger.Error("Error creating request", "error", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -66,7 +72,7 @@ func (a *App) handleInstall(w http.ResponseWriter, req *http.Request) {
 
 	res, err := a.httpClient.Do(installReq)
 	if err != nil {
-		log.DefaultLogger.Error("Error request to oncall: ", err)
+		log.DefaultLogger.Error("Error request to oncall", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -88,21 +94,21 @@ func (a *App) handleInstall(w http.ResponseWriter, req *http.Request) {
 	} else {
 		provisionBody, err := io.ReadAll(res.Body)
 		if err != nil {
-			log.DefaultLogger.Error("Error reading response body: ", err)
+			log.DefaultLogger.Error("Error reading response body", "error", err)
 			return
 		}
 
 		var provisioningData OnCallProvisioningJSONData
 		err = json.Unmarshal(provisionBody, &provisioningData)
 		if err != nil {
-			log.DefaultLogger.Error("Error unmarshalling OnCallProvisioningJSONData: ", err)
+			log.DefaultLogger.Error("Error unmarshalling OnCallProvisioningJSONData", "error", err)
 			return
 		}
 
 		onCallPluginSettings.OnCallToken = provisioningData.OnCallToken
 		err = a.SaveOnCallSettings(onCallPluginSettings)
 		if err != nil {
-			log.DefaultLogger.Error("Error saving settings: ", err)
+			log.DefaultLogger.Error("Error saving settings", "error", err)
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/grafana-plugin/pkg/plugin/resources.go
+++ b/grafana-plugin/pkg/plugin/resources.go
@@ -3,7 +3,6 @@ package plugin
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -54,21 +53,18 @@ func (a *App) handleLegacyInstall(w *responseWriter, req *http.Request) {
 	var provisioningData OnCallProvisioningJSONData
 	err := json.Unmarshal(w.body.Bytes(), &provisioningData)
 	if err != nil {
-		log.DefaultLogger.Error("Error unmarshalling OnCallProvisioningJSONData: ", err)
+		log.DefaultLogger.Error("Error unmarshalling OnCallProvisioningJSONData", "error", err)
 		return
 	}
 
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
-		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		log.DefaultLogger.Error("Error getting settings from context", "error", err)
 		return
 	}
 
-	log.DefaultLogger.Info(fmt.Sprintf("Settings = %+v", onCallPluginSettings))
-	log.DefaultLogger.Info(fmt.Sprintf("Provisioning data = %+v", provisioningData))
-
 	if provisioningData.Error != "" {
-		log.DefaultLogger.Error(fmt.Sprintf("Error installing OnCall = %s", provisioningData.Error))
+		log.DefaultLogger.Error("Error installing OnCall", "error", provisioningData.Error)
 		return
 	}
 	onCallPluginSettings.License = provisioningData.License
@@ -78,7 +74,7 @@ func (a *App) handleLegacyInstall(w *responseWriter, req *http.Request) {
 
 	err = a.SaveOnCallSettings(onCallPluginSettings)
 	if err != nil {
-		log.DefaultLogger.Error("Error saving settings: ", err)
+		log.DefaultLogger.Error("Error saving settings", "error", err)
 		return
 	}
 }

--- a/grafana-plugin/pkg/plugin/settings.go
+++ b/grafana-plugin/pkg/plugin/settings.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
@@ -192,6 +193,12 @@ func (a *App) GetOtherPluginSettings(settings *OnCallPluginSettings, pluginID st
 }
 
 func (a *App) GetSyncData(ctx context.Context, settings *OnCallPluginSettings) (*OnCallSync, error) {
+	startGetSyncData := time.Now()
+	defer func() {
+		elapsed := time.Since(startGetSyncData)
+		log.DefaultLogger.Info("GetSyncData", "time", elapsed)
+	}()
+
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting settings from context = %v", err)

--- a/grafana-plugin/pkg/plugin/status.go
+++ b/grafana-plugin/pkg/plugin/status.go
@@ -130,7 +130,7 @@ func (a *App) ValidateGrafanaConnectionFromPlugin(status *OnCallStatus, settings
 func (a *App) ValidateOnCallConnection(ctx context.Context, status *OnCallStatus, settings *OnCallPluginSettings) error {
 	healthStatus, err := a.CheckOnCallApiHealthStatus(settings)
 	if err != nil {
-		log.DefaultLogger.Error("Error checking OnCall API health: ", err)
+		log.DefaultLogger.Error("Error checking OnCall API health", "error", err)
 		status.PluginConnection.OnCallAPIURL = OnCallPluginConnectionEntry{
 			Ok:    false,
 			Error: fmt.Sprintf("Error checking OnCall API health. %v. Status code: %d", err, healthStatus),
@@ -238,14 +238,14 @@ func (a *App) ValidateOnCallStatus(ctx context.Context, settings *OnCallPluginSe
 func (a *App) handleStatus(w http.ResponseWriter, req *http.Request) {
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
-		log.DefaultLogger.Error("Error getting settings from context: ", err)
+		log.DefaultLogger.Error("Error getting settings from context", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	status, err := a.ValidateOnCallStatus(req.Context(), onCallPluginSettings)
 	if err != nil {
-		log.DefaultLogger.Error("Error validating oncall plugin settings: ", err)
+		log.DefaultLogger.Error("Error validating oncall plugin settings", "error", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/grafana-plugin/pkg/plugin/sync.go
+++ b/grafana-plugin/pkg/plugin/sync.go
@@ -7,18 +7,18 @@ import (
 	"errors"
 	"fmt"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/yudai/gojsondiff"
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 )
 
 func (a *App) handleSync(w http.ResponseWriter, req *http.Request) {
 	waitToCompleteParameter := req.URL.Query().Get("wait")
-	var waitToComplete bool
+	var waitToComplete = false
 	var err error
-	if waitToCompleteParameter == "" {
-		waitToComplete = false
-	} else {
+	if waitToCompleteParameter != "" {
 		waitToComplete, err = strconv.ParseBool(waitToCompleteParameter)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
@@ -26,15 +26,25 @@ func (a *App) handleSync(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
+	forceSendParameter := req.URL.Query().Get("force")
+	var forceSend = false
+	if forceSendParameter != "" {
+		forceSend, err = strconv.ParseBool(forceSendParameter)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if waitToComplete {
-		err := a.makeSyncRequest(req.Context())
+		err := a.makeSyncRequest(req.Context(), forceSend)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	} else {
 		go func() {
-			err := a.makeSyncRequest(req.Context())
+			err := a.makeSyncRequest(req.Context(), forceSend)
 			if err != nil {
 				log.DefaultLogger.Error("Error making sync request", "error", err)
 			}
@@ -44,8 +54,46 @@ func (a *App) handleSync(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (a *App) makeSyncRequest(ctx context.Context) error {
-	log.DefaultLogger.Info("Start makeSyncRequest")
+func structToMap(obj interface{}) map[string]interface{} {
+	var mapResult map[string]interface{}
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		log.DefaultLogger.Error("error marshalling json: ", "error", err)
+		return nil
+	}
+	err = json.Unmarshal(jsonBytes, &mapResult)
+	if err != nil {
+		log.DefaultLogger.Error("error unmarshalling json: ", "error", err)
+		return nil
+	}
+	return mapResult
+}
+
+func (a *App) getDifferences(newOnCallSync *OnCallSync) gojsondiff.Diff {
+	if a.lastOnCallSync == nil {
+		log.DefaultLogger.Info("No saved OnCallSync to compare")
+		return nil
+	}
+
+	last := structToMap(a.lastOnCallSync)
+	current := structToMap(newOnCallSync)
+
+	if last == nil || current == nil {
+		log.DefaultLogger.Info(fmt.Sprintf("last or current OnCallSync is nil %v, %v", last, current))
+		return nil
+	}
+
+	differ := gojsondiff.New()
+	return differ.CompareObjects(last, current)
+}
+
+func (a *App) makeSyncRequest(ctx context.Context, forceSend bool) error {
+	startMakeSyncRequest := time.Now()
+	defer func() {
+		elapsed := time.Since(startMakeSyncRequest)
+		log.DefaultLogger.Info("makeSyncRequest", "time", elapsed)
+	}()
+
 	locked := a.syncMutex.TryLock()
 	if !locked {
 		return errors.New("sync already in progress")
@@ -60,6 +108,12 @@ func (a *App) makeSyncRequest(ctx context.Context) error {
 	onCallSync, err := a.GetSyncData(ctx, onCallPluginSettings)
 	if err != nil {
 		return fmt.Errorf("error getting sync data: %v", err)
+	}
+
+	diff := a.getDifferences(onCallSync)
+	if diff != nil && !diff.Modified() && !forceSend {
+		log.DefaultLogger.Info("No changes detected to sync")
+		return nil
 	}
 
 	onCallSyncJsonData, err := json.Marshal(onCallSync)
@@ -94,6 +148,6 @@ func (a *App) makeSyncRequest(ctx context.Context) error {
 	}
 	defer res.Body.Close()
 
-	log.DefaultLogger.Info("Finish makeSyncRequest")
+	a.lastOnCallSync = onCallSync
 	return nil
 }

--- a/grafana-plugin/pkg/plugin/users.go
+++ b/grafana-plugin/pkg/plugin/users.go
@@ -58,7 +58,7 @@ func (a *App) GetUserForHeader(settings *OnCallPluginSettings, user *backend.Use
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// manually created service account with Admin role doesn't have permission to get user teams
 	if settings.ExternalServiceAccountEnabled {
 		onCallUser.Teams, err = a.GetTeamsForUser(settings, onCallUser)
@@ -142,7 +142,7 @@ func (a *App) GetAllUsersWithPermissions(settings *OnCallPluginSettings) ([]OnCa
 					onCallUsers[i].Permissions = append(onCallUsers[i].Permissions, OnCallPermission{Action: action})
 				}
 			} else {
-				log.DefaultLogger.Error(fmt.Sprintf("Did not find permissions for user %s", onCallUsers[i].Login))
+				log.DefaultLogger.Error("Did not find permissions for user", "user", onCallUsers[i].Login)
 			}
 		}
 	}


### PR DESCRIPTION
- Keep track of last sync data sent, if there are no changes don't bother making the request to the engine.  This can be bypassed with the query parameter `force=true`
- Add timing log messages for sync related functions
- Add lock around install
- Make logging messages more consistent