### PR TITLE
Fix incorrect IDs being used to lookup user permissions during sync

### DIFF
--- a/grafana-plugin/pkg/plugin/settings.go
+++ b/grafana-plugin/pkg/plugin/settings.go
@@ -168,9 +168,9 @@ func (a *App) OnCallSettingsFromContext(ctx context.Context) (*OnCallPluginSetti
 			return &settings, fmt.Errorf("get GrafanaURL from provisioning failed (not set in jsonData), unable to fallback to grafana cfg")
 		}
 		settings.GrafanaURL = appUrl
-		log.DefaultLogger.Info(fmt.Sprintf("Using Grafana URL from grafana cfg app url: %s", settings.GrafanaURL))
+		log.DefaultLogger.Debug(fmt.Sprintf("Using Grafana URL from grafana cfg app url: %s", settings.GrafanaURL))
 	} else {
-		log.DefaultLogger.Info(fmt.Sprintf("Using Grafana URL from provisioning: %s", settings.GrafanaURL))
+		log.DefaultLogger.Debug(fmt.Sprintf("Using Grafana URL from provisioning: %s", settings.GrafanaURL))
 	}
 
 	settings.RBACEnabled = cfg.FeatureToggles().IsEnabled("accessControlOnCall")

--- a/grafana-plugin/pkg/plugin/users.go
+++ b/grafana-plugin/pkg/plugin/users.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -264,14 +265,15 @@ func (a *App) GetAllUsersWithPermissions(settings *OnCallPluginSettings) ([]OnCa
 			return nil, err
 		}
 		for i := range onCallUsers {
-			actions, exists := permissions["1"]
+			userId := strconv.Itoa(onCallUsers[i].ID)
+			actions, exists := permissions[userId]
 			if exists {
 				onCallUsers[i].Permissions = []OnCallPermission{}
 				for action, _ := range actions {
 					onCallUsers[i].Permissions = append(onCallUsers[i].Permissions, OnCallPermission{Action: action})
 				}
 			} else {
-				log.DefaultLogger.Error("Did not find permissions for user", "user", onCallUsers[i].Login)
+				log.DefaultLogger.Error("Did not find permissions for user", "user", onCallUsers[i].Login, "id", userId)
 			}
 		}
 	}


### PR DESCRIPTION
# What this PR does
- Fixes ID being used to lookup user permissions during sync.
- Reduce level on overly chatty log message

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
