### PR TITLE
Change default source link template for alertmanager

### DIFF
--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -13,7 +13,7 @@ featured_tag_name = "Prometheus"
 
 
 # Behaviour
-source_link = "{{ payload.externalURL }}"
+source_link = "{{ payload.alerts[0].generatorURL }}"
 
 grouping_id = "{{ payload.groupKey }}"
 

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -15,7 +15,7 @@ based_on_alertmanager = True
 
 
 # Behaviour
-source_link = "{{ payload.externalURL }}"
+source_link = "{{ payload.alerts[0].generatorURL }}"
 
 grouping_id = "{{ payload.groupKey }}"
 


### PR DESCRIPTION
# What this PR does

Changing source link default template to the link to the first alert in the group `alerts[0].generatorURL`. `externalURL` as a backlink to the Alertmanager, is too general

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
