### PR TITLE
fix alert group page bug

### DIFF
--- a/engine/apps/api/tests/test_alert_group.py
+++ b/engine/apps/api/tests/test_alert_group.py
@@ -2344,3 +2344,41 @@ def test_alert_group_external_urls(
         "url": "https://some-url",
     }
     assert response.json()["external_urls"] == [expected]
+
+
+@pytest.mark.django_db
+def test_filter_default_started_at(
+    make_organization_and_user_with_plugin_token,
+    make_alert_receive_channel,
+    make_channel_filter,
+    make_alert_group,
+    make_alert,
+    make_user_auth_headers,
+):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    alert_receive_channel = make_alert_receive_channel(organization)
+    channel_filter = make_channel_filter(alert_receive_channel, is_default=True)
+
+    old_alert_group = make_alert_group(alert_receive_channel, channel_filter=channel_filter)
+    old_alert_group.started_at = timezone.now() - timezone.timedelta(days=31)
+    old_alert_group.save(update_fields=["started_at"])
+    make_alert(alert_group=old_alert_group, raw_request_data=alert_raw_request_data)
+
+    new_alert_group = make_alert_group(alert_receive_channel, channel_filter=channel_filter)
+    make_alert(alert_group=new_alert_group, raw_request_data=alert_raw_request_data)
+
+    client = APIClient()
+
+    # by default, no alert groups older than 30 days should be listed
+    response = client.get(reverse("api-internal:alertgroup-list"), **make_user_auth_headers(user, token))
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"][0]["pk"] == new_alert_group.public_primary_key
+
+    # but it should still be possible to retrieve an old alert group by its ID
+    response = client.get(
+        reverse("api-internal:alertgroup-detail", kwargs={"pk": old_alert_group.public_primary_key}),
+        **make_user_auth_headers(user, token),
+    )
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json()["pk"] == old_alert_group.public_primary_key

--- a/engine/apps/api/views/alert_group.py
+++ b/engine/apps/api/views/alert_group.py
@@ -332,8 +332,7 @@ class AlertGroupView(
         alert_receive_channels_ids = list(alert_receive_channels_qs.values_list("id", flat=True))
         queryset = AlertGroup.objects.filter(channel__in=alert_receive_channels_ids)
 
-        # This is a quick fix to speed up requests from mobile app by adding default `started_at` filter value
-        if not self.request.query_params.get("started_at"):
+        if self.action in ("list", "stats") and not self.request.query_params.get("started_at"):
             queryset = queryset.filter(started_at__gte=timezone.now() - timezone.timedelta(days=30))
 
         if self.action in ("list", "stats") and settings.ALERT_GROUPS_DISABLE_PREFER_ORDERING_INDEX:


### PR DESCRIPTION
# What this PR does

fixes a bug where it's not possible to view an alert group older than 30 days

<img width="623" alt="Screenshot 2024-10-01 at 14 36 00" src="https://github.com/user-attachments/assets/c06c923e-4c1c-4873-bf4b-9296cfbbb312">

## Which issue(s) this PR closes

the bug was introduced in https://github.com/grafana/oncall/pull/5067

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
