### PR TITLE
Add phone number to serialised users for webhooks

### DIFF
--- a/engine/apps/webhooks/utils.py
+++ b/engine/apps/webhooks/utils.py
@@ -122,6 +122,7 @@ def _serialize_event_user(user):
         "id": user.public_primary_key,
         "username": user.username,
         "email": user.email,
+        "phone_number": user.verified_phone_number,
     }
 
 


### PR DESCRIPTION
# What this PR does

Adds a phone number to the serialised user information included in the payload for webhooks. The `phone_number` will be null if no verified phone number is available.

## Which issue(s) this PR closes

Closes #5154 

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
