### PR TITLE
`apps.webhooks.tasks.trigger_webhook.execute_webhook` task - don't retry on `requests.exceptions.SSLError`

### DIFF
--- a/engine/apps/webhooks/tasks/trigger_webhook.py
+++ b/engine/apps/webhooks/tasks/trigger_webhook.py
@@ -198,6 +198,13 @@ def make_request(
         status["request_headers"] = error = e.message
     except InvalidWebhookData as e:
         status["request_data"] = error = e.message
+    except requests.exceptions.SSLError as e:
+        # Don't raise an exception for SSL errors, as they are out of our control and retrying
+        # isn't going to help. Just show the error to the user and give up
+        #
+        # from the docs (https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification)
+        # "Requests will throw a SSLError if it’s unable to verify the certificate"
+        status["content"] = error = str(e)
     except Exception as e:
         status["content"] = error = str(e)
         exception = e


### PR DESCRIPTION
# Which issue(s) this PR closes

Address retrying `apps.webhooks.tasks.trigger_webhook.execute_webhook` task when `requests.exceptions.SSLError` is raised ([logs](https://ops.grafana-ops.net/goto/vqrouqrIR?orgId=1)). Don't retry the task on these exceptions as retrying will not help. From the [`request`'s docs](https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification):
> By default, SSL verification is enabled, and Requests will throw a SSLError if it’s unable to verify the certificate

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
