### PR TITLE
fix "on helm release pr merged" GitHub Actions workflow

### DIFF
--- a/.github/workflows/on-helm-release-pr-merged.yml
+++ b/.github/workflows/on-helm-release-pr-merged.yml
@@ -8,11 +8,35 @@ on:
       - helm/oncall/Chart.yaml
 
 jobs:
+  get-irm-app-token:
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate-token.outputs.token }}
+    steps:
+      - name: Get Vault secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GH_APP_ID=github-app:app-id
+            GH_APP_PRIVATE_KEY=github-app:private-key
+
+      - name: Generate Github App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.GH_APP_ID }}
+          private-key: ${{ env.GH_APP_PRIVATE_KEY }}
+          owner: grafana
+          repositories: "helm-charts"
+
   call-update-helm-repo:
     uses: grafana/helm-charts/.github/workflows/update-helm-repo.yaml@main
+    needs:
+      - get-irm-app-token
     with:
       charts_dir: helm
       cr_configfile: helm/cr.yaml
       ct_configfile: helm/ct.yaml
     secrets:
-      helm_repo_token: ${{ secrets.GH_HELM_RELEASE }}
+      helm_repo_token: ${{ needs.get-irm-app-token.outputs.token }}

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -22,7 +22,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: rabbitmq.enabled
   - name: redis
-    version: 20.0.5
+    version: 16.13.2
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
   - name: grafana


### PR DESCRIPTION
# What this PR does

- Closes https://github.com/grafana/oncall/issues/5065
- Fixes [failing update Helm repo github workflows](https://github.com/grafana/oncall/actions/workflows/on-helm-release-pr-merged.yml) (due to `secrets. GH_HELM_RELEASE` now seeming to return "Bad credentials")

## TODO

- [ ] after this PR is merged and change merged to `main`, remove `GH_HELM_RELEASE` repository secret

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
