### PR TITLE
chore: fixed headers in user setting tabs #4335 (pr:no public docs)

### DIFF
--- a/grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx
@@ -72,9 +72,9 @@ export const Tabs = ({
         />
       )}
       {showGoogleCalendarTab && (
-        <Tab
+        <Tab"Google Calendar"
           active={activeTab === UserSettingsTab.GoogleCalendar}
-          label="Google Calendar"
+          label=
           key={UserSettingsTab.GoogleCalendar}
           onChangeTab={getTabClickHandler(UserSettingsTab.GoogleCalendar)}
           data-testid="google-calendar-tab"
@@ -90,7 +90,7 @@ export const Tabs = ({
       {showMobileAppConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.MobileAppConnection}
-          label="Mobile App Connection"
+          label="Mobile App"
           key={UserSettingsTab.MobileAppConnection}
           onChangeTab={getTabClickHandler(UserSettingsTab.MobileAppConnection)}
           data-testid="tab-mobile-app"
@@ -99,7 +99,7 @@ export const Tabs = ({
       {showSlackConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.SlackInfo}
-          label="Slack Connection"
+          label="Slack"
           key={UserSettingsTab.SlackInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.SlackInfo)}
           data-testid="tab-slack"
@@ -108,7 +108,7 @@ export const Tabs = ({
       {showTelegramConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.TelegramInfo}
-          label="Telegram Connection"
+          label="Telegram"
           key={UserSettingsTab.TelegramInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.TelegramInfo)}
           data-testid="tab-telegram"
@@ -117,7 +117,7 @@ export const Tabs = ({
       {showMsTeamsConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.MSTeamsInfo}
-          label="Ms Teams Connection"
+          label="MS Teams"
           key={UserSettingsTab.MSTeamsInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.MSTeamsInfo)}
           data-testid="tab-msteams"


### PR DESCRIPTION
# What this PR does
Removed long names in connections, spelling typo of "MS Teams"
## Which issue(s) this PR closes

Related to #4335

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
