### PR TITLE
Update Slack user group for a schedule - handle `paid_team_only` Slack API error

### DIFF
--- a/docs/sources/manage/notify/slack/index.md
+++ b/docs/sources/manage/notify/slack/index.md
@@ -122,6 +122,8 @@ This set of permissions is supporting the ability of Grafana OnCall to match use
   (deprecated) slack commands.
 - **Create and manage user groups** — the permission is used to automatically update user groups linked to on-call
   schedules. It will add users once their on-call shift starts and remove them once the on-call shift ends.
+  - **NOTE**: per [Slack's documentation](https://slack.com/help/articles/212906697-Create-a-user-group), you must have
+  a paid plan for this feature to work properly
 - **Set presence for Grafana OnCall**
 
 ## Post-install configuration for Slack integration

--- a/engine/apps/slack/errors.py
+++ b/engine/apps/slack/errors.py
@@ -61,6 +61,7 @@ class SlackAPIUsergroupPaidTeamOnlyError(SlackAPIError):
     https://api.slack.com/methods/usergroups.create#:~:text=Name%20too%20long.-,paid_teams_only,-Usergroups%20can%20only
     https://slack.com/help/articles/212906697-Create-a-user-group
     """
+
     errors = ("paid_teams_only",)
 
 

--- a/engine/apps/slack/errors.py
+++ b/engine/apps/slack/errors.py
@@ -56,6 +56,14 @@ class SlackAPIUsergroupNotFoundError(SlackAPIError):
     errors = ("no_such_subteam", "subteam_not_found")
 
 
+class SlackAPIUsergroupPaidTeamOnlyError(SlackAPIError):
+    """
+    https://api.slack.com/methods/usergroups.create#:~:text=Name%20too%20long.-,paid_teams_only,-Usergroups%20can%20only
+    https://slack.com/help/articles/212906697-Create-a-user-group
+    """
+    errors = ("paid_teams_only",)
+
+
 class SlackAPIInvalidUsersError(SlackAPIError):
     errors = ("invalid_users",)
 

--- a/engine/apps/slack/models/slack_usergroup.py
+++ b/engine/apps/slack/models/slack_usergroup.py
@@ -16,9 +16,10 @@ from apps.slack.errors import (
     SlackAPIPermissionDeniedError,
     SlackAPITokenError,
     SlackAPIUsergroupNotFoundError,
+    SlackAPIUsergroupPaidTeamOnlyError,
 )
-from apps.slack.models import SlackTeamIdentity
-from apps.user_management.models.user import User
+from apps.slack.models import SlackTeamIdentity, SlackUserIdentity
+from apps.user_management.models import User
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
 if typing.TYPE_CHECKING:
@@ -85,9 +86,9 @@ class SlackUserGroup(models.Model):
             return False
 
     @property
-    def oncall_slack_user_identities(self):
-        users = set(user for schedule in self.oncall_schedules.get_oncall_users().values() for user in schedule)
-        slack_user_identities = []
+    def oncall_slack_user_identities(self) -> list[SlackUserIdentity]:
+        users: set[User] = set(user for schedule in self.oncall_schedules.get_oncall_users().values() for user in schedule)
+        slack_user_identities: list[SlackUserIdentity] = []
         for user in users:
             if user.slack_user_identity is not None:
                 slack_user_identities.append(user.slack_user_identity)
@@ -96,7 +97,7 @@ class SlackUserGroup(models.Model):
 
         return slack_user_identities
 
-    def update_oncall_members(self):
+    def update_oncall_members(self) -> None:
         slack_ids = [slack_user_identity.slack_id for slack_user_identity in self.oncall_slack_user_identities]
         logger.info(f"Updating usergroup {self.slack_id}, members {slack_ids}")
 
@@ -110,20 +111,25 @@ class SlackUserGroup(models.Model):
             logger.info(f"Skipping usergroup {self.slack_id}, already populated correctly")
             return
 
-        logger.info(f"Slack user group  {self.slack_id} memberlist in not up-to-date, updating, members {slack_ids}")
+        logger.info(f"Slack user group {self.slack_id} memberlist in not up-to-date, updating, members {slack_ids}")
 
         try:
             self.update_members(slack_ids)
         except SlackAPIPermissionDeniedError:
             pass
 
-    def update_members(self, slack_ids):
+    def update_members(self, slack_ids: list[str]) -> None:
         sc = SlackClient(self.slack_team_identity, enable_ratelimit_retry=True)
 
         try:
             sc.usergroups_users_update(usergroup=self.slack_id, users=slack_ids)
         except (SlackAPITokenError, SlackAPIUsergroupNotFoundError, SlackAPIInvalidUsersError) as err:
             logger.warning(f"Slack usergroup {self.slack_id} update failed: {err}")
+        except SlackAPIUsergroupPaidTeamOnlyError:
+            logger.warning(
+                f"Slack usergroup {self.slack_id} update failed as this feature is only available for paid teams",
+                exc_info=True,
+            )
         except SlackAPIError as slack_api_error:
             logger.warning(f"Slack usergroup {self.slack_id} update failed: {slack_api_error}")
             raise

--- a/engine/apps/slack/models/slack_usergroup.py
+++ b/engine/apps/slack/models/slack_usergroup.py
@@ -87,7 +87,9 @@ class SlackUserGroup(models.Model):
 
     @property
     def oncall_slack_user_identities(self) -> list[SlackUserIdentity]:
-        users: set[User] = set(user for schedule in self.oncall_schedules.get_oncall_users().values() for user in schedule)
+        users: set[User] = set(
+            user for schedule in self.oncall_schedules.get_oncall_users().values() for user in schedule
+        )
         slack_user_identities: list[SlackUserIdentity] = []
         for user in users:
             if user.slack_user_identity is not None:

--- a/engine/apps/slack/tests/test_slack_client.py
+++ b/engine/apps/slack/tests/test_slack_client.py
@@ -25,6 +25,7 @@ from apps.slack.errors import (
     SlackAPIServerError,
     SlackAPITokenError,
     SlackAPIUsergroupNotFoundError,
+    SlackAPIUsergroupPaidTeamOnlyError,
     SlackAPIUserNotFoundError,
     SlackAPIViewNotFoundError,
 )
@@ -129,6 +130,7 @@ def test_slack_client_generic_error(mock_request, monkeypatch, make_organization
         ("message_not_found", SlackAPIMessageNotFoundError),
         ("method_not_supported_for_channel_type", SlackAPIMethodNotSupportedForChannelTypeError),
         ("no_such_subteam", SlackAPIUsergroupNotFoundError),
+        ("paid_team_only", SlackAPIUsergroupPaidTeamOnlyError),
         ("not_found", SlackAPIViewNotFoundError),
         ("permission_denied", SlackAPIPermissionDeniedError),
         ("plan_upgrade_required", SlackAPIPlanUpgradeRequiredError),

--- a/engine/apps/slack/tests/test_user_group.py
+++ b/engine/apps/slack/tests/test_user_group.py
@@ -9,6 +9,7 @@ from apps.slack.errors import (
     SlackAPIInvalidUsersError,
     SlackAPITokenError,
     SlackAPIUsergroupNotFoundError,
+    SlackAPIUsergroupPaidTeamOnlyError,
 )
 from apps.slack.models import SlackUserGroup
 from apps.slack.tasks import (
@@ -22,7 +23,7 @@ from apps.user_management.models import Organization
 
 @pytest.mark.django_db
 def test_update_members(make_organization_with_slack_team_identity, make_slack_user_group):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, slack_team_identity = make_organization_with_slack_team_identity()
     user_group = make_slack_user_group(slack_team_identity)
 
     slack_ids = ["slack_id_1", "slack_id_2"]
@@ -34,13 +35,18 @@ def test_update_members(make_organization_with_slack_team_identity, make_slack_u
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("exception", [SlackAPITokenError, SlackAPIUsergroupNotFoundError, SlackAPIInvalidUsersError])
+@pytest.mark.parametrize("exception", [
+    SlackAPITokenError,
+    SlackAPIUsergroupNotFoundError,
+    SlackAPIInvalidUsersError,
+    SlackAPIUsergroupPaidTeamOnlyError,
+])
 def test_slack_user_group_update_errors(
     make_organization_with_slack_team_identity,
     make_slack_user_group,
     exception,
 ):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, slack_team_identity = make_organization_with_slack_team_identity()
     user_group = make_slack_user_group(slack_team_identity=slack_team_identity)
 
     slack_ids = ["slack_id_1", "slack_id_2"]
@@ -56,7 +62,7 @@ def test_slack_user_group_update_errors_raise(
     make_organization_with_slack_team_identity,
     make_slack_user_group,
 ):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, slack_team_identity = make_organization_with_slack_team_identity()
     user_group = make_slack_user_group(slack_team_identity=slack_team_identity)
 
     slack_ids = ["slack_id_1", "slack_id_2"]
@@ -100,10 +106,10 @@ def test_update_oncall_members(
     organization, slack_team_identity = make_organization_with_slack_team_identity()
     user_group = make_slack_user_group(slack_team_identity)
 
-    user_1, slack_user_identity_1 = make_user_with_slack_user_identity(
+    _, slack_user_identity_1 = make_user_with_slack_user_identity(
         slack_team_identity, organization, slack_id="slack_id_1"
     )
-    user_2, slack_user_identity_2 = make_user_with_slack_user_identity(
+    _, slack_user_identity_2 = make_user_with_slack_user_identity(
         slack_team_identity, organization, slack_id="slack_id_2"
     )
 
@@ -158,7 +164,7 @@ def test_start_update_slack_user_group_for_schedules_organization_deleted(
 def test_update_or_create_slack_usergroup_from_slack(
     mock_usergroups_list, mock_usergroups_users_list, make_organization_with_slack_team_identity
 ):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, slack_team_identity = make_organization_with_slack_team_identity()
     SlackUserGroup.update_or_create_slack_usergroup_from_slack("test_slack_id", slack_team_identity)
 
     usergroup = SlackUserGroup.objects.get()
@@ -182,7 +188,7 @@ def test_update_or_create_slack_usergroup_from_slack(
 def test_update_or_create_slack_usergroup_from_slack_group_not_found(
     mock_usergroups_list, make_organization_with_slack_team_identity
 ):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, slack_team_identity = make_organization_with_slack_team_identity()
     SlackUserGroup.update_or_create_slack_usergroup_from_slack("other_id", slack_team_identity)
 
     # no group is created, no error is raised
@@ -208,7 +214,7 @@ def test_update_or_create_slack_usergroup_from_slack_group_not_found(
 def test_populate_slack_usergroups_for_team(
     mock_usergroups_list, mock_usergroups_users_list, make_organization_with_slack_team_identity
 ):
-    organization, slack_team_identity = make_organization_with_slack_team_identity()
+    _, slack_team_identity = make_organization_with_slack_team_identity()
     populate_slack_usergroups_for_team(slack_team_identity.pk)
 
     usergroup = SlackUserGroup.objects.get()
@@ -226,10 +232,10 @@ def test_get_users_from_members_for_organization(
 ):
     organization, slack_team_identity = make_organization_with_slack_team_identity()
 
-    user_1, slack_user_identity_1 = make_user_with_slack_user_identity(
+    user_1, _ = make_user_with_slack_user_identity(
         slack_team_identity, organization, slack_id="slack_id_1"
     )
-    user_2, slack_user_identity_2 = make_user_with_slack_user_identity(
+    user_2, _ = make_user_with_slack_user_identity(
         slack_team_identity, organization, slack_id="slack_id_2"
     )
     user_group = make_slack_user_group(slack_team_identity)

--- a/engine/apps/slack/tests/test_user_group.py
+++ b/engine/apps/slack/tests/test_user_group.py
@@ -35,12 +35,15 @@ def test_update_members(make_organization_with_slack_team_identity, make_slack_u
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("exception", [
-    SlackAPITokenError,
-    SlackAPIUsergroupNotFoundError,
-    SlackAPIInvalidUsersError,
-    SlackAPIUsergroupPaidTeamOnlyError,
-])
+@pytest.mark.parametrize(
+    "exception",
+    [
+        SlackAPITokenError,
+        SlackAPIUsergroupNotFoundError,
+        SlackAPIInvalidUsersError,
+        SlackAPIUsergroupPaidTeamOnlyError,
+    ],
+)
 def test_slack_user_group_update_errors(
     make_organization_with_slack_team_identity,
     make_slack_user_group,
@@ -232,12 +235,8 @@ def test_get_users_from_members_for_organization(
 ):
     organization, slack_team_identity = make_organization_with_slack_team_identity()
 
-    user_1, _ = make_user_with_slack_user_identity(
-        slack_team_identity, organization, slack_id="slack_id_1"
-    )
-    user_2, _ = make_user_with_slack_user_identity(
-        slack_team_identity, organization, slack_id="slack_id_2"
-    )
+    user_1, _ = make_user_with_slack_user_identity(slack_team_identity, organization, slack_id="slack_id_1")
+    user_2, _ = make_user_with_slack_user_identity(slack_team_identity, organization, slack_id="slack_id_2")
     user_group = make_slack_user_group(slack_team_identity)
     user_group.members = ["slack_id_1", "slack_id_2"]
     user_group.save(update_fields=["members"])


### PR DESCRIPTION
# What this PR does

Semi-related to https://github.com/grafana/oncall-private/issues/2131

Addresses occasional task failures for `apps.slack.tasks.update_slack_user_group_for_schedules` when trying to update a Slack user group for a non-paid Slack account. [Slack's documentation](https://slack.com/help/articles/212906697-Create-a-user-group) mentions this is a paid only feature, hence the error ([logs](https://ops.grafana-ops.net/goto/-AWfsrrIR?orgId=1) from an actual task):
```
2024-08-08 16:20:36,613 source=engine:celery worker=ForkPoolWorker-16 task_id=6bdaae94-1552-4b6d-93e2-e2fa0bae57b1 task_name=apps.slack.tasks.update_slack_user_group_for_schedules name=apps.slack.models.slack_usergroup level=WARNING Slack usergroup S06LW5GJ88Z update failed: Slack API error! Response: {'ok': False, 'error': 'paid_teams_only'}
```

Updated our docs on our Slack integration to emphasize that this feature _only_ works for paid Slack accounts

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
