### PR TITLE
Fix bug for incorrect arguments used to invoke cleanup_empty_deleted_integrations

### DIFF
--- a/engine/apps/grafana_plugin/tasks/sync.py
+++ b/engine/apps/grafana_plugin/tasks/sync.py
@@ -172,7 +172,7 @@ def start_cleanup_deleted_integrations():
     channels_qs = AlertReceiveChannel.objects_with_deleted.filter(deleted_at__gte=cleanup_threshold)
     organization_pks = set(channels_qs.values_list("organization_id", flat=True))
     logger.debug(f"Found {len(organization_pks)} organizations")
-    for idx, organization_pk in enumerate(organization_pks):
+    for _, organization_pk in enumerate(organization_pks):
         cleanup_empty_deleted_integrations.apply_async(
             (organization_pk, False),
         )

--- a/engine/apps/grafana_plugin/tasks/sync.py
+++ b/engine/apps/grafana_plugin/tasks/sync.py
@@ -167,25 +167,12 @@ def cleanup_empty_deleted_integrations(organization_pk, dry_run=True):
 
 
 @shared_dedicated_queue_retry_task(autoretry_for=(Exception,), max_retries=0)
-def start_cleanup_organizations():
-    # TODO: Remove next release after tasks revoked
-    cleanup_threshold = timezone.now() - INACTIVE_PERIOD
-    organization_qs = Organization.objects.filter(last_time_synced__lte=cleanup_threshold)
-    organization_pks = organization_qs.values_list("pk", flat=True)
-    logger.debug(f"Found {len(organization_pks)} organizations")
-    max_countdown = CLEANUP_PERIOD.seconds
-    for idx, organization_pk in enumerate(organization_pks):
-        countdown = idx % max_countdown  # Spread orgs evenly
-        cleanup_organization_async.apply_async((organization_pk,), countdown=countdown)
-
-
-@shared_dedicated_queue_retry_task(autoretry_for=(Exception,), max_retries=0)
 def start_cleanup_deleted_integrations():
     cleanup_threshold = timezone.now() - CLEANUP_PERIOD
     channels_qs = AlertReceiveChannel.objects_with_deleted.filter(deleted_at__gte=cleanup_threshold)
     organization_pks = set(channels_qs.values_list("organization_id", flat=True))
     logger.debug(f"Found {len(organization_pks)} organizations")
-    for organization_pk in enumerate(organization_pks):
+    for idx, organization_pk in enumerate(organization_pks):
         cleanup_empty_deleted_integrations.apply_async(
             (organization_pk, False),
         )

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -145,7 +145,6 @@ CELERY_TASK_ROUTES = {
     "apps.chatops_proxy.tasks.sync_org_with_chatops_proxy": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.cleanup_organization_async": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.cleanup_empty_deleted_integrations": {"queue": "long"},
-    "apps.grafana_plugin.tasks.sync.start_cleanup_organizations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_integrations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_cleanup_deleted_organizations": {"queue": "long"},
     "apps.grafana_plugin.tasks.sync.start_sync_organizations": {"queue": "long"},


### PR DESCRIPTION
# What this PR does
- Fixes a bug where cleanup_empty_deleted_integrations was not being passed the correct arguments
- Removes start_cleanup_organizations now that it is no longer in use

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
