### PR TITLE
Allow customized SMS message (resolves #197)

### DIFF
--- a/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
+++ b/engine/apps/alerts/incident_appearance/renderers/sms_renderer.py
@@ -24,12 +24,7 @@ class AlertGroupSmsRenderer(AlertGroupBaseRenderer):
     def render(self):
         templated_alert = self.alert_renderer.templated_alert
         title = str_or_backup(templated_alert.title, DEFAULT_BACKUP_TITLE)
-        return (
-            f"Grafana OnCall: Alert group #{self.alert_group.inside_organization_number}"
-            f'"{title}" from stack: "{self.alert_group.channel.organization.stack_slug}", '
-            f"integration: {self.alert_group.channel.short_name}, "
-            f"alerts registered: {self.alert_group.alerts.count()}."
-        )
+        return (f"{title}")
 
 
 class AlertGroupSMSBundleRenderer(AlertGroupBundleBaseRenderer):


### PR DESCRIPTION
# What this PR does
Allows to fully customize the SMS message.
Currently always "Grafana OnCall: Alert group #[NUMBER] ... from stack [STACK], integration: [INTEGRATION], alerts registered: [NUMBER]" is added. This PR removes the surrounding text and let's the user fully decide how the message looks like using the templates (as with other notification channels).

## Which issue(s) this PR closes
Related to [https://github.com/grafana/oncall/issues/197](https://github.com/grafana/oncall/issues/197)

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
