### PR TITLE
Update schedule related users to use cached final representation

### DIFF
--- a/engine/apps/alerts/tests/test_paging.py
+++ b/engine/apps/alerts/tests/test_paging.py
@@ -48,6 +48,7 @@ def test_user_is_oncall(make_organization, make_user_for_organization, make_sche
     )
     on_call_shift.add_rolling_users([[oncall_user]])
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
 
     assert user_is_oncall(not_oncall_user) is False
     assert user_is_oncall(oncall_user) is True

--- a/engine/apps/api/tests/test_schedules.py
+++ b/engine/apps/api/tests/test_schedules.py
@@ -435,6 +435,7 @@ def test_get_list_schedules_by_mine(
     )
     override.add_rolling_users([[user]])
     web_schedule.refresh_ical_file()
+    web_schedule.refresh_ical_final_schedule()
 
     url = reverse("api-internal:schedule-list") + query_param
     response = client.get(url, format="json", **make_user_auth_headers(user, token))
@@ -1497,6 +1498,7 @@ def test_next_shifts_per_user(
     override.add_rolling_users([[user_c]])
 
     # final schedule: 7-12: B, 15-16: A, 16-17: B, 17-18: C (override), 18-20: C
+    schedule.refresh_ical_final_schedule()
 
     url = reverse("api-internal:schedule-next-shifts-per-user", kwargs={"pk": schedule.public_primary_key})
     response = client.get(url, format="json", **make_user_auth_headers(admin, token))
@@ -1569,6 +1571,7 @@ def test_next_shifts_per_user_ical_schedule_using_emails(
         schedule_class=OnCallScheduleICal,
         cached_ical_file_primary=cached_ical_primary_schedule,
     )
+    schedule.refresh_ical_final_schedule()
 
     url = reverse("api-internal:schedule-next-shifts-per-user", kwargs={"pk": schedule.public_primary_key})
     response = client.get(url, format="json", **make_user_auth_headers(admin, token))
@@ -1628,6 +1631,7 @@ def test_related_users(
     )
     override.add_rolling_users([[user_c]])
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
 
     url = reverse("api-internal:schedule-related-users", kwargs={"pk": schedule.public_primary_key})
     response = client.get(url, format="json", **make_user_auth_headers(admin, token))

--- a/engine/apps/mobile_app/tests/tasks/test_new_shift_swap_request.py
+++ b/engine/apps/mobile_app/tests/tasks/test_new_shift_swap_request.py
@@ -229,6 +229,7 @@ def test_notify_shift_swap_request_success(
         on_call_shift.add_rolling_users([[user]])
 
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
     schedule.refresh_from_db()
 
     swap_start = now + timezone.timedelta(days=100)

--- a/engine/apps/slack/tests/test_scenario_steps/test_manage_responders.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_manage_responders.py
@@ -114,6 +114,7 @@ def test_add_user_no_warning(manage_responders_setup, make_schedule, make_on_cal
     )
     on_call_shift.add_rolling_users([[user]])
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
     # setup notification policy
     make_user_notification_policy(
         user=user,
@@ -199,6 +200,7 @@ def test_get_users_select(make_organization, make_user, make_schedule, make_on_c
     )
     on_call_shift.add_rolling_users([[oncall_user]])
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
 
     select_input = _get_users_select(
         organization=organization, input_id_prefix="test", action_id="test", max_options_per_group=2

--- a/engine/apps/slack/tests/test_scenario_steps/test_paging.py
+++ b/engine/apps/slack/tests/test_scenario_steps/test_paging.py
@@ -186,6 +186,7 @@ def test_add_user_no_warning(make_organization_and_user_with_slack_identities, m
     )
     on_call_shift.add_rolling_users([[user]])
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
 
     payload = make_paging_view_slack_payload(selected_org=organization, user=user)
 
@@ -221,6 +222,7 @@ def test_add_user_maximum_exceeded(make_organization_and_user_with_slack_identit
     )
     on_call_shift.add_rolling_users([[user]])
     schedule.refresh_ical_file()
+    schedule.refresh_ical_final_schedule()
 
     payload = make_paging_view_slack_payload(selected_org=organization, user=user)
 


### PR DESCRIPTION
Related to https://github.com/grafana/oncall/issues/4936

Cached final schedule keeps a (now - 15d, now + 6m) window representation of a schedule (this representation always use users' username; it will un-relate users that are not anymore associated to a schedule).