### PR TITLE
Relax sync team serializer validation to match underlying model

### DIFF
--- a/engine/apps/grafana_plugin/serializers/sync_data.py
+++ b/engine/apps/grafana_plugin/serializers/sync_data.py
@@ -36,8 +36,8 @@ class SyncUserSerializer(serializers.Serializer):
 class SyncTeamSerializer(serializers.Serializer):
     team_id = serializers.IntegerField()
     name = serializers.CharField()
-    email = serializers.EmailField(allow_blank=True)
-    avatar_url = serializers.CharField()
+    email = serializers.CharField(allow_blank=True)
+    avatar_url = serializers.CharField(allow_blank=True)
 
     def create(self, validated_data):
         return SyncTeam(**validated_data)

--- a/engine/apps/grafana_plugin/tests/test_sync_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_sync_v2.py
@@ -158,4 +158,4 @@ def test_sync_team_serialization(test_team, validation_pass):
         serializer.is_valid(raise_exception=True)
     except ValidationError as e:
         validation_error = e
-    assert bool(validation_error is None) == validation_pass
+    assert (validation_error is None) == validation_pass

--- a/engine/apps/grafana_plugin/tests/test_sync_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_sync_v2.py
@@ -6,9 +6,11 @@ from unittest.mock import patch
 import pytest
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 from apps.api.permissions import LegacyAccessControlRole
+from apps.grafana_plugin.serializers.sync_data import SyncTeamSerializer
 from apps.grafana_plugin.sync_data import SyncData, SyncSettings, SyncUser
 from apps.grafana_plugin.tasks.sync_v2 import start_sync_organizations_v2
 
@@ -136,3 +138,24 @@ def test_sync_v2_content_encoding(
 
         assert response.status_code == status.HTTP_200_OK
         mock_sync.assert_called()
+
+
+@pytest.mark.parametrize(
+    "test_team, validation_pass",
+    [
+        ({"team_id": 1, "name": "Test Team", "email": "", "avatar_url": ""}, True),
+        ({"team_id": 1, "name": "", "email": "", "avatar_url": ""}, False),
+        ({"name": "ABC", "email": "", "avatar_url": ""}, False),
+        ({"team_id": 1, "name": "ABC", "email": "test@example.com", "avatar_url": ""}, True),
+        ({"team_id": 1, "name": "123", "email": "<invalid email>", "avatar_url": ""}, True),
+    ],
+)
+@pytest.mark.django_db
+def test_sync_team_serialization(test_team, validation_pass):
+    serializer = SyncTeamSerializer(data=test_team)
+    validation_error = None
+    try:
+        serializer.is_valid(raise_exception=True)
+    except ValidationError as e:
+        validation_error = e
+    assert bool(validation_error is None) == validation_pass


### PR DESCRIPTION
# What this PR does
- Teams do not require valid email addresses to be sync'd
- AvatarURL can be blank

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
