### PR TITLE
Add default value for `started_at` filter for `/alertgroups` internal endpoint

### DIFF
--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -339,7 +339,6 @@ class AlertGroupView(
         queryset = AlertGroup.objects.filter(channel__in=alert_receive_channels_ids)
 
         # This is a quick fix to speed up requests from mobile app by adding default `started_at` filter value
-        # if there is no `started_at` value in query params, add default value
         if not self.request.query_params.get("started_at"):
             queryset = self._add_default_filter_started_at(queryset)
 

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -310,12 +310,6 @@ class AlertGroupView(
 
         return super().get_serializer_class()
 
-    def _add_default_filter_started_at(self, queryset):
-        DEFAULT_STARTED_AT_TIMERANGE_DAYS = 30
-        end_time = timezone.now()
-        start_time = end_time - timedelta(days=DEFAULT_STARTED_AT_TIMERANGE_DAYS)
-        return queryset.filter(started_at__gte=start_time, started_at__lte=end_time)
-
     def get_queryset(self, ignore_filtering_by_available_teams=False):
         # no select_related or prefetch_related is used at this point, it will be done on paginate_queryset.
 
@@ -340,7 +334,7 @@ class AlertGroupView(
 
         # This is a quick fix to speed up requests from mobile app by adding default `started_at` filter value
         if not self.request.query_params.get("started_at"):
-            queryset = self._add_default_filter_started_at(queryset)
+            queryset = queryset.filter(started_at__gte=timezone.now() - timezone.timedelta(days=30))
 
         if self.action in ("list", "stats") and settings.ALERT_GROUPS_DISABLE_PREFER_ORDERING_INDEX:
             # workaround related to MySQL "ORDER BY LIMIT Query Optimizer Bug"


### PR DESCRIPTION
# What this PR does
Adds default value for `started_at` filter for `/alertgroups` internal endpoint

## Which issue(s) this PR closes

Related to https://raintank-corp.slack.com/archives/C06K1MQ07GS/p1727184726971589?thread_ts=1727162658.629509&cid=C06K1MQ07GS

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
