### PR TITLE
Check for invalid urls in slack

### DIFF
--- a/engine/config_integrations/alertmanager.py
+++ b/engine/config_integrations/alertmanager.py
@@ -107,7 +107,7 @@ Annotations:
 # Slack
 slack_title = """\
 *<{{ grafana_oncall_link }}|#{{ grafana_oncall_incident_id }} {{ web_title }}>* via {{ integration_name }}
-{% if source_link %}
+{% if source_link and (source_link[:8] == "https://" or source_link[:7] == "http://") %}
  (*<{{ source_link }}|source>*)
 {%- endif %}
 """

--- a/engine/config_integrations/grafana_alerting.py
+++ b/engine/config_integrations/grafana_alerting.py
@@ -109,7 +109,7 @@ Annotations:
 # Slack
 slack_title = """\
 *<{{ grafana_oncall_link }}|#{{ grafana_oncall_incident_id }} {{ web_title }}>* via {{ integration_name }}
-{% if source_link %}
+{% if source_link and (source_link[:8] == "https://" or source_link[:7] == "http://") %}
  (*<{{ source_link }}|source>*)
 {%- endif %}
 """


### PR DESCRIPTION
# What this PR does


We recently changed the default template (https://github.com/grafana/oncall/pull/5005) but some alertmanagers may send invalid URLs.

Our fronted has the check for invalid URLs ("he Integration template Source Link is invalid"), but slack does not, so I added this check


## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
