### PR TITLE
migrate metrics path to /metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We prepared multiple environments:
 
    scrape_configs:
      - job_name: prometheus
-       metrics_path: /metrics/
+       metrics_path: /metrics
        authorization:
          credentials: my_random_prometheus_secret
        static_configs:

--- a/dev/helm-local.yml
+++ b/dev/helm-local.yml
@@ -152,7 +152,7 @@ prometheus:
       scrape_interval: 10s
   extraScrapeConfigs: |
     - job_name: 'oncall-exporter'
-      metrics_path: /metrics/
+      metrics_path: /metrics
       static_configs:
         - targets:
           - oncall-dev-engine.default.svc.cluster.local:8080

--- a/engine/apps/metrics_exporter/urls.py
+++ b/engine/apps/metrics_exporter/urls.py
@@ -1,7 +1,7 @@
-from django.urls import path
+from django.urls import re_path
 
 from .views import MetricsExporterView
 
 urlpatterns = [
-    path("", MetricsExporterView.as_view(), name="metrics-exporter"),
+    re_path(r"^/?$", MetricsExporterView.as_view(), name="metrics-exporter"),
 ]

--- a/engine/engine/urls.py
+++ b/engine/engine/urls.py
@@ -48,7 +48,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
 
 if settings.FEATURE_PROMETHEUS_EXPORTER_ENABLED:
     urlpatterns += [
-        path("metrics/", include("apps.metrics_exporter.urls")),
+        path("metrics", include("apps.metrics_exporter.urls")),
     ]
 
 if settings.FEATURE_TELEGRAM_INTEGRATION_ENABLED:

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -722,7 +722,7 @@ prometheus:
   enabled: false
   # extraScrapeConfigs: |
   #   - job_name: 'oncall-exporter'
-  #     metrics_path: /metrics/
+  #     metrics_path: /metrics
   #     static_configs:
   #       - targets:
   #         - oncall-dev-engine.default.svc.cluster.local:8080


### PR DESCRIPTION
This resolves #3597

# What this PR does
Migrate the `/metrics/` to conform to 
## Which issue(s) this PR closes

Closes #3597 



## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
