### PR TITLE
PR template: "Closes" -> "Related to"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,11 @@
 
 ## Which issue(s) this PR closes
 
-Closes [issue link here]
+Related to [issue link here]
 
 <!--
-*Note*: if you have more than one GitHub issue that this PR closes, be sure to preface
+*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
+If you have more than one GitHub issue that this PR closes, be sure to preface
 each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
 This ensures that the issue(s) are auto-closed once the PR has been merged.
 -->


### PR DESCRIPTION
Make it so that you need to explicitly use the "Closes" keyword when opening PRs (as per [this sprint retro comment](https://miro.com/app/board/uXjVKzhhfgE=/?moveToWidget=3458764594901560846&cot=14))