### PR TITLE
Fix collecting metrics

### DIFF
--- a/engine/apps/metrics_exporter/metrics_collectors.py
+++ b/engine/apps/metrics_exporter/metrics_collectors.py
@@ -232,3 +232,6 @@ class ApplicationMetricsCollector:
                 recalculate_orgs.append({"organization_id": org_id, "force": force_task})
         if recalculate_orgs:
             start_calculate_and_cache_metrics.apply_async((recalculate_orgs,))
+
+
+application_metrics_registry.register(ApplicationMetricsCollector())


### PR DESCRIPTION
# What this PR does
Reverts the accidental removal of the ApplicationMetricsCollector from the metric register

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
