### PR TITLE
Fix <a> link escaping in web template

### DIFF
--- a/engine/apps/alerts/incident_appearance/templaters/web_templater.py
+++ b/engine/apps/alerts/incident_appearance/templaters/web_templater.py
@@ -1,7 +1,7 @@
 import re
 
 from apps.alerts.incident_appearance.templaters.alert_templater import AlertTemplater
-from common.utils import convert_md_to_html, escape_html, url_re, urlize_with_respect_to_a
+from common.utils import convert_md_to_html, url_re, urlize_with_respect_to_a
 
 
 class AlertWebTemplater(AlertTemplater):
@@ -13,9 +13,9 @@ class AlertWebTemplater(AlertTemplater):
     def _postformat(self, templated_alert):
         link_substitution = {}
         if templated_alert.title:
-            templated_alert.title = escape_html(self._slack_format_for_web(templated_alert.title))
+            templated_alert.title = self._slack_format_for_web(templated_alert.title)
         if templated_alert.message:
-            message = escape_html(self._slack_format_for_web(templated_alert.message))
+            message = self._slack_format_for_web(templated_alert.message)
             link_matches = re.findall(url_re, message)
             for idx, link in enumerate(link_matches):
                 substitution = f"oncallsubstitutedlink{idx}marker"
@@ -25,8 +25,6 @@ class AlertWebTemplater(AlertTemplater):
             for substitution, original_link in link_substitution.items():
                 message = message.replace(substitution, original_link)
             templated_alert.message = urlize_with_respect_to_a(message)
-        if templated_alert.image_url:
-            templated_alert.image_url = escape_html(templated_alert.image_url)
 
         return templated_alert
 

--- a/engine/apps/alerts/incident_appearance/templaters/web_templater.py
+++ b/engine/apps/alerts/incident_appearance/templaters/web_templater.py
@@ -15,7 +15,7 @@ class AlertWebTemplater(AlertTemplater):
         if templated_alert.title:
             templated_alert.title = escape_html(self._slack_format_for_web(templated_alert.title))
         if templated_alert.message:
-            message = templated_alert.message
+            message = self._slack_format_for_web(templated_alert.message)
             link_matches = re.findall(url_re, message)
             for idx, link in enumerate(link_matches):
                 substitution = f"oncallsubstitutedlink{idx}marker"

--- a/engine/apps/alerts/incident_appearance/templaters/web_templater.py
+++ b/engine/apps/alerts/incident_appearance/templaters/web_templater.py
@@ -1,7 +1,7 @@
 import re
 
 from apps.alerts.incident_appearance.templaters.alert_templater import AlertTemplater
-from common.utils import convert_md_to_html, url_re, urlize_with_respect_to_a
+from common.utils import convert_md_to_html, escape_html, url_re, urlize_with_respect_to_a
 
 
 class AlertWebTemplater(AlertTemplater):
@@ -13,9 +13,9 @@ class AlertWebTemplater(AlertTemplater):
     def _postformat(self, templated_alert):
         link_substitution = {}
         if templated_alert.title:
-            templated_alert.title = self._slack_format_for_web(templated_alert.title)
+            templated_alert.title = escape_html(self._slack_format_for_web(templated_alert.title))
         if templated_alert.message:
-            message = self._slack_format_for_web(templated_alert.message)
+            message = templated_alert.message
             link_matches = re.findall(url_re, message)
             for idx, link in enumerate(link_matches):
                 substitution = f"oncallsubstitutedlink{idx}marker"
@@ -25,6 +25,8 @@ class AlertWebTemplater(AlertTemplater):
             for substitution, original_link in link_substitution.items():
                 message = message.replace(substitution, original_link)
             templated_alert.message = urlize_with_respect_to_a(message)
+        if templated_alert.image_url:
+            templated_alert.image_url = escape_html(templated_alert.image_url)
 
         return templated_alert
 

--- a/engine/apps/alerts/tests/test_alert_group_renderer.py
+++ b/engine/apps/alerts/tests/test_alert_group_renderer.py
@@ -55,12 +55,36 @@ def test_render_web_alert_links(
     )
 
 
