### PR TITLE
Add more validation when updating api_token

### DIFF
--- a/engine/apps/grafana_plugin/tests/test_gcom.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom.py
@@ -12,6 +12,7 @@ from apps.grafana_plugin.helpers.gcom import check_gcom_permission
         ("abcdefghijklmnopqrztuvwxyz", True),
         ("abc", False),
         ("", False),
+        ("<no_value>", False),
         (None, False),
         (24, False),
     ],

--- a/engine/apps/grafana_plugin/tests/test_gcom.py
+++ b/engine/apps/grafana_plugin/tests/test_gcom.py
@@ -5,10 +5,21 @@ import pytest
 from apps.grafana_plugin.helpers.gcom import check_gcom_permission
 
 
+@pytest.mark.parametrize(
+    "api_token, api_token_updated",
+    [
+        ("glsa_abcdefghijklmnopqrztuvwxyz", True),
+        ("abcdefghijklmnopqrztuvwxyz", True),
+        ("abc", False),
+        ("", False),
+        (None, False),
+        (24, False),
+    ],
+)
 @pytest.mark.django_db
-def test_check_gcom_permission_updates_fields(make_organization):
+def test_check_gcom_permission_updates_fields(make_organization, api_token, api_token_updated):
     gcom_token = "gcom:test_token"
-    fixed_token = "fixed_token"
+    broken_token = "broken_token"
     instance_info = {
         "id": 324534,
         "slug": "testinstance",
@@ -22,10 +33,11 @@ def test_check_gcom_permission_updates_fields(make_organization):
     context = {
         "stack_id": str(instance_info["id"]),
         "org_id": str(instance_info["orgId"]),
-        "grafana_token": fixed_token,
+        "grafana_token": api_token,
     }
 
-    org = make_organization(stack_id=instance_info["id"], org_id=instance_info["orgId"], api_token="broken_token")
+    org = make_organization(stack_id=instance_info["id"], org_id=instance_info["orgId"], api_token=broken_token)
+    last_time_gcom_synced = org.gcom_token_org_last_time_synced
 
     with patch(
         "apps.grafana_plugin.helpers.GcomAPIClient.get_instance_info",
@@ -43,5 +55,6 @@ def test_check_gcom_permission_updates_fields(make_organization):
     assert org.org_title == instance_info["orgName"]
     assert org.region_slug == instance_info["regionSlug"]
     assert org.cluster_slug == instance_info["clusterSlug"]
-    assert org.api_token == fixed_token
+    assert org.api_token == api_token if api_token_updated else broken_token
     assert org.gcom_token == gcom_token
+    assert org.gcom_token_org_last_time_synced != last_time_gcom_synced


### PR DESCRIPTION
# What this PR does
Skip updating stored api_token for Grafana if it does not look like one.  Note: Exact format is not checked (prefix) since there are some differences between versions for what API tokens might look like and this should tolerate those differences.

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
