### PR TITLE
Update regex to jinja route conversion to correctly escape double quotes

### DIFF
--- a/engine/apps/api/serializers/channel_filter.py
+++ b/engine/apps/api/serializers/channel_filter.py
@@ -147,7 +147,8 @@ class ChannelFilterSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         elif obj.filtering_term_type == ChannelFilter.FILTERING_TERM_TYPE_REGEX:
             # Four curly braces will result in two curly braces in the final string
             # rf"..." is a raw f string, to keep original filtering_term
-            return rf'{{{{ payload | json_dumps | regex_search("{obj.filtering_term}") }}}}'
+            escaped_quotes = obj.filtering_term.replace('"', '\\"') if obj.filtering_term else ""
+            return rf'{{{{ payload | json_dumps | regex_search("{escaped_quotes}") }}}}'
         elif obj.filtering_labels and obj.filtering_term_type == ChannelFilter.FILTERING_TERM_TYPE_LABELS:
             # required labels
             labels = [

--- a/engine/apps/api/tests/test_channel_filter.py
+++ b/engine/apps/api/tests/test_channel_filter.py
@@ -509,8 +509,10 @@ def test_channel_filter_convert_from_regex_to_jinja2(
 
     make_channel_filter(alert_receive_channel, is_default=True)
 
-    # r"..." used to keep this string as raw string
-    regex_filtering_term = r"\".*\": \"This alert was sent by user for demonstration purposes\""
+    # regex as set by Terraform/API (not a raw string, but a string with escaped characters)
+    # see ChannelFilterSerializer in apps.public_api.serializers.routes.py
+    regex_filtering_term = '".*": "This alert was sent by user for demonstration purposes"'
+    # r"..." to define the expected jinja2 template translation
     final_filtering_term = r'{{ payload | json_dumps | regex_search("\".*\": \"This alert was sent by user for demonstration purposes\"") }}'
     payload = {"description": "This alert was sent by user for demonstration purposes"}
 


### PR DESCRIPTION
Related to this [thread](https://raintank-corp.slack.com/archives/C0229FD3CE9/p1721309907422709).