### PR TITLE
docs: hide slack doc from toc

### DIFF
--- a/docs/sources/configure/integrations/references/slack/index.md
+++ b/docs/sources/configure/integrations/references/slack/index.md
@@ -3,6 +3,8 @@ title: Slack integration for Grafana IRM
 menuTitle: IRM Slack
 description: Learn more about Slack integration for Grafana IRM.
 weight: 0
+_build:
+  list: false
 keywords:
   - OnCall
   - IRM


### PR DESCRIPTION
# What this PR does

This PR hides the IRM Slack doc currently located in the OnCall TOC to support moving this content to the top-level IRM docs navigation. This will improve visibility and clarify that this is an IRM feature, not just an OnCall feature. 

Rather than removing the document altogether, we can hide it so that the URL is still active for anyone who is directed to it. This also gives us transition time to update the links in the product and elsewhere. 

## Background

This update addresses our initial feedback on the Unified IRM Slack app. The goal of this change is to reduce confusion around migration and document location to ease the transition to the new app.

Replacement docs can be found here:
https://github.com/grafana/website/pull/21657

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
