### PR TITLE
Add openAPI schema for some internal endpoints

### DIFF
--- a/engine/apps/alerts/models/escalation_policy.py
+++ b/engine/apps/alerts/models/escalation_policy.py
@@ -345,7 +345,7 @@ class EscalationPolicy(OrderedModel):
         return sorted(self.notify_to_users_queue.all(), key=lambda user: (user.username or "", user.pk))
 
     @property
-    def slack_integration_required(self):
+    def slack_integration_required(self) -> bool:
         if self.step in self.SLACK_INTEGRATION_REQUIRED_STEPS:
             return True
         else:

--- a/engine/apps/api/serializers/alert_group_escalation_snapshot.py
+++ b/engine/apps/api/serializers/alert_group_escalation_snapshot.py
@@ -36,17 +36,17 @@ class EscalationPolicySnapshotAPISerializer(EscalationPolicySerializer):
 class AlertGroupEscalationSnapshotAPISerializer(serializers.Serializer):
     """Serializes AlertGroup escalation snapshot for API endpoint"""
 
-    escalation_chain = serializers.SerializerMethodField()
-    channel_filter = serializers.SerializerMethodField()
+    class EscalationChainSnapshotAPISerializer(serializers.Serializer):
+        name = serializers.CharField()
+
+    class ChannelFilterSnapshotAPISerializer(serializers.Serializer):
+        name = serializers.CharField(source="str_for_clients")
+
+    escalation_chain = EscalationChainSnapshotAPISerializer(read_only=True, source="escalation_chain_snapshot")
+    channel_filter = ChannelFilterSnapshotAPISerializer(read_only=True, source="channel_filter_snapshot")
     escalation_policies = EscalationPolicySnapshotAPISerializer(
         source="escalation_policies_snapshots", many=True, read_only=True
     )
 
     class Meta:
         fields = ["escalation_chain", "channel_filter", "escalation_policies"]
-
-    def get_escalation_chain(self, obj):
-        return {"name": obj.escalation_chain_snapshot.name}
-
-    def get_channel_filter(self, obj):
-        return {"name": obj.channel_filter_snapshot.str_for_clients}

--- a/engine/apps/api/serializers/escalation_chain.py
+++ b/engine/apps/api/serializers/escalation_chain.py
@@ -22,11 +22,11 @@ class EscalationChainListSerializer(EscalationChainSerializer):
     class Meta(EscalationChainSerializer.Meta):
         fields = [*EscalationChainSerializer.Meta.fields, "number_of_integrations", "number_of_routes"]
 
-    def get_number_of_integrations(self, obj):
+    def get_number_of_integrations(self, obj) -> int:
         # num_integrations param added in queryset via annotate. Check EscalationChainViewSet.get_queryset
         return getattr(obj, "num_integrations", 0)
 
-    def get_number_of_routes(self, obj):
+    def get_number_of_routes(self, obj) -> int:
         # num_routes param added in queryset via annotate. Check EscalationChainViewSet.get_queryset
         return getattr(obj, "num_routes", 0)
 

--- a/engine/apps/api/views/user_notification_policy.py
+++ b/engine/apps/api/views/user_notification_policy.py
@@ -1,5 +1,8 @@
 from django.conf import settings
 from django.http import Http404
+from django_filters import rest_framework as filters
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
+from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -14,14 +17,30 @@ from apps.base.messaging import get_messaging_backend_from_id
 from apps.base.models import UserNotificationPolicy
 from apps.base.models.user_notification_policy import BUILT_IN_BACKENDS, NotificationChannelAPIOptions
 from apps.mobile_app.auth import MobileAppAuthTokenAuthentication
-from apps.user_management.models import User
-from common.api_helpers.exceptions import BadRequest
+from common.api_helpers.filters import ModelChoiceCharFilter, get_user_queryset
 from common.api_helpers.mixins import UpdateSerializerMixin
 from common.insight_log import EntityEvent, write_resource_insight_log
 from common.ordered_model.viewset import OrderedModelViewSet
 
 
+class UserNotificationPolicyFilter(filters.FilterSet):
+    important = filters.BooleanFilter()
+    user = ModelChoiceCharFilter(
+        queryset=get_user_queryset,
+        to_field_name="public_primary_key",
+    )
+
+
+@extend_schema_view(
+    list=extend_schema(responses=UserNotificationPolicySerializer),
+    update=extend_schema(responses=UserNotificationPolicyUpdateSerializer),
+    partial_update=extend_schema(responses=UserNotificationPolicyUpdateSerializer),
+)
 class UserNotificationPolicyView(UpdateSerializerMixin, OrderedModelViewSet):
