### PR TITLE
fix: don't update Slack messages if resolution note text not changed

### DIFF
--- a/engine/apps/public_api/tests/test_resolution_notes.py
+++ b/engine/apps/public_api/tests/test_resolution_notes.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -106,8 +107,14 @@ def test_get_resolution_note(
     assert response.data == result
 
 
+@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
-def test_create_resolution_note(make_organization_and_user_with_token, make_alert_receive_channel, make_alert_group):
+def test_create_resolution_note(
+    mock_send_update_resolution_note_signal,
+    make_organization_and_user_with_token,
+    make_alert_receive_channel,
+    make_alert_group,
+):
     organization, user, token = make_organization_and_user_with_token()
     client = APIClient()
 
@@ -137,6 +144,8 @@ def test_create_resolution_note(make_organization_and_user_with_token, make_aler
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data == result
 
+    mock_send_update_resolution_note_signal.assert_called_once()
+
 
 @pytest.mark.django_db
 def test_create_resolution_note_invalid_text(
@@ -163,8 +172,10 @@ def test_create_resolution_note_invalid_text(
     assert response.data["text"][0] == "This field may not be blank."
 
 
+@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
 def test_update_resolution_note(
+    mock_send_update_resolution_note_signal,
     make_organization_and_user_with_token,
     make_alert_receive_channel,
     make_alert_group,
@@ -206,6 +217,39 @@ def test_update_resolution_note(
     assert resolution_note.text == result["text"]
     assert response.data == result
 
+    mock_send_update_resolution_note_signal.assert_called_once()
+
+
+@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
+@pytest.mark.django_db
+def test_update_resolution_note_same_text(
+    mock_send_update_resolution_note_signal,
+    make_organization_and_user_with_token,
+    make_alert_receive_channel,
+    make_alert_group,
+    make_resolution_note,
+):
+    organization, user, token = make_organization_and_user_with_token()
+    client = APIClient()
+
+    alert_receive_channel = make_alert_receive_channel(organization)
+    alert_group = make_alert_group(alert_receive_channel)
+
+    resolution_note = make_resolution_note(
+        alert_group=alert_group,
+        source=ResolutionNote.Source.WEB,
+        author=user,
+    )
+
+    url = reverse("api-public:resolution_notes-detail", kwargs={"pk": resolution_note.public_primary_key})
+    response = client.put(
+        url, data={"text": resolution_note.message_text}, format="json", HTTP_AUTHORIZATION=f"{token}"
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # update signal shouldn't be sent when text doesn't change
+    mock_send_update_resolution_note_signal.assert_not_called()
+
 
 @pytest.mark.django_db
 def test_update_resolution_note_invalid_source(
@@ -242,8 +286,10 @@ def test_update_resolution_note_invalid_source(
     assert response.data["detail"] == "Cannot update message with this source type"
 
 
+@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
 def test_delete_resolution_note(
+    mock_send_update_resolution_note_signal,
     make_organization_and_user_with_token,
     make_alert_receive_channel,
     make_alert_group,
@@ -272,6 +318,7 @@ def test_delete_resolution_note(
     resolution_note.refresh_from_db()
 
     assert resolution_note.deleted_at is not None
+    mock_send_update_resolution_note_signal.assert_called_once()
 
     response = client.get(url, format="json", HTTP_AUTHORIZATION=f"{token}")
 

--- a/engine/apps/public_api/tests/test_resolution_notes.py
+++ b/engine/apps/public_api/tests/test_resolution_notes.py
@@ -1,4 +1,3 @@
-from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -107,7 +106,7 @@ def test_get_resolution_note(
     assert response.data == result
 
 
-@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
+@patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
 def test_create_resolution_note(
     mock_send_update_resolution_note_signal,
@@ -172,7 +171,7 @@ def test_create_resolution_note_invalid_text(
     assert response.data["text"][0] == "This field may not be blank."
 
 
-@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
+@patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
 def test_update_resolution_note(
     mock_send_update_resolution_note_signal,
@@ -220,7 +219,7 @@ def test_update_resolution_note(
     mock_send_update_resolution_note_signal.assert_called_once()
 
 
-@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
+@patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
 def test_update_resolution_note_same_text(
     mock_send_update_resolution_note_signal,
@@ -286,7 +285,7 @@ def test_update_resolution_note_invalid_source(
     assert response.data["detail"] == "Cannot update message with this source type"
 
 
-@mock.patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
+@patch("apps.alerts.tasks.send_update_resolution_note_signal.send_update_resolution_note_signal.apply_async")
 @pytest.mark.django_db
 def test_delete_resolution_note(
     mock_send_update_resolution_note_signal,


### PR DESCRIPTION
# What this PR does

Reduces the number of `chat.update` Slack API calls when a resolution note is updated with the same text.

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
