### PR TITLE
Improve schedule filters before generating user calendar export

### DIFF
--- a/engine/apps/public_api/views/users.py
+++ b/engine/apps/public_api/views/users.py
@@ -84,6 +84,8 @@ class UserView(RateLimitHeadersMixin, ShortSerializerMixin, ReadOnlyModelViewSet
         permission_classes=(IsAuthenticated,),
     )
     def schedule_export(self, request, pk):
-        schedules = OnCallSchedule.objects.filter(organization=self.request.auth.organization)
+        schedules = OnCallSchedule.objects.filter(organization=self.request.auth.organization).related_to_user(
+            self.request.user
+        )
         export = user_ical_export(self.request.user, schedules)
         return Response(export)


### PR DESCRIPTION
Avoid checking all schedules in an organization when filtering user events during export.
This should help with some slow requests we are noticing.