### PR TITLE
Drop stale metrics cache

### DIFF
--- a/engine/apps/metrics_exporter/metrics_collectors.py
+++ b/engine/apps/metrics_exporter/metrics_collectors.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import typing
 
@@ -28,6 +29,7 @@ from apps.metrics_exporter.tasks import start_calculate_and_cache_metrics, start
 
 application_metrics_registry = CollectorRegistry()
 
+logger = logging.getLogger(__name__)
 
 # _RE_BASE_PATTERN allows for optional curly-brackets around the metric name as in some cases this may occur
 # see common.cache.ensure_cache_key_allocates_to_the_same_hash_slot for more details regarding this
@@ -92,6 +94,10 @@ class ApplicationMetricsCollector:
         )
         for org_key, ag_states in org_ag_states.items():
             for _, integration_data in ag_states.items():
+                if "services" not in integration_data:
+                    logger.warning(f"Deleting stale metrics cache for {org_key}")
+                    cache.delete(org_key)
+                    break
                 # Labels values should have the same order as _integration_labels_with_state
                 labels_values = [
                     integration_data["integration_name"],  # integration
@@ -125,6 +131,10 @@ class ApplicationMetricsCollector:
         )
         for org_key, ag_response_time in org_ag_response_times.items():
             for _, integration_data in ag_response_time.items():
+                if "services" not in integration_data:
+                    logger.warning(f"Deleting stale metrics cache for {org_key}")
+                    cache.delete(org_key)
+                    break
                 # Labels values should have the same order as _integration_labels
                 labels_values = [
                     integration_data["integration_name"],  # integration

--- a/engine/apps/metrics_exporter/tests/conftest.py
+++ b/engine/apps/metrics_exporter/tests/conftest.py
@@ -114,6 +114,60 @@ def mock_cache_get_metrics_for_collector(monkeypatch):
 
 
 @pytest.fixture()
+def mock_cache_get_old_metrics_for_collector(monkeypatch):
+    def _mock_cache_get(key, *args, **kwargs):
+        if ALERT_GROUPS_TOTAL in key:
+            key = ALERT_GROUPS_TOTAL
+        elif ALERT_GROUPS_RESPONSE_TIME in key:
+            key = ALERT_GROUPS_RESPONSE_TIME
+        elif USER_WAS_NOTIFIED_OF_ALERT_GROUPS in key:
+            key = USER_WAS_NOTIFIED_OF_ALERT_GROUPS
+        test_metrics = {
+            ALERT_GROUPS_TOTAL: {
+                1: {
+                    "integration_name": "Test metrics integration",
+                    "team_name": "Test team",
+                    "team_id": 1,
+                    "org_id": 1,
+                    "slug": "Test stack",
+                    "id": 1,
+                    "firing": 2,
+                    "silenced": 4,
+                    "acknowledged": 3,
+                    "resolved": 5,
+                },
+            },
+            ALERT_GROUPS_RESPONSE_TIME: {
+                1: {
+                    "integration_name": "Test metrics integration",
+                    "team_name": "Test team",
+                    "team_id": 1,
+                    "org_id": 1,
+                    "slug": "Test stack",
+                    "id": 1,
+                    "response_time": [2, 10, 200, 650],
+                },
+            },
+            USER_WAS_NOTIFIED_OF_ALERT_GROUPS: {
+                1: {
+                    "org_id": 1,
+                    "slug": "Test stack",
+                    "id": 1,
+                    "user_username": "Alex",
+                    "counter": 4,
+                }
+            },
+        }
+        return test_metrics.get(key)
+
+    def _mock_cache_get_many(keys, *args, **kwargs):
+        return {key: _mock_cache_get(key) for key in keys if _mock_cache_get(key)}
+
+    monkeypatch.setattr(cache, "get", _mock_cache_get)
+    monkeypatch.setattr(cache, "get_many", _mock_cache_get_many)
+
+
+@pytest.fixture()
 def mock_get_metrics_cache(monkeypatch):
     def _mock_cache_get(key, *args, **kwargs):
         return {}


### PR DESCRIPTION
# What this PR does
based on this PR - https://github.com/grafana/oncall/pull/4517

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall/issues/4455

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
