### PR TITLE
Get license and grafanaUrl from environment

### DIFF
--- a/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
+++ b/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
@@ -6,5 +6,5 @@ apps:
       stackId: 5
       orgId: 100
       license: OpenSource
-      onCallApiUrl: $ONCALL_API_URL
-      grafanaUrl: http://grafana:3000
+      onCallApiUrl: http://host.docker.internal:8080
+      grafanaUrl: http://localhost:3000

--- a/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
+++ b/dev/grafana/provisioning/plugins/grafana-oncall-app-provisioning.yaml
@@ -5,6 +5,4 @@ apps:
     jsonData:
       stackId: 5
       orgId: 100
-      license: OpenSource
-      onCallApiUrl: http://host.docker.internal:8080
-      grafanaUrl: http://localhost:3000
+      onCallApiUrl: $ONCALL_API_URL

--- a/grafana-plugin/pkg/plugin/install.go
+++ b/grafana-plugin/pkg/plugin/install.go
@@ -16,6 +16,11 @@ type OnCallInstall struct {
 }
 
 func (a *App) handleInstall(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	locked := a.installMutex.TryLock()
 	if !locked {
 		http.Error(w, "Install is already in progress", http.StatusBadRequest)

--- a/grafana-plugin/pkg/plugin/proxy.go
+++ b/grafana-plugin/pkg/plugin/proxy.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -115,6 +116,9 @@ func (a *App) SetupRequestHeadersForOnCall(ctx context.Context, settings *OnCall
 		log.DefaultLogger.Error("Error setting user header", "error", err)
 		return err
 	}
+
+	pluginContext := httpadapter.PluginConfigFromContext(ctx)
+	req.Header.Set("User-Agent", fmt.Sprintf("GrafanaOnCall/%s", pluginContext.PluginVersion))
 
 	return nil
 }

--- a/grafana-plugin/pkg/plugin/settings.go
+++ b/grafana-plugin/pkg/plugin/settings.go
@@ -79,12 +79,10 @@ func (a *App) OnCallSettingsFromContext(ctx context.Context) (*OnCallPluginSetti
 	if settings.License == "" {
 		cloudRe := regexp.MustCompile(CLOUD_VERSION_PATTERN)
 		ossRe := regexp.MustCompile(OSS_VERSION_PATTERN)
-		if pluginContext.PluginVersion == DEV_PATTERN {
-			return &settings, fmt.Errorf("plugin version is dev-oss license must be set in jsonData.license")
+		if pluginContext.PluginVersion == DEV_PATTERN || ossRe.MatchString(pluginContext.PluginVersion) {
+			settings.License = OPEN_SOURCE_LICENSE_NAME
 		} else if cloudRe.MatchString(pluginContext.PluginVersion) {
 			settings.License = CLOUD_LICENSE_NAME
-		} else if ossRe.MatchString(pluginContext.PluginVersion) {
-			settings.License = OPEN_SOURCE_LICENSE_NAME
 		} else {
 			return &settings, fmt.Errorf("jsonData.license is not set and version %s did not match a known pattern", pluginContext.PluginVersion)
 		}

--- a/grafana-plugin/pkg/plugin/status.go
+++ b/grafana-plugin/pkg/plugin/status.go
@@ -236,6 +236,11 @@ func (a *App) ValidateOnCallStatus(ctx context.Context, settings *OnCallPluginSe
 }
 
 func (a *App) handleStatus(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	onCallPluginSettings, err := a.OnCallSettingsFromContext(req.Context())
 	if err != nil {
 		log.DefaultLogger.Error("Error getting settings from context", "error", err)

--- a/grafana-plugin/pkg/plugin/sync.go
+++ b/grafana-plugin/pkg/plugin/sync.go
@@ -15,6 +15,11 @@ import (
 )
 
 func (a *App) handleSync(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	waitToCompleteParameter := req.URL.Query().Get("wait")
 	var waitToComplete = false
 	var err error

--- a/grafana-plugin/src/models/plugin/plugin.ts
+++ b/grafana-plugin/src/models/plugin/plugin.ts
@@ -53,9 +53,7 @@ export class PluginStore {
 
   @AutoLoadingState(ActionKey.PLUGIN_VERIFY_CONNECTION)
   async verifyPluginConnection() {
-    const { pluginConnection } = await makeRequest<PostStatusResponse>(`/plugin/status`, {
-      method: 'POST',
-    });
+    const { pluginConnection } = await makeRequest<PostStatusResponse>(`/plugin/status`, {});
     runInAction(() => {
       this.connectionStatus = pluginConnection;
       this.isPluginConnected = Object.keys(pluginConnection).every(


### PR DESCRIPTION
- license now determined based on value of version in package.json (vX.Y.Z or dev-oss => OpenSource, rWWW-vX.Y.Z => Cloud). You can still set it in the provisioning data to override
- grafanaUrl is based on GrafanaCfg AppURL if it is not overridden by being set in provisioning data
- Change /status call to GET
- Enforce http method for sync, install and status
- Add custom user agent to identify plugin