### PR TITLE
Keep internal API proxy plugin route

### DIFF
--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -111,6 +111,23 @@
       "name": "OnCall Insights"
     }
   ],
+  "routes": [
+    {
+      "path": "api/internal/v1/*",
+      "method": "*",
+      "url": "{{ .JsonData.onCallApiUrl }}/api/internal/v1/",
+      "headers": [
+        {
+          "name": "X-Instance-Context",
+          "content": "{ \"stack_id\": \"{{ printf \"%.0f\" .JsonData.stackId }}\", \"org_id\": \"{{ printf \"%.0f\" .JsonData.orgId }}\", \"grafana_token\": \"{{ .SecureJsonData.grafanaToken }}\" }"
+        },
+        {
+          "name": "Authorization",
+          "content": "{{ .SecureJsonData.onCallApiToken }}"
+        }
+      ]
+    }
+  ],
   "roles": [
     {
       "role": {


### PR DESCRIPTION
I tried redirecting to the backend plugin resources instead, but I don't seem to have `grafanaUrl` set in `jsonData` (at least locally, so I cannot use that in the route `url` field), and also there are some issues with the auth headers (if I force a fixed URL pointing to my local grafana). OTOH, using the original route setting things work (in any case I guess it would be nice to migrate people to the new endpoints eventually).