### PR TITLE
Make it clear alert groups can't be searched

### DIFF
--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -747,7 +747,6 @@ class AlertGroupView(
                 "href": api_root + "teams/",
                 "global": True,
             },
-            {"name": "search", "type": "search"},
             {"name": "integration", "type": "options", "href": api_root + "alert_receive_channels/?filters=true"},
             {"name": "escalation_chain", "type": "options", "href": api_root + "escalation_chains/?filters=true"},
             {
@@ -810,6 +809,9 @@ class AlertGroupView(
                 "description": f"This filter works only for last {AlertGroupFilter.FILTER_BY_INVOLVED_USERS_ALERT_GROUPS_CUTOFF} alert groups you're involved in.",
             },
         ]
+
+        if settings.FEATURE_ALERT_GROUP_SEARCH_ENABLED:
+            filter_options = [{"name": "search", "type": "search"}] + filter_options
 
         if is_labels_feature_enabled(self.request.auth.organization):
             filter_options.append(

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -474,6 +474,7 @@ class AlertReceiveChannelView(
         api_root = "/api/internal/v1/"
 
         filter_options = [
+            {"name": "search", "type": "search"},
             {
                 "name": "team",
                 "type": "team_select",

--- a/engine/apps/api/views/escalation_chain.py
+++ b/engine/apps/api/views/escalation_chain.py
@@ -183,7 +183,6 @@ class EscalationChainViewSet(
 
     @action(methods=["get"], detail=False)
     def filters(self, request):
-        filter_name = request.query_params.get("search", None)
         api_root = "/api/internal/v1/"
 
         filter_options = [
@@ -195,8 +194,5 @@ class EscalationChainViewSet(
                 "global": True,
             },
         ]
-
-        if filter_name is not None:
-            filter_options = list(filter(lambda f: filter_name in f["name"], filter_options))
 
         return Response(filter_options)

--- a/engine/apps/api/views/escalation_chain.py
+++ b/engine/apps/api/views/escalation_chain.py
@@ -187,6 +187,7 @@ class EscalationChainViewSet(
         api_root = "/api/internal/v1/"
 
         filter_options = [
+            {"name": "search", "type": "search"},
             {
                 "name": "team",
                 "type": "team_select",

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -581,6 +581,7 @@ class ScheduleView(
         api_root = "/api/internal/v1/"
 
         filter_options = [
+            {"name": "search", "type": "search"},
             {
                 "name": "team",
                 "type": "team_select",

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -577,7 +577,6 @@ class ScheduleView(
 
     @action(methods=["get"], detail=False)
     def filters(self, request):
-        filter_name = request.query_params.get("search", None)
         api_root = "/api/internal/v1/"
 
         filter_options = [
@@ -610,8 +609,5 @@ class ScheduleView(
                 ],
             },
         ]
-
-        if filter_name is not None:
-            filter_options = list(filter(lambda f: filter_name in f["name"], filter_options))
 
         return Response(filter_options)

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -874,6 +874,7 @@ class UserView(
         api_root = "/api/internal/v1/"
 
         filter_options = [
+            {"name": "search", "type": "search"},
             {
                 "name": "team",
                 "type": "team_select",

--- a/engine/apps/api/views/user.py
+++ b/engine/apps/api/views/user.py
@@ -870,7 +870,6 @@ class UserView(
     )
     @action(methods=["get"], detail=False)
     def filters(self, request):
-        filter_name = request.query_params.get("search", None)
         api_root = "/api/internal/v1/"
 
         filter_options = [
@@ -882,9 +881,6 @@ class UserView(
                 "global": True,
             },
         ]
-
-        if filter_name is not None:
-            filter_options = list(filter(lambda f: filter_name in f["name"], filter_options))
 
         return Response(filter_options)
 

--- a/engine/apps/api/views/webhooks.py
+++ b/engine/apps/api/views/webhooks.py
@@ -144,6 +144,7 @@ class WebhooksView(TeamFilteringMixin, PublicPrimaryKeyMixin[Webhook], ModelView
         api_root = "/api/internal/v1/"
 
         filter_options = [
+            {"name": "search", "type": "search"},
             {
                 "name": "team",
                 "type": "team_select",

--- a/engine/apps/api/views/webhooks.py
+++ b/engine/apps/api/views/webhooks.py
@@ -140,7 +140,6 @@ class WebhooksView(TeamFilteringMixin, PublicPrimaryKeyMixin[Webhook], ModelView
 
     @action(methods=["get"], detail=False)
     def filters(self, request):
-        filter_name = request.query_params.get("search", None)
         api_root = "/api/internal/v1/"
 
         filter_options = [
@@ -161,9 +160,6 @@ class WebhooksView(TeamFilteringMixin, PublicPrimaryKeyMixin[Webhook], ModelView
                     "type": "labels",
                 }
             )
-
-        if filter_name is not None:
-            filter_options = list(filter(lambda f: filter_name in f["name"], filter_options))
 
         return Response(filter_options)
 

--- a/grafana-plugin/e2e-tests/utils/alertGroup.ts
+++ b/grafana-plugin/e2e-tests/utils/alertGroup.ts
@@ -49,7 +49,7 @@ export const filterAlertGroupsTableByIntegrationAndGoToDetailPage = async (
   const selectElement = await selectDropdownValue({
     page,
     selectType: 'grafanaSelect',
-    placeholderText: 'Search or filter results...',
+    placeholderText: 'Filter results...',
     value: 'Integration',
   });
   await selectElement.type(integrationName);

--- a/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.tsx
+++ b/grafana-plugin/src/containers/RemoteFilters/RemoteFilters.tsx
@@ -173,7 +173,7 @@ class _RemoteFilters extends Component<RemoteFiltersProps, RemoteFiltersState> {
           <Select
             menuShouldPortal
             key={filters.length}
-            placeholder="Search or filter results..."
+            placeholder={allowFreeSearch ? 'Search or filter results...' : 'Filter results...'}
             value={undefined}
             onChange={this.handleAddFilter}
             getOptionLabel={(item: SelectableValue) => capitalCase(item.label)}

--- a/grafana-plugin/src/models/filters/filters.ts
+++ b/grafana-plugin/src/models/filters/filters.ts
@@ -58,11 +58,6 @@ export class FiltersStore extends BaseStore {
   public async updateOptionsForPage(page: string) {
     const result = await makeRequest(`/${getApiPathByPage(page)}/filters/`, {});
 
-    const allowFreeSearch = result.some((filter: FilterOption) => filter.name === 'search');
-    if (!allowFreeSearch) {
-      result.unshift({ name: 'search', type: 'search' });
-    }
-
     runInAction(() => {
       this.options = {
         ...this.options,


### PR DESCRIPTION
# What this PR does

* Make the filter input say `Filter results...` instead of `Search or filter results...` on the alert group page; disallow custom input there so it's only possible to choose among existing filters
* Remove outdated `<page>/filters?search=` functionality from internal API

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2679

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
