### PR TITLE
chore: return 422 on slack step not found

### DIFF
--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -433,8 +433,7 @@ class SlackEventApiEndpointView(APIView):
                             step_was_found = True
 
         if not step_was_found:
-            raise Exception("Step is undefined" + str(payload))
-
+            logger.warning("SlackEventApiEndpointView: Step is undefined" + str(payload))
         return Response(status=200)
 
     @staticmethod

--- a/engine/apps/slack/views.py
+++ b/engine/apps/slack/views.py
@@ -434,6 +434,7 @@ class SlackEventApiEndpointView(APIView):
 
         if not step_was_found:
             logger.warning("SlackEventApiEndpointView: Step is undefined" + str(payload))
+            return Response(status=422)
         return Response(status=200)
 
     @staticmethod


### PR DESCRIPTION
# What this PR does
Return 422 instead of 500 when the handler for the slack incoming event was not found to gracefully omit events on call not subscribed to.
