### PR TITLE
fix: support running install-frontend-dependency from subdirectory

### DIFF
--- a/.github/actions/install-frontend-dependencies/action.yml
+++ b/.github/actions/install-frontend-dependencies/action.yml
@@ -2,7 +2,7 @@ name: Install frontend dependencies
 description: Setup node/pnpm + install frontend dependencies
 inputs:
   working-directory:
-    description: "Relative path to oncall/grafana-plugin directory"
+    description: "Relative path to oncall directory"
     required: false
     default: "."
 runs:
@@ -29,5 +29,5 @@ runs:
         cache-dependency-path: ${{ steps.pnpm-lock-location.outputs.pnpm-lock-location }}
     - name: Install frontend dependencies
       shell: bash
-      working-directory: grafana-plugin
+      working-directory: ${{ steps.grafana-plugin-directory.outputs.grafana-plugin-directory }}
       run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/actions/install-frontend-dependencies/action.yml
+++ b/.github/actions/install-frontend-dependencies/action.yml
@@ -16,11 +16,11 @@ runs:
       id: grafana-plugin-directory
       shell: bash
       run: echo "grafana-plugin-directory=${{ inputs.working-directory }}/grafana-plugin" >> $GITHUB_OUTPUT
-    - name: Determine pnpm.lock location
+    - name: Determine pnpm-lock.yaml location
       id: pnpm-lock-location
       shell: bash
       # yamllint disable rule:line-length
-      run: echo "pnpm-lock-location=${{ steps.grafana-plugin-directory.outputs.grafana-plugin-directory }}/pnpm.lock" >> $GITHUB_OUTPUT
+      run: echo "pnpm-lock-location=${{ steps.grafana-plugin-directory.outputs.grafana-plugin-directory }}/pnpm-lock.yaml" >> $GITHUB_OUTPUT
       # yamllint enable rule:line-length
     - uses: actions/setup-node@v4
       with:

--- a/.github/actions/install-frontend-dependencies/action.yml
+++ b/.github/actions/install-frontend-dependencies/action.yml
@@ -1,5 +1,10 @@
 name: Install frontend dependencies
 description: Setup node/pnpm + install frontend dependencies
+inputs:
+  working-directory:
+    description: "Relative path to oncall/grafana-plugin directory"
+    required: false
+    default: "."
 runs:
   using: composite
   steps:
@@ -7,11 +12,21 @@ runs:
       uses: pnpm/action-setup@v4
       with:
         version: 9.1.4
+    - name: Determine grafana-plugin directory location
+      id: grafana-plugin-directory
+      shell: bash
+      run: echo "grafana-plugin-directory=${{ inputs.working-directory }}/grafana-plugin" >> $GITHUB_OUTPUT
+    - name: Determine pnpm.lock location
+      id: pnpm-lock-location
+      shell: bash
+      # yamllint disable rule:line-length
+      run: echo "pnpm-lock-location=${{ steps.grafana-plugin-directory.outputs.grafana-plugin-directory }}/pnpm.lock" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length
     - uses: actions/setup-node@v4
       with:
         node-version: 20.15.1
         cache: pnpm
-        cache-dependency-path: grafana-plugin/pnpm-lock.yaml
+        cache-dependency-path: ${{ steps.pnpm-lock-location.outputs.pnpm-lock-location }}
     - name: Install frontend dependencies
       shell: bash
       working-directory: grafana-plugin

--- a/.github/actions/install-frontend-dependencies/action.yml
+++ b/.github/actions/install-frontend-dependencies/action.yml
@@ -1,7 +1,7 @@
 name: Install frontend dependencies
 description: Setup node/pnpm + install frontend dependencies
 inputs:
-  working-directory:
+  oncall-directory:
     description: "Relative path to oncall directory"
     required: false
     default: "."
@@ -15,7 +15,7 @@ runs:
     - name: Determine grafana-plugin directory location
       id: grafana-plugin-directory
       shell: bash
-      run: echo "grafana-plugin-directory=${{ inputs.working-directory }}/grafana-plugin" >> $GITHUB_OUTPUT
+      run: echo "grafana-plugin-directory=${{ inputs.oncall-directory }}/grafana-plugin" >> $GITHUB_OUTPUT
     - name: Determine pnpm-lock.yaml location
       id: pnpm-lock-location
       shell: bash


### PR DESCRIPTION
# What this PR does

- support running install-frontend-dependency from subdirectory (used by oncall-private)

## Which issue(s) this PR closes
https://raintank-corp.slack.com/archives/C06K1MQ07GS/p1725445756941869


<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
