### PR TITLE
Add logging for invalid api_tokens during sync

### DIFF
--- a/engine/apps/grafana_plugin/tasks/sync_v2.py
+++ b/engine/apps/grafana_plugin/tasks/sync_v2.py
@@ -41,14 +41,17 @@ def sync_organizations_v2(org_ids=None):
             orgs_per_second = math.ceil(len(organization_qs) / SYNC_PERIOD.seconds)
             logger.info(f"Syncing {len(organization_qs)} organizations @ {orgs_per_second} per 1s pause")
             for idx, org in enumerate(organization_qs):
-                client = GrafanaAPIClient(api_url=org.grafana_url, api_token=org.api_token)
-                _, status = client.sync()
-                if status["status_code"] != 200:
-                    logger.error(
-                        f"Failed to request sync stack_slug={org.stack_slug} status_code={status['status_code']} url={status['url']} message={status['message']}"
-                    )
-                if idx % orgs_per_second == 0:
-                    logger.info(f"Sleep 1s after {idx + 1} organizations processed")
-                    sleep(1)
+                if org.api_token:
+                    client = GrafanaAPIClient(api_url=org.grafana_url, api_token=org.api_token)
+                    _, status = client.sync()
+                    if status["status_code"] != 200:
+                        logger.error(
+                            f"Failed to request sync stack_slug={org.stack_slug} status_code={status['status_code']} url={status['url']} message={status['message']}"
+                        )
+                    if idx % orgs_per_second == 0:
+                        logger.info(f"Sleep 1s after {idx + 1} organizations processed")
+                        sleep(1)
+                else:
+                    logger.info(f"Skipping stack_slug={org.stack_slug}, api_token is not set")
         else:
             logger.info(f"Issuing sync requests already in progress lock_id={lock_id}, check slow outgoing requests")


### PR DESCRIPTION
# What this PR does
Add logging for when we skip an organization for sync if it is missing its api token.

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
