### PR TITLE
Bump Redis deps

### DIFF
--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled
   - name: redis
-    version: 16.13.2
+    version: 20.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: grafana


### PR DESCRIPTION
Can we update this dependency? The current version of Redis has CVE.