### PR TITLE
helm: allow specific pod annotations for migration job

### DIFF
--- a/helm/oncall/templates/engine/job-migrate.yaml
+++ b/helm/oncall/templates/engine/job-migrate.yaml
@@ -27,10 +27,15 @@ spec:
   template:
     metadata:
       name: {{ printf "%s-migrate-%s" (include "oncall.engine.fullname" .) (now | date "2006-01-02-15-04-05") }}
-      {{- with .Values.podAnnotations }}
+      {{- if or (.Values.podAnnotations ) (.Values.migrate.annotations) }}
       annotations:
         random-annotation: {{ randAlphaNum 10 | lower }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrate.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       labels:
         {{- include "oncall.engine.selectorLabels" . | nindent 8 }}

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -385,6 +385,7 @@ migrate:
   ttlSecondsAfterFinished: 20
   # use a helm hook to manage the migration job
   useHook: false
+  # Annotations for the job and job template
   annotations: {}
 
   ## Affinity for pod assignment


### PR DESCRIPTION
# What this PR does

This pr adds the possibility to add specific annotations to the migration job pod

## Motivation

Because Kubernetes jobs and services mesh applications are not that compatible in regards to finishing jobs and removing service mesh sidecar proxy containers these jobs stay forever.

With this change these pods can be explicitly marked via the annotation to skip the service mesh injection

For example:

If you are running a linkerd service mesh all pods within a namespace are automatically injected via an annotation to the namespace.
This leads to Kubernetes jobs to never finish because the proxy is never finished.
To disable this behaviour you can add the "linkerd.io/inject: disabled" annotation to the pod. This skips the injection process for this pod and the job then is finished.

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
