### PR TITLE
Fix api_token not being updated

### DIFF
--- a/engine/apps/grafana_plugin/helpers/gcom.py
+++ b/engine/apps/grafana_plugin/helpers/gcom.py
@@ -86,6 +86,7 @@ def check_gcom_permission(token_string: str, context) -> GcomToken:
                 "gcom_token",
                 "gcom_token_org_last_time_synced",
                 "cluster_slug",
+                "api_token",
             ]
         )
     logger.debug(f"Finish authenticate by making request to gcom api for org={org_id}, stack_id={stack_id}")

--- a/engine/apps/grafana_plugin/tests/test_gcom.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom.py
@@ -1,5 +1,4 @@
-import uuid
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/engine/apps/grafana_plugin/tests/test_gcom.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom.py
@@ -1,0 +1,48 @@
+import uuid
+from unittest.mock import call, patch
+
+import pytest
+
+from apps.grafana_plugin.helpers.gcom import check_gcom_permission
+
+
+@pytest.mark.django_db
+def test_check_gcom_permission_updates_fields(make_organization):
+    gcom_token = "gcom:test_token"
+    fixed_token = "fixed_token"
+    instance_info = {
+        "id": 324534,
+        "slug": "testinstance",
+        "url": "http://example.com",
+        "orgId": 5671,
+        "orgSlug": "testorg",
+        "orgName": "Test Org",
+        "regionSlug": "us",
+        "clusterSlug": "us-test",
+    }
+    context = {
+        "stack_id": str(instance_info["id"]),
+        "org_id": str(instance_info["orgId"]),
+        "grafana_token": fixed_token,
+    }
+
+    org = make_organization(stack_id=instance_info["id"], org_id=instance_info["orgId"], api_token="broken_token")
+
+    with patch(
+        "apps.grafana_plugin.helpers.GcomAPIClient.get_instance_info",
+        return_value=instance_info,
+    ) as mock_instance_info:
+        check_gcom_permission(gcom_token, context)
+        mock_instance_info.assert_called()
+
+    org.refresh_from_db()
+    assert org.stack_id == instance_info["id"]
+    assert org.stack_slug == instance_info["slug"]
+    assert org.grafana_url == instance_info["url"]
+    assert org.org_id == instance_info["orgId"]
+    assert org.org_slug == instance_info["orgSlug"]
+    assert org.org_title == instance_info["orgName"]
+    assert org.region_slug == instance_info["regionSlug"]
+    assert org.cluster_slug == instance_info["clusterSlug"]
+    assert org.api_token == fixed_token
+    assert org.gcom_token == gcom_token


### PR DESCRIPTION
# What this PR does
Fixes organization api_token not being updated when it differs from what is stored in the DB.

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
