### PR TITLE
Fix `send_bundled_notification` task

### DIFF
--- a/engine/apps/alerts/tasks/notify_user.py
+++ b/engine/apps/alerts/tasks/notify_user.py
@@ -626,6 +626,7 @@ def send_bundled_notification(user_notification_bundle_id: int):
                     schedule_perform_notification_task,
                     log_record_notification_triggered.pk,
                     log_record_notification_triggered.alert_group_id,
+                    False,
                 )
             )
             notifications.delete()


### PR DESCRIPTION
# What this PR does
Fix scheduling `perform_notification` from `send_bundled_notification` task - leftover after resolving merge conflict

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
