### PR TITLE
feat(app/integrations): Add rate_limit to AlertReceiverChannel

### DIFF
--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -291,6 +291,7 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
     alertmanager_v2_backup_templates: AlertmanagerV2LegacyTemplates | None = models.JSONField(null=True, default=None)
     """Backing up templates before the Alertmanager V2 migration, so that they can be restored if needed."""
 
+    rate_limit = models.CharField(max_length=100, null=True, default=None)
     rate_limited_in_slack_at = models.DateTimeField(null=True, default=None)
     rate_limit_message_task_id = models.CharField(max_length=100, null=True, default=None)
 

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -313,6 +313,7 @@ class AlertReceiveChannelSerializer(
             "labels",
             "alert_group_labels",
             "alertmanager_v2_migrated_at",
+            "rate_limit"
             "additional_settings",
         ]
         read_only_fields = [

--- a/engine/apps/integrations/mixins/ratelimit_mixin.py
+++ b/engine/apps/integrations/mixins/ratelimit_mixin.py
@@ -41,6 +41,10 @@ def get_rate_limit_per_organization_key(_, request):
 
 
 def get_rate_limit(group, request):
+    # Return the configured rate limit for the alert receiver channel
+    if request.alert_receive_channel.rate_limit:
+        return request.alert_receive_channel.rate_limit
+
     custom_ratelimits = settings.CUSTOM_RATELIMITS
 
     organization_id = str(request.alert_receive_channel.organization_id)


### PR DESCRIPTION
The rate limit added to AlertReceiverChannel model
Related to https://github.com/grafana/oncall/issues/5035