### PR TITLE
fix: no longer set `AlertGroup.resolved_by_alert`

### DIFF
--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -25,8 +25,6 @@ from common.jinja_templater.apply_jinja_template import (
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
 
 if typing.TYPE_CHECKING:
-    from django.db.models.manager import RelatedManager
-
     from apps.alerts.models import AlertGroup, AlertReceiveChannel, ChannelFilter
 
 logger = logging.getLogger(__name__)

--- a/engine/apps/alerts/models/alert.py
+++ b/engine/apps/alerts/models/alert.py
@@ -49,7 +49,6 @@ def generate_public_primary_key_for_alert():
 
 class Alert(models.Model):
     group: typing.Optional["AlertGroup"]
-    resolved_alert_groups: "RelatedManager['AlertGroup']"
 
     public_primary_key = models.CharField(
         max_length=20,
@@ -162,11 +161,6 @@ class Alert(models.Model):
         )
         if not group.resolved and mark_as_resolved:
             group.resolve_by_source()
-
-        # Store exact alert which resolved group.
-        if group.resolved_by == AlertGroup.SOURCE and group.resolved_by_alert is None:
-            group.resolved_by_alert = alert
-            group.save(update_fields=["resolved_by_alert"])
 
         if group_created:
             # all code below related to maintenance mode

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -40,6 +40,7 @@ if typing.TYPE_CHECKING:
     from django.db.models.manager import RelatedManager
 
     from apps.alerts.models import (
+        Alert,
         AlertGroupLogRecord,
         AlertReceiveChannel,
         BundledNotification,

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -287,13 +287,15 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         related_name="resolved_alert_groups",
     )
 
-    resolved_by_alert = deprecate_field(models.ForeignKey(
-        "alerts.Alert",
-        on_delete=models.SET_NULL,
-        null=True,
-        default=None,
-        related_name="resolved_alert_groups",
-    ))
+    resolved_by_alert = deprecate_field(
+        models.ForeignKey(
+            "alerts.Alert",
+            on_delete=models.SET_NULL,
+            null=True,
+            default=None,
+            related_name="resolved_alert_groups",
+        )
+    )
 
     resolved_at = models.DateTimeField(blank=True, null=True)
     acknowledged = models.BooleanField(default=False)

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -288,6 +288,8 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         related_name="resolved_alert_groups",
     )
 
+    # NOTE: see https://raintank-corp.slack.com/archives/C07RGREUH4Z/p1728494111646319
+    # This field should eventually be dropped as it's no longer being set/read anywhere
     resolved_by_alert = deprecate_field(
         models.ForeignKey(
             "alerts.Alert",

--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -12,6 +12,7 @@ from django.db import IntegrityError, models, transaction
 from django.db.models import JSONField, Q, QuerySet
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django_deprecate_fields import deprecate_field
 
 from apps.alerts.constants import ActionSource, AlertGroupState
 from apps.alerts.escalation_snapshot import EscalationSnapshotMixin
@@ -39,7 +40,6 @@ if typing.TYPE_CHECKING:
     from django.db.models.manager import RelatedManager
 
     from apps.alerts.models import (
-        Alert,
         AlertGroupLogRecord,
         AlertReceiveChannel,
         BundledNotification,
@@ -200,7 +200,6 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
     personal_log_records: "RelatedManager['UserNotificationPolicyLogRecord']"
     resolution_notes: "RelatedManager['ResolutionNote']"
     resolution_note_slack_messages: "RelatedManager['ResolutionNoteSlackMessage']"
-    resolved_by_alert: typing.Optional["Alert"]
     resolved_by_user: typing.Optional["User"]
     root_alert_group: typing.Optional["AlertGroup"]
     silenced_by_user: typing.Optional["User"]
@@ -288,13 +287,13 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         related_name="resolved_alert_groups",
     )
 
-    resolved_by_alert = models.ForeignKey(
+    resolved_by_alert = deprecate_field(models.ForeignKey(
         "alerts.Alert",
         on_delete=models.SET_NULL,
         null=True,
         default=None,
         related_name="resolved_alert_groups",
-    )
+    ))
 
     resolved_at = models.DateTimeField(blank=True, null=True)
     acknowledged = models.BooleanField(default=False)

--- a/engine/apps/user_management/tests/test_organization.py
+++ b/engine/apps/user_management/tests/test_organization.py
@@ -116,8 +116,6 @@ def test_organization_hard_delete(
     )
 
     alert = make_alert(alert_group=alert_group, raw_request_data={})
-    alert_group.resolved_by_alert = alert
-    alert_group.save(update_fields=["resolved_by_alert"])
 
     user_notification_policy_log_record = make_user_notification_policy_log_record(
         author=user_1,


### PR DESCRIPTION
# What this PR does

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
