### PR TITLE
Disable checking alerting notification policy when checking contact points

### DIFF
--- a/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
+++ b/engine/apps/alerts/grafana_alerting_sync_manager/grafana_alerting_sync.py
@@ -370,16 +370,20 @@ class GrafanaAlertingSyncManager:
         return contact_points
 
     def _recursive_check_contact_point_is_in_routes(self, route_config: dict, receiver_name: str) -> bool:
-        if route_config.get("receiver") == receiver_name:
-            return True
-        routes = route_config.get("routes", [])
-        for route in routes:
-            if route.get("receiver") == receiver_name:
-                return True
-            if route.get("routes"):
-                if self._recursive_check_contact_point_is_in_routes(route, receiver_name):
-                    return True
-        return False
+        # TODO: Relaxing this condition due to API limitations when requesting config with external service account
+        # instead of Admin response does not contain child routes.  We are currently considering the integration
+        # connected as long as the contact point exists.
+        return True
+        # if route_config.get("receiver") == receiver_name:
+        #     return True
+        # routes = route_config.get("routes", [])
+        # for route in routes:
+        #     if route.get("receiver") == receiver_name:
+        #         return True
+        #     if route.get("routes"):
+        #         if self._recursive_check_contact_point_is_in_routes(route, receiver_name):
+        #             return True
+        # return False
 
     def _get_oncall_config_and_config_field_for_datasource_type(
         self, contact_point_name: str, is_grafana_datasource: bool, is_oncall_type_available: bool

--- a/engine/apps/alerts/tests/test_grafana_alerting_sync.py
+++ b/engine/apps/alerts/tests/test_grafana_alerting_sync.py
@@ -334,7 +334,7 @@ def test_get_connected_contact_points_from_config(
             },
             {
                 "name": ALERTMANAGER_INACTIVE_RECEIVER_CONNECTED,
-                "notification_connected": False,
+                "notification_connected": True,
             },
         ]
         if alertmanager_config

--- a/grafana-plugin/src/plugin.json
+++ b/grafana-plugin/src/plugin.json
@@ -568,6 +568,12 @@
   "iam": {
     "permissions": [
       {
+        "action": "alert.notifications:read"
+      },
+      {
+        "action": "alert.notifications:write"
+      },
+      {
         "action": "dashboards:create",
         "scope": "folders:*"
       },
@@ -578,6 +584,10 @@
       {
         "action": "dashboards:write",
         "scope": "dashboards:*"
+      },
+      {
+        "action": "datasources:read",
+        "scope": "datasources:*"
       },
       {
         "action": "folders:read",


### PR DESCRIPTION
As we are not getting back the same info when querying `/api/alertmanager/grafana/config/api/v1/alerts` when using the external service account vs admin account we will only validate that the contact point exists instead of checking if it is in the notification policy tree as well.

Note: This could be cleaner either remove the field or fix but that should be done as part of a separate task to improve contact point <-> integration in general. This is to unblock the plugin initialization changes.