### PR TITLE
update go toolchain version to use the 1.N.P syntax

### DIFF
--- a/grafana-plugin/go.mod
+++ b/grafana-plugin/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana-labs/grafana-oncall-app
 
-go 1.21
+go 1.21.5
 
 require github.com/grafana/grafana-plugin-sdk-go v0.228.0
 


### PR DESCRIPTION
# What this PR does

Fixes [this CodeQL warning](https://github.com/grafana/oncall/security/code-scanning/tools/CodeQL/status/configurations/automatic/69f48dd4390b44ab31e994b324fcb2b55dc7b51c7542feb4e14e5a6a5b7f869b):
<img width="1246" alt="Screenshot 2024-08-20 at 15 10 42" src="https://github.com/user-attachments/assets/7e643a71-4c36-47dc-9dff-cb666419286f">


[Go docs](https://go.dev/doc/toolchain#version) on 1.N.P syntax versioning

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
