### PR TITLE
fix: Add rolling users validation for oncall shift API

### DIFF
--- a/engine/apps/api/serializers/on_call_shifts.py
+++ b/engine/apps/api/serializers/on_call_shifts.py
@@ -29,7 +29,7 @@ class OnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         allow_null=True,
         required=False,
         child=UsersFilteredByOrganizationField(
-            queryset=User.objects, required=False, allow_null=True
+            queryset=User.objects, db_verification=True, required=False, allow_null=True
         ),  # todo: filter by team?
     )
     updated_shift = serializers.CharField(read_only=True, allow_null=True, source="updated_shift.public_primary_key")

--- a/engine/apps/api/serializers/on_call_shifts.py
+++ b/engine/apps/api/serializers/on_call_shifts.py
@@ -29,7 +29,7 @@ class OnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         allow_null=True,
         required=False,
         child=UsersFilteredByOrganizationField(
-            queryset=User.objects, db_verification=True, required=False, allow_null=True
+            queryset=User.objects, require_all_exist=True, required=False, allow_null=True
         ),  # todo: filter by team?
     )
     updated_shift = serializers.CharField(read_only=True, allow_null=True, source="updated_shift.public_primary_key")

--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -594,7 +594,7 @@ def test_update_on_call_shift_invalid_rolling_users(
     response = client.put(url, data=data_to_update, format="json", **make_user_auth_headers(user1, token))
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {"rolling_users": {"0": ["User does not exist fuzz"]}}
+    assert response.json() == {"rolling_users": {"0": ["User does not exist {'fuzz'}"]}}
 
 
 @pytest.mark.django_db
@@ -1273,7 +1273,7 @@ def test_create_on_call_shift_invalid_rolling_users(on_call_shift_internal_api_s
     with patch("apps.schedules.models.CustomOnCallShift.refresh_schedule") as mock_refresh_schedule:
         response = client.post(url, data, format="json", **make_user_auth_headers(user1, token))
 
-    expected_payload = {"rolling_users": {"1": ["User does not exist fuzz"]}}
+    expected_payload = {"rolling_users": {"1": ["User does not exist {'fuzz'}"]}}
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.json() == expected_payload
     mock_refresh_schedule.assert_not_called()

--- a/engine/apps/api/tests/test_oncall_shift.py
+++ b/engine/apps/api/tests/test_oncall_shift.py
@@ -556,6 +556,48 @@ def test_update_future_on_call_shift_removing_users(
 
 
 @pytest.mark.django_db
+def test_update_on_call_shift_invalid_rolling_users(
+    on_call_shift_internal_api_setup,
+    make_on_call_shift,
+    make_user_auth_headers,
+):
+    token, user1, _, _, schedule = on_call_shift_internal_api_setup
+
+    client = APIClient()
+    start_date = (timezone.now() + timezone.timedelta(days=1)).replace(microsecond=0)
+
+    name = "Test Shift Rotation"
+    on_call_shift = make_on_call_shift(
+        schedule.organization,
+        shift_type=CustomOnCallShift.TYPE_ROLLING_USERS_EVENT,
+        schedule=schedule,
+        name=name,
+        start=start_date,
+        duration=timezone.timedelta(hours=1),
+        rotation_start=start_date,
+        rolling_users=[{user1.pk: user1.public_primary_key}],
+    )
+    data_to_update = {
+        "name": name,
+        "priority_level": 2,
+        "shift_start": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "shift_end": (start_date + timezone.timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "rotation_start": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "until": None,
+        "frequency": None,
+        "interval": None,
+        "by_day": None,
+        "rolling_users": [["fuzz"]],
+    }
+
+    url = reverse("api-internal:oncall_shifts-detail", kwargs={"pk": on_call_shift.public_primary_key})
+    response = client.put(url, data=data_to_update, format="json", **make_user_auth_headers(user1, token))
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == {"rolling_users": {"0": ["User does not exist fuzz"]}}
+
+
+@pytest.mark.django_db
 def test_update_started_on_call_shift(
     on_call_shift_internal_api_setup,
     make_on_call_shift,
@@ -1200,6 +1242,41 @@ def test_create_on_call_shift_invalid_data_rolling_users(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["rolling_users"][0] == "Cannot set multiple user groups for non-recurrent shifts"
+
+
+@pytest.mark.django_db
+def test_create_on_call_shift_invalid_rolling_users(on_call_shift_internal_api_setup, make_user_auth_headers):
+    token, user1, user2, _, schedule = on_call_shift_internal_api_setup
+    client = APIClient()
+    url = reverse("api-internal:oncall_shifts-list")
+    start_date = timezone.now().replace(microsecond=0, tzinfo=None)
+
+    data = {
+        "name": "Test Shift",
+        "type": CustomOnCallShift.TYPE_ROLLING_USERS_EVENT,
+        "schedule": schedule.public_primary_key,
+        "priority_level": 1,
+        "shift_start": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "shift_end": (start_date + timezone.timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "rotation_start": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "until": None,
+        "frequency": 1,
+        "interval": 1,
+        "by_day": [
+            CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
+            CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.FRIDAY],
+        ],
+        "week_start": CustomOnCallShift.ICAL_WEEKDAY_MAP[CustomOnCallShift.MONDAY],
+        "rolling_users": [[user1.public_primary_key], [user2.public_primary_key, "fuzz"]],
+    }
+
+    with patch("apps.schedules.models.CustomOnCallShift.refresh_schedule") as mock_refresh_schedule:
+        response = client.post(url, data, format="json", **make_user_auth_headers(user1, token))
+
+    expected_payload = {"rolling_users": {"1": ["User does not exist fuzz"]}}
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json() == expected_payload
+    mock_refresh_schedule.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/engine/apps/public_api/serializers/on_call_shifts.py
+++ b/engine/apps/public_api/serializers/on_call_shifts.py
@@ -85,7 +85,9 @@ class CustomOnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer
     rolling_users = RollingUsersField(
         allow_null=True,
         required=False,
-        child=UsersFilteredByOrganizationField(queryset=User.objects, required=False, allow_null=True),
+        child=UsersFilteredByOrganizationField(
+            queryset=User.objects, db_verification=True, required=False, allow_null=True
+        ),
     )
     rotation_start = serializers.DateTimeField(required=False)
 

--- a/engine/apps/public_api/serializers/on_call_shifts.py
+++ b/engine/apps/public_api/serializers/on_call_shifts.py
@@ -86,7 +86,7 @@ class CustomOnCallShiftSerializer(EagerLoadingMixin, serializers.ModelSerializer
         allow_null=True,
         required=False,
         child=UsersFilteredByOrganizationField(
-            queryset=User.objects, db_verification=True, required=False, allow_null=True
+            queryset=User.objects, require_all_exist=True, required=False, allow_null=True
         ),
     )
     rotation_start = serializers.DateTimeField(required=False)

--- a/engine/apps/public_api/tests/test_on_call_shifts.py
+++ b/engine/apps/public_api/tests/test_on_call_shifts.py
@@ -492,7 +492,7 @@ def test_create_on_call_shift_invalid_rolling_users(make_organization_and_user_w
     response = client.post(url, data=data, format="json", HTTP_AUTHORIZATION=f"{token}")
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
-    assert response.json() == {"rolling_users": {"1": ["User does not exist fuzz"]}}
+    assert response.json() == {"rolling_users": {"1": ["User does not exist {'fuzz'}"]}}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
# What this PR does
Adds validation for rolling users param in the shift api

## Which issue(s) this PR closes
Closes [5041](https://github.com/grafana/oncall/issues/5041)

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
