### PR TITLE
chore: always point livereload to localhost

### DIFF
--- a/grafana-plugin/webpack.config.ts
+++ b/grafana-plugin/webpack.config.ts
@@ -59,7 +59,16 @@ const config = async (env): Promise<Configuration> => {
     },
     plugins: [
       ...(baseConfig.plugins?.filter((plugin) => !(plugin instanceof LiveReloadPlugin)) || []),
-      ...(env.development ? [new LiveReloadPlugin({ appendScriptTag: true, useSourceHash: true })] : []),
+      ...(env.development
+        ? [
+            new LiveReloadPlugin({
+              appendScriptTag: true,
+              useSourceHash: true,
+              protocol: 'http',
+              hostname: 'localhost',
+            }),
+          ]
+        : []),
       new EnvironmentPlugin({
         NODE_ENV: 'development',
         PLUGIN_ID: 'grafana-oncall-app',


### PR DESCRIPTION
# What this PR does

Always point livereload to localhost. I missed this change when submitting this PR: https://github.com/grafana/oncall/pull/5021

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
