### PR TITLE
Only run cleanup for integrations deleted recently

### DIFF
--- a/engine/apps/grafana_plugin/tasks/sync.py
+++ b/engine/apps/grafana_plugin/tasks/sync.py
@@ -20,7 +20,7 @@ logger.setLevel(logging.DEBUG)
 # to make sure that orgs are synced every 30 minutes, SYNC_PERIOD should be a little lower
 SYNC_PERIOD = timezone.timedelta(minutes=25)
 INACTIVE_PERIOD = timezone.timedelta(minutes=55)
-CLEANUP_PERIOD = timezone.timedelta(hours=12)
+CLEANUP_PERIOD = timezone.timedelta(hours=13)
 
 
 @shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True, max_retries=0)
@@ -168,6 +168,7 @@ def cleanup_empty_deleted_integrations(organization_pk, dry_run=True):
 
 @shared_dedicated_queue_retry_task(autoretry_for=(Exception,), max_retries=0)
 def start_cleanup_organizations():
+    # TODO: Remove next release after tasks revoked
     cleanup_threshold = timezone.now() - INACTIVE_PERIOD
     organization_qs = Organization.objects.filter(last_time_synced__lte=cleanup_threshold)
     organization_pks = organization_qs.values_list("pk", flat=True)
@@ -176,3 +177,15 @@ def start_cleanup_organizations():
     for idx, organization_pk in enumerate(organization_pks):
         countdown = idx % max_countdown  # Spread orgs evenly
         cleanup_organization_async.apply_async((organization_pk,), countdown=countdown)
+
+
+@shared_dedicated_queue_retry_task(autoretry_for=(Exception,), max_retries=0)
+def start_cleanup_deleted_integrations():
+    cleanup_threshold = timezone.now() - CLEANUP_PERIOD
+    channels_qs = AlertReceiveChannel.objects_with_deleted.filter(deleted_at__gte=cleanup_threshold)
+    organization_pks = set(channels_qs.values_list("organization_id", flat=True))
+    logger.debug(f"Found {len(organization_pks)} organizations")
+    for organization_pk in enumerate(organization_pks):
+        cleanup_empty_deleted_integrations.apply_async(
+            (organization_pk, False),
+        )

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -551,8 +551,8 @@ CELERY_BEAT_SCHEDULE = {
         "schedule": crontab(minute="*/30"),
         "args": (),
     },
-    "start_cleanup_organizations": {
-        "task": "apps.grafana_plugin.tasks.sync.start_cleanup_organizations",
+    "start_cleanup_deleted_integrations": {
+        "task": "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_integrations",
         "schedule": crontab(hour="4, 16", minute=35),
         "args": (),
     },

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -144,6 +144,7 @@ CELERY_TASK_ROUTES = {
     "apps.grafana_plugin.tasks.sync.cleanup_organization_async": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.cleanup_empty_deleted_integrations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_cleanup_organizations": {"queue": "long"},
+    "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_integrations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_organizations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_sync_organizations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.sync_organization_async": {"queue": "long"},


### PR DESCRIPTION
# What this PR does
Changes operations to cleanup deleted empty integrations so that they are only performed on organizations that have deleted integrations recently.  The previous task checked everything because we were not performing the cleanup on a regular basis, now that it has been scheduled regularly we can operate on recently deleted integrations instead.

The existing task has been removed from the schedule, the code for it can be removed after the other tasks have cleared.

## Which issue(s) this PR closes

Closes [issue link here]

<!--
*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
