### PR TITLE
Update schedule events internal API to return default priority level

### DIFF
--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -1778,7 +1778,7 @@ def test_on_call_shift_preview_without_users(
             "is_override": False,
             "is_empty": True,
             "is_gap": False,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [],
             "source": "web",

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1201,7 +1201,7 @@ def test_filter_events_overrides(
                     }
                 ],
                 "missing_users": [],
-                "priority_level": None,
+                "priority_level": 0,
                 "source": "api",
                 "calendar_type": OnCallSchedule.OVERRIDES,
                 "is_empty": False,
@@ -1307,7 +1307,7 @@ def test_filter_events_final_schedule(
             "end": start_date + timezone.timedelta(hours=start + duration),
             "is_gap": is_gap,
             "is_override": is_override,
-            "priority_level": priority,
+            "priority_level": priority or 0,
             "start": start_date + timezone.timedelta(hours=start),
             "user": user,
         }

--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -412,7 +412,7 @@ class OnCallSchedule(PolymorphicModel):
                     for user in shift["users"]
                 ],
                 "missing_users": shift["missing_users"],
-                "priority_level": shift["priority"] if shift["priority"] != 0 else None,
+                "priority_level": shift["priority"] or 0,
                 "source": shift["source"],
                 "calendar_type": shift["calendar_type"],
                 "is_empty": len(shift["users"]) == 0 and not is_gap,

--- a/engine/apps/schedules/tests/test_on_call_schedule.py
+++ b/engine/apps/schedules/tests/test_on_call_schedule.py
@@ -120,7 +120,7 @@ def test_filter_events(make_organization, make_user_for_organization, make_sched
             "is_override": True,
             "is_empty": False,
             "is_gap": False,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [
                 {
@@ -178,7 +178,7 @@ def test_filter_events_include_gaps(make_organization, make_user_for_organizatio
             "is_override": False,
             "is_empty": False,
             "is_gap": True,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [],
             "shift": {"pk": None},
@@ -213,7 +213,7 @@ def test_filter_events_include_gaps(make_organization, make_user_for_organizatio
             "is_override": False,
             "is_empty": False,
             "is_gap": True,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [],
             "shift": {"pk": None},
@@ -263,7 +263,7 @@ def test_filter_events_include_shift_info(
             "is_override": False,
             "is_empty": False,
             "is_gap": True,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [],
             "shift": {"pk": None},
@@ -302,7 +302,7 @@ def test_filter_events_include_shift_info(
             "is_override": False,
             "is_empty": False,
             "is_gap": True,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [],
             "shift": {"pk": None},
@@ -512,7 +512,7 @@ def test_final_schedule_events(
             "end": start_date + timezone.timedelta(hours=start + duration),
             "is_gap": is_gap,
             "is_override": is_override,
-            "priority_level": priority,
+            "priority_level": priority or 0,
             "start": start_date + timezone.timedelta(hours=start),
             "user": user,
             "shift": (
@@ -599,7 +599,7 @@ def test_final_schedule_override_no_priority_shift(
             "calendar_type": 1 if is_override else 0,
             "end": start_date + timezone.timedelta(hours=start + duration),
             "is_override": is_override,
-            "priority_level": priority,
+            "priority_level": priority or 0,
             "start": start_date + timezone.timedelta(hours=start, milliseconds=1 if start == 0 else 0),
             "user": user,
         }
@@ -679,7 +679,7 @@ def test_final_schedule_override_split(
             "calendar_type": 1 if is_override else 0,
             "end": start_date + timezone.timedelta(hours=start + duration),
             "is_override": is_override,
-            "priority_level": priority,
+            "priority_level": priority or 0,
             "start": start_date + timezone.timedelta(hours=start, milliseconds=1 if start == 0 else 0),
             "user": user,
         }
@@ -1051,7 +1051,7 @@ def test_preview_shift_no_user(make_organization, make_user_for_organization, ma
             "is_override": False,
             "is_empty": True,
             "is_gap": False,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [],
             "shift": {"pk": new_shift.public_primary_key},
@@ -1130,7 +1130,7 @@ def test_preview_override_shift(make_organization, make_user_for_organization, m
             "is_override": True,
             "is_empty": False,
             "is_gap": False,
-            "priority_level": None,
+            "priority_level": 0,
             "missing_users": [],
             "users": [
                 {
@@ -1156,7 +1156,7 @@ def test_preview_override_shift(make_organization, make_user_for_organization, m
     expected_events = [
         {
             "end": start_date + timezone.timedelta(hours=start + duration),
-            "priority_level": priority,
+            "priority_level": priority or 0,
             "start": start_date + timezone.timedelta(hours=start, milliseconds=1 if start == 0 else 0),
             "user": user,
             "is_override": is_override,


### PR DESCRIPTION
No need to change 0 to `None` in priority level when returning schedule events (related to this [thread](https://raintank-corp.slack.com/archives/C0229FD3CE9/p1721239227358309?thread_ts=1721148066.857589&cid=C0229FD3CE9))