### PR TITLE
upgrade Docker base image from `python:3.12.3-alpine3.18` to `python:3.12.3-alpine3.20`

### DIFF
--- a/.github/workflows/snyk-security-scan.yml
+++ b/.github/workflows/snyk-security-scan.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  snyk-python-security-scan:
+  snyk-security-scan:
     name: Snyk security scan
     runs-on: ubuntu-latest
     # see this PR regarding the permissions needed for this workflow
@@ -40,3 +40,7 @@ jobs:
         # yamllint enable rule:line-length
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      # TODO: setup snyk container monitor & snyk container test
+      # will require building the docker image and storing it in the local docker registry..
+      # will need to refactor .github/workflows/build-engine-docker-image-and-publish-to-dockerhub.yml
+      # to be a composable action instead of a workflow

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.3-alpine3.18 AS base
+FROM python:3.12.3-alpine3.20 AS base
 ARG TARGETPLATFORM
 
 # Create a group and user to run an app


### PR DESCRIPTION
# What this PR does

Fixes [many CVEs](https://ops.grafana-ops.net/a/grafana-vulnerabilityobs-app/sources/9/version/5561?var-package=&var-cve=CVE-2023-42363&var-riskLevel=$__all) currently present in our `latest` tagged Docker image:

**Before**
<img width="1250" alt="Screenshot 2024-08-20 at 16 33 14" src="https://github.com/user-attachments/assets/8215cefe-0a4c-44a8-a817-47d5d9633ceb">

**After**
<img width="1245" alt="Screenshot 2024-08-20 at 16 30 09" src="https://github.com/user-attachments/assets/2ddc9246-edbc-4801-8dc4-cdc962786ef8">

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
