### PR TITLE
fix: fix alert group card layout

### DIFF
--- a/grafana-plugin/src/components/CardButton/CardButton.tsx
+++ b/grafana-plugin/src/components/CardButton/CardButton.tsx
@@ -31,7 +31,7 @@ export const CardButton: FC<CardButtonProps> = (props) => {
     >
       <div className={styles.icon}>{icon}</div>
       <div className={styles.meta}>
-        <Stack gap={StackSize.xs}>
+        <Stack gap={StackSize.xs} direction="column">
           <Text type="secondary">{description}</Text>
           <Text.Title level={1}>{title}</Text.Title>
         </Stack>


### PR DESCRIPTION
# What this PR does
fix alert group card layout

## Which issue(s) this PR closes

[Related to [issue link here]](https://raintank-corp.slack.com/archives/C06K1MQ07GS/p1724882302489259)

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
