### PR TITLE
Deleted organization fixes

### DIFF
--- a/engine/apps/google/tasks.py
+++ b/engine/apps/google/tasks.py
@@ -118,5 +118,5 @@ def sync_out_of_office_calendar_events_for_user(google_oauth2_user_pk: int) -> N
 
 @shared_dedicated_queue_retry_task(autoretry_for=(Exception,), retry_backoff=True)
 def sync_out_of_office_calendar_events_for_all_users() -> None:
-    for google_oauth2_user in GoogleOAuth2User.objects.all():
+    for google_oauth2_user in GoogleOAuth2User.objects.filter(user__organization__deleted_at__isnull=True):
         sync_out_of_office_calendar_events_for_user.apply_async(args=(google_oauth2_user.pk,))

--- a/engine/apps/google/tests/test_sync_out_of_office_calendar_events_for_user.py
+++ b/engine/apps/google/tests/test_sync_out_of_office_calendar_events_for_user.py
@@ -372,3 +372,21 @@ def test_sync_out_of_office_calendar_events_for_user_preexisting_shift_swap_requ
     ssrs.first().delete()
     tasks.sync_out_of_office_calendar_events_for_user(google_oauth2_user_pk)
     assert _fetch_shift_swap_requests().count() == 1
+
+
+@patch("apps.google.tasks.sync_out_of_office_calendar_events_for_user.apply_async")
+@pytest.mark.django_db
+def test_sync_out_of_office_calendar_events_for_all_users(
+    mock_sync_out_of_office_calendar_events_for_user,
+    make_organization_and_user,
+    make_google_oauth2_user_for_user,
+):
+    organization, user = make_organization_and_user()
+    google_oauth2_user = make_google_oauth2_user_for_user(user)
+
+    deleted_organization, deleted_user = make_organization_and_user()
+    make_google_oauth2_user_for_user(deleted_user)
+    deleted_organization.delete()
+
+    tasks.sync_out_of_office_calendar_events_for_all_users()
+    mock_sync_out_of_office_calendar_events_for_user.assert_called_once_with(args=(google_oauth2_user.pk,))

--- a/engine/apps/mobile_app/tasks/going_oncall_notification.py
+++ b/engine/apps/mobile_app/tasks/going_oncall_notification.py
@@ -256,5 +256,5 @@ def conditionally_send_going_oncall_push_notifications_for_schedule(schedule_pk)
 
 @shared_dedicated_queue_retry_task()
 def conditionally_send_going_oncall_push_notifications_for_all_schedules() -> None:
-    for schedule in OnCallSchedule.objects.all():
+    for schedule in OnCallSchedule.objects.filter(organization__deleted_at__isnull=True):
         conditionally_send_going_oncall_push_notifications_for_schedule.apply_async((schedule.pk,))

--- a/engine/apps/mobile_app/tests/tasks/test_going_oncall_notification.py
+++ b/engine/apps/mobile_app/tests/tasks/test_going_oncall_notification.py
@@ -470,13 +470,16 @@ def test_conditionally_send_going_oncall_push_notifications_for_schedule(
 @pytest.mark.django_db
 def test_conditionally_send_going_oncall_push_notifications_for_all_schedules(
     mocked_conditionally_send_going_oncall_push_notifications_for_schedule,
-    make_organization_and_user,
+    make_organization,
     make_schedule,
 ):
-    organization, _ = make_organization_and_user()
+    organization = make_organization()
+    deleted_organization = make_organization(deleted_at=timezone.now())
+
     schedule1 = make_schedule(organization, schedule_class=OnCallScheduleCalendar)
     schedule2 = make_schedule(organization, schedule_class=OnCallScheduleICal)
     schedule3 = make_schedule(organization, schedule_class=OnCallScheduleWeb)
+    make_schedule(deleted_organization, schedule_class=OnCallScheduleWeb)
 
     conditionally_send_going_oncall_push_notifications_for_all_schedules()
 


### PR DESCRIPTION
# What this PR does

Makes it so that:
* Shift swap requests are not created from Google Calendar for deleted orgs
* On-call shift mobile app notifications are not sent to users from deleted orgs

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
