### PR TITLE
Fix deleted schedule on getting on-call users from cache

### DIFF
--- a/engine/apps/schedules/ical_utils.py
+++ b/engine/apps/schedules/ical_utils.py
@@ -489,7 +489,10 @@ def get_cached_oncall_users_for_multiple_schedules(schedules: typing.List["OnCal
     # revisit our cached_results and this time populate the results with the actual objects
     for cache_key, oncall_users in cached_results.items():
         schedule_public_primary_key = _get_schedule_public_primary_key_from_schedule_oncall_users_cache_key(cache_key)
-        schedule = schedules[schedule_public_primary_key]
+        schedule = schedules.get(schedule_public_primary_key)
+        if schedule is None:
+            # schedule might have been deleted
+            continue
         oncall_users = [
             users[user_public_primary_key]
             for user_public_primary_key in oncall_users

--- a/engine/apps/schedules/tests/test_ical_utils.py
+++ b/engine/apps/schedules/tests/test_ical_utils.py
@@ -680,3 +680,11 @@ def test_get_cached_oncall_users_for_multiple_schedules(
         schedule2: [users[2], users[3]],
         schedule3: [users[4], users[5]],
     }
+
+    # scenario: schedule is deleted but still in cache
+    schedule1.delete()
+    results = get_cached_oncall_users_for_multiple_schedules(schedules)
+    assert results == {
+        schedule2: [users[2], users[3]],
+        schedule3: [users[4], users[5]],
+    }


### PR DESCRIPTION
# What this PR does
Covers the case on getting cached on-call users when cached schedule was deleted

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2836

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
