### PR TITLE
adjust to unified slack

### DIFF
--- a/engine/apps/api/views/features.py
+++ b/engine/apps/api/views/features.py
@@ -15,6 +15,7 @@ from apps.labels.utils import is_labels_feature_enabled
 class Feature(enum.StrEnum):
     MSTEAMS = "msteams"
     SLACK = "slack"
+    UNIFIED_SLACK = "unified_slack"
     TELEGRAM = "telegram"
     LIVE_SETTINGS = "live_settings"
     GRAFANA_CLOUD_NOTIFICATIONS = "grafana_cloud_notifications"
@@ -45,6 +46,9 @@ class FeaturesAPIView(APIView):
 
         if settings.FEATURE_SLACK_INTEGRATION_ENABLED:
             enabled_features.append(Feature.SLACK)
+
+        if settings.UNIFIED_SLACK_APP_ENABLED:
+            enabled_features.append(Feature.UNIFIED_SLACK)
 
         if settings.FEATURE_TELEGRAM_INTEGRATION_ENABLED:
             enabled_features.append(Feature.TELEGRAM)

--- a/grafana-plugin/src/models/slack/slack.ts
+++ b/grafana-plugin/src/models/slack/slack.ts
@@ -82,10 +82,10 @@ export class SlackStore extends BaseStore {
     window.location = url_for_redirect;
   }
 