+    """
+    Internal API endpoints for user notification policies.
+    """
+
     authentication_classes = (
         MobileAppAuthTokenAuthentication,
         PluginAuthentication,
@@ -54,25 +73,27 @@ class UserNotificationPolicyView(UpdateSerializerMixin, OrderedModelViewSet):
             "move_to_position",
         ],
     }
+    queryset = UserNotificationPolicy.objects.none()  # needed for drf-spectacular introspection
 
     model = UserNotificationPolicy
     serializer_class = UserNotificationPolicySerializer
     update_serializer_class = UserNotificationPolicyUpdateSerializer
 
+    filter_backends = (filters.DjangoFilterBackend,)
+    filterset_class = UserNotificationPolicyFilter
+
     def get_queryset(self):
-        important = self.request.query_params.get("important", None) == "true"
-        try:
-            user_id = self.request.query_params.get("user", None)
-        except ValueError:
-            raise BadRequest(detail="Invalid user param")
-        if user_id is None or user_id == self.request.user.public_primary_key:
-            target_user = self.request.user
-        else:
-            try:
-                target_user = User.objects.get(public_primary_key=user_id)
-            except User.DoesNotExist:
-                raise BadRequest(detail="User does not exist")
-        queryset = UserNotificationPolicy.objects.filter(user=target_user, important=important)
+        # if there are no query params, set default value
+        lookup_kwargs = {}
+        important = self.request.query_params.get("important", None)
+        user_id = self.request.query_params.get("user", None)
+        if important is None:
+            lookup_kwargs.update({"important": False})
+        if user_id is None:
+            lookup_kwargs.update({"user": self.request.user})
+        queryset = UserNotificationPolicy.objects.filter(
+            **lookup_kwargs, user__organization=self.request.auth.organization
+        )
         return self.serializer_class.setup_eager_loading(queryset)
 
     def get_object(self):
@@ -128,6 +149,17 @@ class UserNotificationPolicyView(UpdateSerializerMixin, OrderedModelViewSet):
             new_state=new_state,
         )
 
+    @extend_schema(
+        responses=inline_serializer(
+            name="UserNotificationPolicyDelayOptions",
+            fields={
+                "value": serializers.CharField(),
+                "sec_value": serializers.IntegerField(),
+                "display_name": serializers.CharField(),
+            },
+            many=True,
+        )
+    )
     @action(detail=False, methods=["get"])
     def delay_options(self, request):
         choices = []
@@ -135,6 +167,18 @@ class UserNotificationPolicyView(UpdateSerializerMixin, OrderedModelViewSet):
             choices.append({"value": str(item[0]), "sec_value": item[0], "display_name": item[1]})
         return Response(choices)
 
+    @extend_schema(
+        responses=inline_serializer(
+            name="UserNotificationPolicyNotifyByOptions",
+            fields={
+                "value": serializers.IntegerField(),
+                "display_name": serializers.CharField(),
+                "slack_integration_required": serializers.BooleanField(),
+                "telegram_integration_required": serializers.BooleanField(),
+            },
+            many=True,
+        )
+    )
     @action(detail=False, methods=["get"])
     def notify_by_options(self, request):
         """

--- a/engine/common/api_helpers/custom_fields.py
+++ b/engine/common/api_helpers/custom_fields.py
@@ -82,6 +82,7 @@ class TeamPrimaryKeyRelatedField(RelatedField):
         return super().validate_empty_values(data)
 
 
+@extend_schema_field(serializers.ListField(child=serializers.CharField()))
 class UsersFilteredByOrganizationField(serializers.Field):
     """
     This field reduces queries count when accessing User many related field (ex: notify_to_users_queue).

--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -348,6 +348,10 @@ SPECTACULAR_INCLUDED_PATHS = [
     "/alertgroups",
     "/alert_receive_channels",
     "/webhooks",
+    "/channel_filters",
+    "/escalation_chains",
+    "/escalation_policies",
+    "/notification_policies",
     # current user endpoint 👇, without trailing slash we pick-up /user_group endpoints, which we don't want for now
     "/user/",
     "/users",


### PR DESCRIPTION
# What this PR does
Adds openAPI schema for following endpoints:
- /escalation_chain
- /escalation_policy
- /channel_filter
- /user_notification_policy

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2457

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
