### PR TITLE
test: fix flaky configuration test

### DIFF
--- a/grafana-plugin/e2e-tests/pluginInitialization/configuration.test.ts
+++ b/grafana-plugin/e2e-tests/pluginInitialization/configuration.test.ts
@@ -3,20 +3,21 @@ import { PLUGIN_CONFIG } from 'utils/consts';
 import { test, expect } from '../fixtures';
 import { goToGrafanaPage } from '../utils/navigation';
 
+const DEFAULT_ONCALL_API_URL = 'http://oncall-dev-engine:8080';
+
 test.describe('Plugin configuration', () => {
   test('Admin user can see currently applied URL', async ({ adminRolePage: { page } }) => {
     await goToGrafanaPage(page, PLUGIN_CONFIG);
     await page.waitForLoadState('networkidle');
     const currentlyAppliedURL = await page.getByTestId('oncall-api-url-input').inputValue();
 
-    expect(currentlyAppliedURL).toBe('http://oncall-dev-engine:8080');
+    expect(currentlyAppliedURL).toBe(DEFAULT_ONCALL_API_URL);
   });
 
   test('Admin user can see error when invalid OnCall API URL is entered and plugin is reconnected', async ({
     adminRolePage: { page },
   }) => {
     await goToGrafanaPage(page, PLUGIN_CONFIG);
-    const correctURLAppliedByDefault = await page.getByTestId('oncall-api-url-input').inputValue();
 
     // show client-side validation errors
     const urlInput = page.getByTestId('oncall-api-url-input');
@@ -26,7 +27,7 @@ test.describe('Plugin configuration', () => {
     await page.getByText('URL is invalid').waitFor();
 
     // apply back correct url and verify plugin connected again
-    await urlInput.fill(correctURLAppliedByDefault);
+    await urlInput.fill(DEFAULT_ONCALL_API_URL);
     await page.getByTestId('connect-plugin').click();
     await page.waitForLoadState('networkidle');
     await page.getByText('Plugin is connected').waitFor();


### PR DESCRIPTION

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
