### PR TITLE
security: Update docker redis image to v7.0.15

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -193,7 +193,7 @@ jobs:
       ONCALL_TESTING_RBAC_ENABLED: ${{ matrix.rbac_enabled }}
     services:
       redis_test:
-        image: redis:7.0.5
+        image: redis:7.0.15
         ports:
           - 6379:6379
         options: >-

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -172,7 +172,7 @@ services:
   redis:
     container_name: redis
     labels: *oncall-labels
-    image: redis:7.0.5
+    image: redis:7.0.15
     restart: always
     ports:
       - "6379:6379"

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -87,7 +87,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7.0.5
+    image: redis:7.0.15
     restart: always
     expose:
       - 6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
         condition: service_healthy
 
   redis:
-    image: redis:7.0.5
+    image: redis:7.0.15
     restart: always
     expose:
       - 6379


### PR DESCRIPTION
# What this PR does
Updating docker image for Redis to latest version on 7.0 branch

## Which issue(s) this PR closes
* (CVE-2022-35977) Integer overflow in the Redis SETRANGE and SORT/SORT_RO
  commands can drive Redis to OOM panic
* (CVE-2023-22458) Integer overflow in the Redis HRANDFIELD and ZRANDMEMBER
  commands can lead to denial-of-service
* (CVE-2023-25155) Specially crafted SRANDMEMBER, ZRANDMEMBER, and HRANDFIELD
  commands can trigger an integer overflow, resulting in a runtime assertion
  and termination of the Redis server process.
* (CVE-2022-36021) String matching commands (like SCAN or KEYS) with a specially
  crafted pattern to trigger a denial-of-service attack on Redis, causing it to
  hang and consume 100% CPU time.
* (CVE-2023-28425) Specially crafted MSETNX command can lead to assertion and denial-of-service
* (CVE-2023-28856) Authenticated users can use the HINCRBYFLOAT command to create
  an invalid hash field that will crash Redis on access
* (CVE-2022-24834) A specially crafted Lua script executing in Redis can trigger
  a heap overflow in the cjson and cmsgpack libraries, and result in heap
  corruption and potentially remote code execution. The problem exists in all
  versions of Redis with Lua scripting support, starting from 2.6, and affects
  only authenticated and authorized users.
* (CVE-2023-36824) Extracting key names from a command and a list of arguments
  may, in some cases, trigger a heap overflow and result in reading random heap
  memory, heap corruption and potentially remote code execution. Specifically:
  using COMMAND GETKEYS* and validation of key names in ACL rules.
* (CVE-2023-41053) Redis does not correctly identify keys accessed by SORT_RO and
  as a result may grant users executing this command access to keys that are not
  explicitly authorized by the ACL configuration.
* (CVE-2023-45145) The wrong order of listen(2) and chmod(2) calls creates a
  race condition that can be used by another process to bypass desired Unix
  socket permissions on startup.
* (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory
  buffers which can result in incorrect accounting of buffer sizes and lead to
  heap overflow and potential remote code execution.


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
