### PR TITLE
set default grafana_url if GRAFANA_API_URL set

### DIFF
--- a/engine/apps/grafana_plugin/helpers/client.py
+++ b/engine/apps/grafana_plugin/helpers/client.py
@@ -2,7 +2,7 @@ import json
 import logging
 import time
 import typing
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 from django.conf import settings
@@ -94,7 +94,10 @@ class HttpMethod(typing.Protocol):
 
 class APIClient:
     def __init__(self, api_url: str, api_token: str) -> None:
-        self.api_url = api_url
+        if settings.SELF_HOSTED_SETTINGS["GRAFANA_API_URL"] is not None:
+            self.api_url = settings.SELF_HOSTED_SETTINGS["GRAFANA_API_URL"]
+            if urlparse(self.api_url).path and not self.api_url.endswith('/'):
+                self.api_url += '/'
         self.api_token = api_token
 
     def api_head(self, endpoint: str, body: typing.Optional[typing.Dict] = None, **kwargs) -> APIClientResponse[_RT]:


### PR DESCRIPTION
# Issue Oncall backend calling grafana api when grafana is self hosted and under certain path

fixes errors like:
```
source=engine:app google_trace_id=none logger=apps.grafana_plugin.helpers.client Error connecting to api instance 404 Client Error: Not Found for url: https://test.com/api/access-control/users/permissions/search?actionPrefix=grafana-oncall-app
```
while GRAFANA_API_URL=https://test.com/grafana

relevant for when external self-hosted grafana has same URL, but under different path, like /grafana

Also fixes issue when self.api_url has path, but no '/' in the end
```
if urlparse(self.api_url).path and not self.api_url.endswith('/'):
            self.api_url += '/'
```
because in case of `urljoin(self.api_url, endpoint)`
Example:
`https://test.com/path`, `api/v1` -> will become `https://test.com/api/v1`
`https://test.com/path/`, `api/v1` -> will become `https://test.com/path/api/v1`