+  @action.bound
   async installSlackIntegration() {
     try {
       const response = await makeRequestRaw('/login/slack-install-free/', {});
-
       if (response.status === 201) {
         this.rootStore.organizationStore.loadCurrentOrganization();
       } else if (response.status === 200) {

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.module.css
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.module.css
@@ -39,3 +39,18 @@
 .infoblock-icon {
   margin-top: 24px;
 }
+
+.upgradeSlackBtn {
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.upgradeSlackAlert svg {
+  display: none;
+}
+
+.linkToIncidentWrapper {
+  margin-top: 16px;
+}

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
@@ -156,10 +156,19 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
           <WithPermissionControlTooltip userAction={UserActions.ChatOpsUpdateSettings}>
             {isUnifiedSlackInstalled ? (
               <WithConfirm
-                title="TODO: uninstall unified slack title"
+                title="Remove IRM Slack integration"
                 description={
                   <Alert severity="error" title="WARNING">
-                    <p>TODO: uninstall unified slack description</p>
+                    <p>Are you sure to delete this Slack Integration? It will affect both OnCall & Incident.</p>
+                    <p>Removing the integration will irreverisbly remove the following data for IRM;</p>
+                    <ul style={{ marginLeft: '20px' }}>
+                      <li>OnCall default Slack channel</li>
+                      <li>Slack channels for OnCall escalation policies</li>
+                      <li>Slack channels & Slack user groups for OnCall Schedules</li>
+                      <li>linked Slack usernames for OnCall Users</li>
+                      <li>Incident hooks</li>
+                    </ul>
+                    <br />
                   </Alert>
                 }
                 confirmationText="DELETE"
@@ -348,7 +357,9 @@ const UpgradeToUnifiedSlackBanner = observer(() => {
         title="Upgrade to Grafana IRM unified Slack app"
         buttonContent={<div>Upgrade</div>}
       >
-        TODO: some description
+        We've rebranded the OnCall Slack app as the Grafana IRM Slack app, now with incident management features.
+        <p>Click "Upgrade" to reviewn and approve the new permissions and complete the process.</p>
+        <p>For more details, check our documentation.</p>
         <Button
           variant="secondary"
           className={styles.upgradeSlackBtn}
@@ -358,7 +369,25 @@ const UpgradeToUnifiedSlackBanner = observer(() => {
               onConfirm: installSlackIntegration,
               confirmButtonVariant: 'primary',
               title: `Upgrade to Grafana IRM Slack app`,
-              description: 'TODO: some description',
+              description: (
+                <div>
+                  <p>
+                    You will be redirected to Slack to approve additional permissions for the Grafana IRM Slack app.{' '}
+                  </p>
+                  <p>
+                    These permissions are necessary for incident management. You can view the detailed list of new
+                    permissions here.[LINK]
+                  </p>
+                  <p>After the upgrade, you'll be able to manage incidents in Slack using the Grafana IRM Slack app.</p>
+                  <ul style={{ marginLeft: '20px' }}>
+                    <li>Your OnCall Slack configuration will remain unchanged. </li>
+                    <li>
+                      Your Incident Slack integration will be upgraded to use the Grafana IRM Slack app. Please refer to
+                      the documentation for more details.[LINK]
+                    </li>
+                  </ul>
+                </div>
+              ),
               confirmVariant: 'secondary',
             })
           }

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
@@ -224,7 +224,7 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
             </WithPermissionControlTooltip>
           </HorizontalGroup>
         </InlineField>
-        {1 === 1 && (
+        {isUnifiedSlackInstalled && (
           <div className={styles.linkToIncidentWrapper}>
             <PluginBridge plugin={SupportedPlugin.Incident}>
               <Text type="secondary">

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
@@ -118,10 +118,9 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
       slackChannelStore,
       // dereferencing items is needed to rerender GSelect
       slackChannelStore: { items: slackChannelItems },
-      hasFeature,
     } = store;
 
-    const isUnifiedSlackEnabled = hasFeature(AppFeature.UnifiedSlack);
+    const isUnifiedSlackInstalled = !currentOrganization.slack_team_identity.needs_reinstall;
 
     return (
       <div className={cx('root')}>
@@ -155,7 +154,7 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
         />
         <InlineField>
           <WithPermissionControlTooltip userAction={UserActions.ChatOpsUpdateSettings}>
-            {isUnifiedSlackEnabled ? (
+            {isUnifiedSlackInstalled ? (
               <WithConfirm
                 title="TODO: uninstall unified slack title"
                 description={
@@ -225,12 +224,15 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
             </WithPermissionControlTooltip>
           </HorizontalGroup>
         </InlineField>
-        {isUnifiedSlackEnabled && (
+        {1 === 1 && (
           <div className={styles.linkToIncidentWrapper}>
             <PluginBridge plugin={SupportedPlugin.Incident}>
               <Text type="secondary">
-                {/* TODO: update link to incident slack settings */}
-                <a href={`/a/${SupportedPlugin.Incident}/settings`} target="_blank" rel="noreferrer">
+                <a
+                  href={`/a/${SupportedPlugin.Incident}/integrations/grate.irm.slack`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   <Text type="link">Open Slack Incident settings</Text>
                 </a>
               </Text>
@@ -355,7 +357,7 @@ const UpgradeToUnifiedSlackBanner = observer(() => {
               confirmText: 'Confirm',
               onConfirm: installSlackIntegration,
               confirmButtonVariant: 'primary',
-              title: `Are you sure you want to upgrade to Grafana IRM unified Slack app?`,
+              title: `Upgrade to Grafana IRM Slack app`,
               description: 'TODO: some description',
               confirmVariant: 'secondary',
             })

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
@@ -296,13 +296,12 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
             </div>
             <Text className={cx('infoblock-text')}>
               {isUnifiedSlackEnabled
-                ? 'TODO: Some unified slack text'
+                ? 'Connecting Slack App will allow you to manage alert groups and incidents in your team Slack workspace.'
                 : 'Connecting Slack App will allow you to manage alert groups in your team Slack workspace.'}
             </Text>
             <Text className={cx('infoblock-text')}>
-              {isUnifiedSlackEnabled
-                ? 'TODO: Some unified slack text'
-                : 'After a basic workspace connection your team members need to connect their personal Slack accounts in order to be allowed to manage alert groups.'}
+              After a basic workspace connection your team members need to connect their personal Slack accounts in
+              order to be allowed to manage alert groups.
             </Text>
             {isLiveSettingAvailable && (
               <Text type="secondary" className={cx('infoblock-text')}>

--- a/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
+++ b/grafana-plugin/src/pages/settings/tabs/ChatOps/tabs/SlackSettings/SlackSettings.tsx
@@ -10,11 +10,13 @@ import {
   InlineField,
   Input,
   Legend,
+  ConfirmModal,
 } from '@grafana/ui';
 import cn from 'classnames/bind';
 import { observer } from 'mobx-react';
 
 import { Block } from 'components/GBlock/Block';
+import { PluginBridge, SupportedPlugin } from 'components/PluginBridge/PluginBridge';
 import { PluginLink } from 'components/PluginLink/PluginLink';
 import { Text } from 'components/Text/Text';
 import { WithConfirm } from 'components/WithConfirm/WithConfirm';
@@ -26,9 +28,11 @@ import { PRIVATE_CHANNEL_NAME } from 'models/slack_channel/slack_channel.config'
 import { SlackChannel } from 'models/slack_channel/slack_channel.types';
 import { AppFeature } from 'state/features';
 import { WithStoreProps } from 'state/types';
+import { useStore } from 'state/useStore';
 import { withMobXProviderContext } from 'state/withStore';
 import { UserActions } from 'utils/authorization/authorization';
 import { DOCS_SLACK_SETUP, getPluginId } from 'utils/consts';
+import { useConfirmModal } from 'utils/hooks';
 import { showApiError } from 'utils/utils';
 
 import styles from './SlackSettings.module.css';
@@ -114,11 +118,15 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
       slackChannelStore,
       // dereferencing items is needed to rerender GSelect
       slackChannelStore: { items: slackChannelItems },
+      hasFeature,
     } = store;
+
+    const isUnifiedSlackEnabled = hasFeature(AppFeature.UnifiedSlack);
 
     return (
       <div className={cx('root')}>
         <Legend>Slack App settings</Legend>
+        {currentOrganization.slack_team_identity.needs_reinstall && <UpgradeToUnifiedSlackBanner />}
         <InlineField label="Slack Workspace" grow disabled>
           <Input value={currentOrganization?.slack_team_identity?.cached_name} />
         </InlineField>
@@ -147,33 +155,49 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
         />
         <InlineField>
           <WithPermissionControlTooltip userAction={UserActions.ChatOpsUpdateSettings}>
-            <WithConfirm
-              title="Remove Slack Integration for all of OnCall"
-              description={
-                <Alert severity="error" title="WARNING">
-                  <p>Are you sure to delete this Slack Integration?</p>
-                  <p>
-                    Removing the integration will also irreverisbly remove the following data for your OnCall plugin:
-                  </p>
-                  <ul style={{ marginLeft: '20px' }}>
-                    <li>default organization Slack channel</li>
-                    <li>default Slack channels for OnCall Integrations</li>
-                    <li>Slack channels & Slack user groups for OnCall Schedules</li>
-                    <li>linked Slack usernames for OnCall Users</li>
-                  </ul>
-                  <br />
-                  <p>
-                    If you would like to instead remove your linked Slack username, please head{' '}
-                    <PluginLink query={{ page: 'users/me' }}>here</PluginLink>.
-                  </p>
-                </Alert>
-              }
-              confirmationText="DELETE"
-            >
-              <Button variant="destructive" onClick={() => this.removeSlackIntegration()}>
-                Disconnect Slack App
-              </Button>
-            </WithConfirm>
+            {isUnifiedSlackEnabled ? (
+              <WithConfirm
+                title="TODO: uninstall unified slack title"
+                description={
+                  <Alert severity="error" title="WARNING">
+                    <p>TODO: uninstall unified slack description</p>
+                  </Alert>
+                }
+                confirmationText="DELETE"
+              >
+                <Button variant="destructive" onClick={() => this.removeSlackIntegration()}>
+                  Disconnect Slack App
+                </Button>
+              </WithConfirm>
+            ) : (
+              <WithConfirm
+                title="Remove Slack Integration for all of OnCall"
+                description={
+                  <Alert severity="error" title="WARNING">
+                    <p>Are you sure to delete this Slack Integration?</p>
+                    <p>
+                      Removing the integration will also irreverisbly remove the following data for your OnCall plugin:
+                    </p>
+                    <ul style={{ marginLeft: '20px' }}>
+                      <li>default organization Slack channel</li>
+                      <li>default Slack channels for OnCall Integrations</li>
+                      <li>Slack channels & Slack user groups for OnCall Schedules</li>
+                      <li>linked Slack usernames for OnCall Users</li>
+                    </ul>
+                    <br />
+                    <p>
+                      If you would like to instead remove your linked Slack username, please head{' '}
+                      <PluginLink query={{ page: 'users/me' }}>here</PluginLink>.
+                    </p>
+                  </Alert>
+                }
+                confirmationText="DELETE"
+              >
+                <Button variant="destructive" onClick={() => this.removeSlackIntegration()}>
+                  Disconnect Slack App
+                </Button>
+              </WithConfirm>
+            )}
           </WithPermissionControlTooltip>
         </InlineField>
         <Legend>Additional settings</Legend>
@@ -201,19 +225,17 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
             </WithPermissionControlTooltip>
           </HorizontalGroup>
         </InlineField>
-        {currentOrganization.slack_team_identity.needs_reinstall && (
-          <>
-            <Legend>Unified Slack App</Legend>
-            <InlineField>
-              <WithPermissionControlTooltip userAction={UserActions.ChatOpsUpdateSettings}>
-                <Button onClick={this.handleOpenSlackInstructions}>
-                  <HorizontalGroup spacing="xs" align="center">
-                    <Icon name="external-link-alt" className={cx('external-link-style')} /> Reinstall Slack App
-                  </HorizontalGroup>
-                </Button>
-              </WithPermissionControlTooltip>
-            </InlineField>
-          </>
+        {isUnifiedSlackEnabled && (
+          <div className={styles.linkToIncidentWrapper}>
+            <PluginBridge plugin={SupportedPlugin.Incident}>
+              <Text type="secondary">
+                {/* TODO: update link to incident slack settings */}
+                <a href={`/a/${SupportedPlugin.Incident}/settings`} target="_blank" rel="noreferrer">
+                  <Text type="link">Open Slack Incident settings</Text>
+                </a>
+              </Text>
+            </PluginBridge>
+          </div>
         )}
       </div>
     );
@@ -251,6 +273,7 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
     const { store } = this.props;
     const { showENVVariablesButton } = this.state;
     const isLiveSettingAvailable = store.hasFeature(AppFeature.LiveSettings) && showENVVariablesButton;
+    const isUnifiedSlackEnabled = store.hasFeature(AppFeature.UnifiedSlack);
 
     return (
       <VerticalGroup spacing="lg">
@@ -261,11 +284,14 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
               <SlackNewIcon />
             </div>
             <Text className={cx('infoblock-text')}>
-              Connecting Slack App will allow you to manage alert groups in your team Slack workspace.
+              {isUnifiedSlackEnabled
+                ? 'TODO: Some unified slack text'
+                : 'Connecting Slack App will allow you to manage alert groups in your team Slack workspace.'}
             </Text>
             <Text className={cx('infoblock-text')}>
-              After a basic workspace connection your team members need to connect their personal Slack accounts in
-              order to be allowed to manage alert groups.
+              {isUnifiedSlackEnabled
+                ? 'TODO: Some unified slack text'
+                : 'After a basic workspace connection your team members need to connect their personal Slack accounts in order to be allowed to manage alert groups.'}
             </Text>
             {isLiveSettingAvailable && (
               <Text type="secondary" className={cx('infoblock-text')}>
@@ -304,5 +330,42 @@ class _SlackSettings extends Component<SlackProps, SlackState> {
     );
   };
 }
+
+const UpgradeToUnifiedSlackBanner = observer(() => {
+  const {
+    slackStore: { installSlackIntegration },
+  } = useStore();
+  const { modalProps, openModal } = useConfirmModal();
+
+  return (
+    <>
+      <ConfirmModal {...modalProps} />
+      <Alert
+        className={styles.upgradeSlackAlert}
+        severity="success"
+        title="Upgrade to Grafana IRM unified Slack app"
+        buttonContent={<div>Upgrade</div>}
+      >
+        TODO: some description
+        <Button
+          variant="secondary"
+          className={styles.upgradeSlackBtn}
+          onClick={() =>
+            openModal({
+              confirmText: 'Confirm',
+              onConfirm: installSlackIntegration,
+              confirmButtonVariant: 'primary',
+              title: `Are you sure you want to upgrade to Grafana IRM unified Slack app?`,
+              description: 'TODO: some description',
+              confirmVariant: 'secondary',
+            })
+          }
+        >
+          Upgrade
+        </Button>
+      </Alert>
+    </>
+  );
+});
 
 export const SlackSettings = withMobXProviderContext(_SlackSettings);

--- a/grafana-plugin/src/state/features.ts
+++ b/grafana-plugin/src/state/features.ts
@@ -1,5 +1,6 @@
 export enum AppFeature {
   Slack = 'slack',
+  UnifiedSlack = 'unified_slack',
   Telegram = 'telegram',
   LiveSettings = 'live_settings',
   CloudNotifications = 'grafana_cloud_notifications',


### PR DESCRIPTION
# What this PR does

Introduce OnCall UI for Unified Slack migration. It's mostly banners and text adjustments. Changes are behind feature flag.

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
