### PR TITLE
Revert "Fix <a> link escaping in web template"

### DIFF
--- a/engine/apps/alerts/incident_appearance/templaters/web_templater.py
+++ b/engine/apps/alerts/incident_appearance/templaters/web_templater.py
@@ -15,7 +15,7 @@ class AlertWebTemplater(AlertTemplater):
         if templated_alert.title:
             templated_alert.title = escape_html(self._slack_format_for_web(templated_alert.title))
         if templated_alert.message:
-            message = self._slack_format_for_web(templated_alert.message)
+            message = escape_html(self._slack_format_for_web(templated_alert.message))
             link_matches = re.findall(url_re, message)
             for idx, link in enumerate(link_matches):
                 substitution = f"oncallsubstitutedlink{idx}marker"

--- a/engine/apps/alerts/tests/test_alert_group_renderer.py
+++ b/engine/apps/alerts/tests/test_alert_group_renderer.py
@@ -55,50 +55,6 @@ def test_render_web_alert_links(
     )
 
 
-@pytest.mark.parametrize(
-    "message, expected_result",
-    [
-        (
-            '<a href="https://www.google.com">google</a>',
-            '<p><a href="https://www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>',
-        ),
-        (
-            '<a href="http://www.google.com">google</a>',
-            '<p><a href="http://www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>',
-        ),
-        (
-            '<a href="//www.google.com">google</a>',
-            '<p><a href="//www.google.com" rel="nofollow noopener" target="_blank">google</a> </p>',
-        ),
-        ("http://www.google.com/", '<p><a href="http://www.google.com/">http://www.google.com/</a> </p>'),
-        (
-            "[Hello](http://www.google.com)",
-            '<p><a href="http://www.google.com" rel="nofollow noopener" target="_blank">Hello</a> </p>',
-        ),
-    ],
-)
-@pytest.mark.django_db
-def test_render_web_postformat_html_a_links(
-    make_organization_and_user_with_slack_identities,
-    make_alert_receive_channel,
-    make_alert_group,
-    make_alert,
-    message,
-    expected_result,
-):
-    organization, _, _, _ = make_organization_and_user_with_slack_identities()
-    alert_receive_channel = make_alert_receive_channel(
-        organization,
-    )
-    alert_group = make_alert_group(alert_receive_channel)
-
-    alert = make_alert(alert_group=alert_group, raw_request_data={"message": message})
-
-    templater = AlertWebTemplater(alert)
-    templated_alert = templater.render()
-    assert templated_alert.message == expected_result
-
-
 @pytest.mark.django_db
 def test_getattr_template(
     make_organization_and_user_with_slack_identities,


### PR DESCRIPTION
Reverts grafana/oncall#5019

Investigating alternatives, although we have a sanitize function called on the UI side we probably don't want to allow other html.