### PR TITLE
Fix error encoding on install_v2 endpoint

### DIFF
--- a/engine/apps/grafana_plugin/tests/test_install_v2.py
+++ b/engine/apps/grafana_plugin/tests/test_install_v2.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.grafana_plugin.views.sync_v2 import SyncException
+from common.api_helpers.errors import INVALID_SELF_HOSTED_ID
+
+
+@pytest.mark.django_db
+def test_install_v2_error_encoding(make_organization_and_user_with_plugin_token, make_user_auth_headers):
+    organization, user, token = make_organization_and_user_with_plugin_token()
+    client = APIClient()
+
+    auth_headers = make_user_auth_headers(user, token)
+
+    exc = SyncException(INVALID_SELF_HOSTED_ID)
+
+    with patch("apps.grafana_plugin.views.InstallV2View.do_sync", side_effect=exc):
+        response = client.post(reverse("grafana-plugin:install-v2"), format="json", **auth_headers)
+        assert response.data["code"] == INVALID_SELF_HOSTED_ID.code
+        assert response.data["message"] == INVALID_SELF_HOSTED_ID.message
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/engine/apps/grafana_plugin/views/install_v2.py
+++ b/engine/apps/grafana_plugin/views/install_v2.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
 
 from django.conf import settings
 from rest_framework import status
@@ -23,7 +23,10 @@ class InstallV2View(SyncV2View):
         try:
             organization = self.do_sync(request)
         except SyncException as e:
-            return Response(data=e.error_data, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                data=asdict(e.error_data) if is_dataclass(e.error_data) else e.error_data,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         organization.revoke_plugin()
         provisioned_data = organization.provision_plugin()


### PR DESCRIPTION
# What this PR does
Fixes incorrect encoding when SyncException contains one of the predefined dataclass errors in install_v2 endpoint.

## Which issue(s) this PR closes

Related to #5124 

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
