### PR TITLE
Use cloud access policy to publish plugin to grafana.com

### DIFF
--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -38,7 +38,6 @@ jobs:
           repo_secrets: |
             GRAFANA_ACCESS_POLICY_TOKEN=github_actions:cloud-access-policy-token
             GCS_PLUGIN_PUBLISHER_SERVICE_ACCOUNT_JSON=github_actions:gcs-plugin-publisher
-            GCOM_PLUGIN_PUBLISHER_API_KEY=github_actions:gcom-plugin-publisher-api-key
       - name: Build, sign, and package plugin
         id: build-sign-and-package-plugin
         uses: ./.github/actions/build-sign-and-package-plugin
@@ -64,7 +63,7 @@ jobs:
           echo url="https://storage.googleapis.com/grafana-oncall-app/releases/grafana-oncall-app-${{ github.ref_name }}.zip" >> $GITHUB_OUTPUT
       - name: Publish plugin to grafana.com
         run: |
-          curl -f -w "status=%{http_code}" -s -H "Authorization: Bearer ${{ env.GCOM_PLUGIN_PUBLISHER_API_KEY }}" -d "download[any][url]=${{ steps.gcs-artifact-url.outputs.url }}" -d "download[any][md5]=$(curl -sL ${{ steps.gcs-artifact-url.outputs.url }} | md5sum | cut -d'' '' -f1)" -d url=https://github.com/grafana/oncall/grafana-plugin https://grafana.com/api/plugins
+          curl -f -w "status=%{http_code}" -s -H "Authorization: Bearer ${{ env.GRAFANA_ACCESS_POLICY_TOKEN }}" -d "download[any][url]=${{ steps.gcs-artifact-url.outputs.url }}" -d "download[any][md5]=$(curl -sL ${{ steps.gcs-artifact-url.outputs.url }} | md5sum | cut -d'' '' -f1)" -d url=https://github.com/grafana/oncall/grafana-plugin https://grafana.com/api/plugins
         # yamllint enable rule:line-length
 
   build-engine-docker-image-and-publish-to-dockerhub:


### PR DESCRIPTION
related to https://github.com/grafana/oncall-private/issues/2881

use the same token to both sign and publish plugin