### PR TITLE
Fix retrying email notification task

### DIFF
--- a/engine/apps/email/models.py
+++ b/engine/apps/email/models.py
@@ -1,12 +1,6 @@
-import typing
 import uuid
 
 from django.db import models
-
-if typing.TYPE_CHECKING:
-    from apps.alerts.models import Alert, AlertGroup
-    from apps.base.models import UserNotificationPolicy
-    from apps.user_management.models import User
 
 
 class EmailMessageQuerySet(models.QuerySet):
@@ -20,12 +14,7 @@ class EmailMessageQuerySet(models.QuerySet):
 
 
 class EmailMessage(models.Model):
-    represents_alert: "Alert"
-    represents_alert_group: "AlertGroup"
-    notification_policy: typing.Optional["UserNotificationPolicy"]
-    receiver: typing.Optional["User"]
-
-    objects: models.Manager["EmailMessage"] = EmailMessageQuerySet.as_manager()
+    objects = EmailMessageQuerySet.as_manager()
 
     message_uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 

--- a/engine/apps/email/models.py
+++ b/engine/apps/email/models.py
@@ -3,13 +3,11 @@ import uuid
 
 from django.db import models
 
-from apps.base.models.user_notification_policy_log_record import _check_if_notification_policy_is_transient_fallback
-
-logger = logging.getLogger(__name__)
-
 
 class EmailMessageQuerySet(models.QuerySet):
     def create(self, **kwargs):
+        from apps.base.models.user_notification_policy_log_record import \
+            _check_if_notification_policy_is_transient_fallback
         _check_if_notification_policy_is_transient_fallback(kwargs)
         return super().create(**kwargs)
 

--- a/engine/apps/email/models.py
+++ b/engine/apps/email/models.py
@@ -3,10 +3,20 @@ import uuid
 
 from django.db import models
 
+from apps.base.models.user_notification_policy_log_record import _check_if_notification_policy_is_transient_fallback
+
 logger = logging.getLogger(__name__)
 
 
+class EmailMessageQuerySet(models.QuerySet):
+    def create(self, **kwargs):
+        _check_if_notification_policy_is_transient_fallback(kwargs)
+        return super().create(**kwargs)
+
+
 class EmailMessage(models.Model):
+    objects: models.Manager["EmailMessage"] = EmailMessageQuerySet.as_manager()
+
     message_uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
     exceeded_limit = models.BooleanField(null=True, default=None)

--- a/engine/apps/email/models.py
+++ b/engine/apps/email/models.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 
 from django.db import models
@@ -6,8 +5,10 @@ from django.db import models
 
 class EmailMessageQuerySet(models.QuerySet):
     def create(self, **kwargs):
-        from apps.base.models.user_notification_policy_log_record import \
-            _check_if_notification_policy_is_transient_fallback
+        from apps.base.models.user_notification_policy_log_record import (
+            _check_if_notification_policy_is_transient_fallback,
+        )
+
         _check_if_notification_policy_is_transient_fallback(kwargs)
         return super().create(**kwargs)
 

--- a/engine/apps/email/models.py
+++ b/engine/apps/email/models.py
@@ -1,6 +1,12 @@
+import typing
 import uuid
 
 from django.db import models
+
+if typing.TYPE_CHECKING:
+    from apps.alerts.models import Alert, AlertGroup
+    from apps.base.models import UserNotificationPolicy
+    from apps.user_management.models import User
 
 
 class EmailMessageQuerySet(models.QuerySet):
@@ -14,6 +20,11 @@ class EmailMessageQuerySet(models.QuerySet):
 
 
 class EmailMessage(models.Model):
+    represents_alert: "Alert"
+    represents_alert_group: "AlertGroup"
+    notification_policy: typing.Optional["UserNotificationPolicy"]
+    receiver: typing.Optional["User"]
+
     objects: models.Manager["EmailMessage"] = EmailMessageQuerySet.as_manager()
 
     message_uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/engine/apps/email/tasks.py
+++ b/engine/apps/email/tasks.py
@@ -62,6 +62,11 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
             **kwargs, using_fallback_default_notification_policy_step=using_fallback_default_notification_policy_step
         )
 
+    def _create_email_message(**kwargs):
+        return EmailMessage.objects.create(
+            **kwargs, using_fallback_default_notification_policy_step=using_fallback_default_notification_policy_step
+        )
+
     # create an error log in case EMAIL_HOST is not specified
     if not live_settings.EMAIL_HOST:
         _create_user_notification_policy_log_record(
@@ -88,7 +93,7 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
             notification_channel=notification_policy.notify_by,
             notification_error_code=UserNotificationPolicyLogRecord.ERROR_NOTIFICATION_MAIL_LIMIT_EXCEEDED,
         )
-        EmailMessage.objects.create(
+        _create_email_message(
             represents_alert_group=alert_group,
             notification_policy=notification_policy,
             receiver=user,
@@ -115,7 +120,7 @@ def notify_user_async(user_pk, alert_group_pk, notification_policy_pk):
 
     try:
         send_mail(subject, message, from_email, recipient_list, html_message=html_message, connection=connection)
-        EmailMessage.objects.create(
+        _create_email_message(
             represents_alert_group=alert_group,
             notification_policy=notification_policy,
             receiver=user,

--- a/engine/apps/email/tests/test_notify_user.py
+++ b/engine/apps/email/tests/test_notify_user.py
@@ -7,6 +7,7 @@ from django.core.mail.backends.locmem import EmailBackend
 
 from apps.base.models import UserNotificationPolicy, UserNotificationPolicyLogRecord
 from apps.email.alert_rendering import build_subject_and_message
+from apps.email.models import EmailMessage
 from apps.email.tasks import get_from_email, notify_user_async
 from apps.user_management.subscription_strategy.free_public_beta_subscription_strategy import (
     FreePublicBetaSubscriptionStrategy,
@@ -239,5 +240,7 @@ def test_notify_user_fallback_default_policy(
     notify_user_async(user.pk, alert_group.pk, None)
     assert len(mail.outbox) == 1
 
-    log_record = UserNotificationPolicyLogRecord.objects.filter(author=user, alert_group=alert_group).last()
+    log_record = UserNotificationPolicyLogRecord.objects.filter(author=user, alert_group=alert_group).first()
     assert log_record.type == UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_SUCCESS
+
+    EmailMessage.objects.get(receiver=user, represents_alert_group=alert_group, notification_policy=None)


### PR DESCRIPTION
# What this PR does
Email tasks are failing and retrying when they use the fallback default notification policy as it does not get saved in the DB.  This PR uses the same way as UserNotificationPolicyLogRecord to set that field to null to avoid `ValueError("save() prohibited to prevent data loss due to unsaved related object 'notification_policy'.").` when that is the case.

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