+@pytest.mark.parametrize(
+    "message, expected_result",
+    [
+        (
+            '<a href="https://www.google.com">google</a>',
+            '<p><a href="https://www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>',
+        ),
+        (
+            '<a href="http://www.google.com">google</a>',
+            '<p><a href="http://www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>',
+        ),
+        (
+            '<a href="//www.google.com">google</a>',
+            '<p><a href="//www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>',
+        ),
+        ("http://www.google.com/", '<p><a href="http://www.google.com/">http://www.google.com/</a> </p>'),
+        (
+            "[Hello](http://www.google.com)",
+            '<p><a href="http://www.google.com" rel="nofollow noopener" target="_blank">Hello</a> </p>',
+        ),
+    ],
+)
 @pytest.mark.django_db
 def test_render_web_postformat_html_a_links(
     make_organization_and_user_with_slack_identities,
     make_alert_receive_channel,
     make_alert_group,
     make_alert,
+    message,
+    expected_result,
 ):
     organization, _, _, _ = make_organization_and_user_with_slack_identities()
     alert_receive_channel = make_alert_receive_channel(
@@ -68,21 +92,11 @@ def test_render_web_postformat_html_a_links(
     )
     alert_group = make_alert_group(alert_receive_channel)
 
-    message = (
-        '<a href="https://www.google.com">google</a>\n'
-        '<a href="http://www.google.com">google</a>\n'
-        '<a href="//www.google.com">google</a>'
-    )
     alert = make_alert(alert_group=alert_group, raw_request_data={"message": message})
 
     templater = AlertWebTemplater(alert)
     templated_alert = templater.render()
-    assert (
-        templated_alert.message
-        == '<p><a href="https://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n'
-        '<a href="http://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n'
-        '<a href="//www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>'
-    )
+    assert templated_alert.message == expected_result
 
 
 @pytest.mark.django_db

--- a/engine/apps/alerts/tests/test_alert_group_renderer.py
+++ b/engine/apps/alerts/tests/test_alert_group_renderer.py
@@ -56,6 +56,30 @@ def test_render_web_alert_links(
 
 
 @pytest.mark.django_db
+def test_render_web_postformat_html_a_links(
+    make_organization_and_user_with_slack_identities,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_alert,
+):
+    organization, _, _, _ = make_organization_and_user_with_slack_identities()
+    alert_receive_channel = make_alert_receive_channel(
+        organization,
+    )
+    alert_group = make_alert_group(alert_receive_channel)
+
+    message = '<a href="https://www.google.com">google</a>\n<a href="http://www.google.com">google</a>\n<a href="//www.google.com">google</a>'
+    alert = make_alert(alert_group=alert_group, raw_request_data={"message": message})
+
+    templater = AlertWebTemplater(alert)
+    templated_alert = templater.render()
+    assert (
+        templated_alert.message
+        == '<p><a href="https://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n<a href="http://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n<a href="//www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>'
+    )
+
+
+@pytest.mark.django_db
 def test_getattr_template(
     make_organization_and_user_with_slack_identities,
     make_alert_receive_channel,

--- a/engine/apps/alerts/tests/test_alert_group_renderer.py
+++ b/engine/apps/alerts/tests/test_alert_group_renderer.py
@@ -68,14 +68,20 @@ def test_render_web_postformat_html_a_links(
     )
     alert_group = make_alert_group(alert_receive_channel)
 
-    message = '<a href="https://www.google.com">google</a>\n<a href="http://www.google.com">google</a>\n<a href="//www.google.com">google</a>'
+    message = (
+        '<a href="https://www.google.com">google</a>\n'
+        '<a href="http://www.google.com">google</a>\n'
+        '<a href="//www.google.com">google</a>'
+    )
     alert = make_alert(alert_group=alert_group, raw_request_data={"message": message})
 
     templater = AlertWebTemplater(alert)
     templated_alert = templater.render()
     assert (
         templated_alert.message
-        == '<p><a href="https://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n<a href="http://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n<a href="//www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>'
+        == '<p><a href="https://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n'
+        '<a href="http://www.google.com" rel="nofollow noopener" target="_blank">google</a> <br/>\n'
+        '<a href="//www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>'
     )
 
 


### PR DESCRIPTION
# What this PR does
Removed escaping of html in web template to fix issue where <a> links were not being detected correctly when post processing the web template.

## Which issue(s) this PR closes

https://github.com/grafana/support-escalations/issues/12412

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
