### PR TITLE
address occasional missing `nextCursor` data key from GCOM GET /instances

### DIFF
--- a/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
@@ -80,12 +80,14 @@ def test_get_instances_pagination_handles_streaming_errors_with_cursor_paginatio
     assert instance2 in objects
     assert instance3 in objects
 
-    mock_api_get.assert_has_calls([
-        call(f"{query}&cursor=0&pageSize={page_size}"),  # 1st page
-        call(f"{query}&cursor={next_cursor1}&pageSize={page_size}"),  # 2nd page, first try
-        call(f"{query}&cursor={next_cursor1}&pageSize={page_size}"),  # 2nd page, retry
-        call(f"{query}&cursor={next_cursor2}&pageSize={page_size}"),  # 3rd page
-    ])
+    mock_api_get.assert_has_calls(
+        [
+            call(f"{query}&cursor=0&pageSize={page_size}"),  # 1st page
+            call(f"{query}&cursor={next_cursor1}&pageSize={page_size}"),  # 2nd page, first try
+            call(f"{query}&cursor={next_cursor1}&pageSize={page_size}"),  # 2nd page, retry
+            call(f"{query}&cursor={next_cursor2}&pageSize={page_size}"),  # 3rd page
+        ]
+    )
 
 
 @patch("apps.grafana_plugin.helpers.client.APIClient.api_get")
@@ -115,13 +117,16 @@ def test_get_instances_pagination_doesnt_infinitely_retry_on_streaming_errors(mo
     second_page_call = call(f"{query}&cursor={next_cursor1}&pageSize={page_size}")
 
     assert len(mock_api_get.mock_calls) == 5
-    mock_api_get.assert_has_calls([
-        call(f"{query}&cursor=0&pageSize={page_size}"),  # 1st page
-        second_page_call,  # 2nd page, 1st try
-        second_page_call,  # 2nd page, 1st retry
-        second_page_call,  # 2nd page, 2nd retry
-        second_page_call,  # 2nd page, 3rd retry
-    ])
+    mock_api_get.assert_has_calls(
+        [
+            call(f"{query}&cursor=0&pageSize={page_size}"),  # 1st page
+            second_page_call,  # 2nd page, 1st try
+            second_page_call,  # 2nd page, 1st retry
+            second_page_call,  # 2nd page, 2nd retry
+            second_page_call,  # 2nd page, 3rd retry
+        ]
+    )
+
 
 @pytest.mark.parametrize(
     "query, expected_pages, expected_items",

--- a/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom_api_client.py
@@ -1,5 +1,5 @@
 import uuid
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
@@ -53,6 +53,75 @@ def test_get_instances_pagination(page_size, expected_pages, expected_items):
     assert len(pages) == expected_pages
     assert items == expected_items
 
+
+@patch("apps.grafana_plugin.helpers.client.APIClient.api_get")
+def test_get_instances_pagination_handles_streaming_errors_with_cursor_pagination(mock_api_get):
+    query = GcomAPIClient.ACTIVE_INSTANCE_QUERY
+    page_size = 10
+    next_cursor1 = "abcd1234"
+    next_cursor2 = "efgh5678"
+    instance1 = {"id": "1"}
+    instance2 = {"id": "2"}
+    instance3 = {"id": "3"}
+
+    mock_api_get.side_effect = [
+        ({"items": [instance1], "nextCursor": next_cursor1}, {}),
+        ({"items": [instance2]}, {}),  # failed request for the second page (missing nextCursor key)
+        ({"items": [instance2], "nextCursor": next_cursor2}, {}),  # retried second page request has nextCursor key
+        ({"items": [instance3], "nextCursor": None}, {}),  # last page
+    ]
+    client = GcomAPIClient("someToken")
+
+    objects = []
+    for page in client.get_instances(query, page_size):
+        objects.extend(page["items"])
+
+    assert instance1 in objects
+    assert instance2 in objects
+    assert instance3 in objects
+
+    mock_api_get.assert_has_calls([
+        call(f"{query}&cursor=0&pageSize={page_size}"),  # 1st page
+        call(f"{query}&cursor={next_cursor1}&pageSize={page_size}"),  # 2nd page, first try
+        call(f"{query}&cursor={next_cursor1}&pageSize={page_size}"),  # 2nd page, retry
+        call(f"{query}&cursor={next_cursor2}&pageSize={page_size}"),  # 3rd page
+    ])
+
+
+@patch("apps.grafana_plugin.helpers.client.APIClient.api_get")
+def test_get_instances_pagination_doesnt_infinitely_retry_on_streaming_errors(mock_api_get):
+    query = GcomAPIClient.ACTIVE_INSTANCE_QUERY
+    page_size = 10
+    next_cursor1 = "abcd1234"
+    instance1 = {"id": "1"}
+    instance2 = {"id": "2"}
+
+    mock_api_get.side_effect = [
+        ({"items": [instance1], "nextCursor": next_cursor1}, {}),
+        ({"items": [instance2]}, {}),  # failed request for the second page (missing nextCursor key)
+        ({"items": [instance2]}, {}),  # 2nd failed request for the second page
+        ({"items": [instance2]}, {}),  # 3rd failed request for the second page
+        ({"items": [instance2]}, {}),  # 4th failed request for the second page
+    ]
+    client = GcomAPIClient("someToken")
+
+    objects = []
+    for page in client.get_instances(query, page_size):
+        objects.extend(page["items"])
+
+    assert instance1 in objects
+    assert instance2 not in objects
+
+    second_page_call = call(f"{query}&cursor={next_cursor1}&pageSize={page_size}")
+
+    assert len(mock_api_get.mock_calls) == 5
+    mock_api_get.assert_has_calls([
+        call(f"{query}&cursor=0&pageSize={page_size}"),  # 1st page
+        second_page_call,  # 2nd page, 1st try
+        second_page_call,  # 2nd page, 1st retry
+        second_page_call,  # 2nd page, 2nd retry
+        second_page_call,  # 2nd page, 3rd retry
+    ])
 
 @pytest.mark.parametrize(
     "query, expected_pages, expected_items",


### PR DESCRIPTION
# What this PR does

Addressing this task exception ([logs](https://ops.grafana-ops.net/goto/rkVAurrSR?orgId=1)):
```
2024-08-08 16:30:49,455 source=engine:celery worker=ForkPoolWorker-18 task_id=969226be-64a8-4616-ac32-3909d1f0cb60 task_name=apps.grafana_plugin.tasks.sync.start_sync_organizations name=celery.app.trace level=ERROR Task apps.grafana_plugin.tasks.sync.start_sync_organizations[969226be-64a8-4616-ac32-3909d1f0cb60] raised unexpected: KeyError('nextCursor')
```

[This conversation](https://raintank-corp.slack.com/archives/C0K031RP1/p1723158123932529) in `#grafana-com-dev` has more context. The _tldr;_ takeaway after chatting w/ the GCOM team was lets simply retry requests in this case.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
