### PR TITLE
Don't send request for permalink if slack token has been revoked

### DIFF
--- a/engine/apps/slack/models/slack_message.py
+++ b/engine/apps/slack/models/slack_message.py
@@ -82,7 +82,8 @@ class SlackMessage(models.Model):
 
     @property
     def permalink(self) -> typing.Optional[str]:
-        if self.cached_permalink or not self.slack_team_identity:
+        # Don't send request for permalink if there is no slack_team_identity or slack token has been revoked
+        if self.cached_permalink or not self.slack_team_identity or self.slack_team_identity.detected_token_revoked:
             return self.cached_permalink
 
         try:


### PR DESCRIPTION
# What this PR does
Don't send request for permalink if slack token has been revoked

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2843

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
