### PR TITLE
Check for `user.is_active` during mobile app auth

### DIFF
--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -52,7 +52,7 @@ class ApiTokenAuthentication(BaseAuthentication):
         auth = get_authorization_header(request).decode("utf-8")
         user, auth_token = self.authenticate_credentials(auth)
 
-        if not user_is_authorized(user, [RBACPermission.Permissions.API_KEYS_WRITE]):
+        if not user.is_active or not user_is_authorized(user, [RBACPermission.Permissions.API_KEYS_WRITE]):
             raise exceptions.AuthenticationFailed(
                 "Only users with Admin permissions are allowed to perform this action."
             )

--- a/engine/apps/mobile_app/auth.py
+++ b/engine/apps/mobile_app/auth.py
@@ -33,7 +33,7 @@ class MobileAppAuthTokenAuthentication(BaseAuthentication):
     def authenticate(self, request) -> Optional[Tuple[User, MobileAppAuthToken]]:
         auth = get_authorization_header(request).decode("utf-8")
         user, auth_token = self.authenticate_credentials(auth)
-        if user is None:
+        if user is None or not user.is_active:
             return None
         return user, auth_token
 

--- a/engine/apps/public_api/tests/test_alert_groups.py
+++ b/engine/apps/public_api/tests/test_alert_groups.py
@@ -181,6 +181,20 @@ def test_get_alert_groups(alert_group_public_api_setup):
 
 
 @pytest.mark.django_db
+def test_get_alert_groups_inactive_user(make_organization_and_user_with_token):
+    _, user, token = make_organization_and_user_with_token()
+    # user is set to inactive if deleted via queryset (ie. during sync)
+    user.is_active = False
+    user.save()
+
+    client = APIClient()
+    url = reverse("api-public:alert_groups-list")
+    response = client.get(url, format="json", HTTP_AUTHORIZATION=token)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
 def test_get_alert_groups_include_labels(alert_group_public_api_setup, make_alert_group_label_association):
     token, _, _, _ = alert_group_public_api_setup
     alert_groups = AlertGroup.objects.all().order_by("-started_at")


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/12253