### PR TITLE
fix: Remove past users from schedule details page

### DIFF
--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1518,6 +1518,7 @@ def test_next_shifts_per_user(
             tomorrow + timezone.timedelta(hours=18),
             user_c.timezone,
         ),
+        user_d.public_primary_key: (None, None, user_d.timezone),
     }
     returned_data = {
         u: (ev.get("start"), ev.get("end"), ev.get("user_timezone")) for u, ev in response.data["users"].items()

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -1518,7 +1518,6 @@ def test_next_shifts_per_user(
             tomorrow + timezone.timedelta(hours=18),
             user_c.timezone,
         ),
-        user_d.public_primary_key: (None, None, user_d.timezone),
     }
     returned_data = {
         u: (ev.get("start"), ev.get("end"), ev.get("user_timezone")) for u, ev in response.data["users"].items()

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -401,24 +401,14 @@ class ScheduleView(
 
         events = schedule.final_events(now, datetime_end)
 
-        related_users = {}
+        # include user TZ information for every user
+        users = {u.public_primary_key: {"user_timezone": u.timezone} for u in schedule.related_users()}
         added_users = set()
         for e in events:
             user = e["users"][0]["pk"] if e["users"] else None
-            if user is not None and user not in added_users and e["end"] > now:
-                if user not in related_users:
-                    related_users[user] = {}
-
-                related_users[user].update(e)
+            if user is not None and user not in added_users and user in users and e["end"] > now:
+                users[user].update(e)
                 added_users.add(user)
-
-        users = {}
-        for u in schedule.related_users():
-            if u.public_primary_key in related_users:
-                users[u.public_primary_key] = {}
-                # include user TZ information for every user
-                users[u.public_primary_key]["user_timezone"] = u.timezone
-                users[u.public_primary_key].update(related_users[u.public_primary_key])
 
         result = {"users": users}
         return Response(result, status=status.HTTP_200_OK)

--- a/engine/apps/schedules/models/shift_swap_request.py
+++ b/engine/apps/schedules/models/shift_swap_request.py
@@ -181,7 +181,7 @@ class ShiftSwapRequest(models.Model):
 
     @property
     def possible_benefactors(self) -> QuerySet["User"]:
-        return self.schedule.related_users().exclude(pk=self.beneficiary_id)
+        return self.schedule.users_in_future_schedule().exclude(pk=self.beneficiary_id)
 
     @property
     def web_link(self) -> str:

--- a/engine/apps/schedules/tests/test_shift_swap_request.py
+++ b/engine/apps/schedules/tests/test_shift_swap_request.py
@@ -183,6 +183,6 @@ def test_related_shifts(shift_swap_request_setup, make_on_call_shift) -> None:
 def test_possible_benefactors(shift_swap_request_setup) -> None:
     ssr, beneficiary, benefactor = shift_swap_request_setup()
 
-    with patch.object(ssr.schedule, "related_users") as mock_related_users:
+    with patch.object(ssr.schedule, "users_in_future_schedule") as mock_related_users:
         mock_related_users.return_value = User.objects.filter(pk__in=[beneficiary.pk, benefactor.pk])
         assert list(ssr.possible_benefactors) == [benefactor]


### PR DESCRIPTION
# What this PR does
Removes users from schedule details page if the user does not have any future events

## Which issue(s) this PR closes
[#4936](https://github.com/grafana/oncall/issues/4936)

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
