### PR TITLE
Fix acknowledge reminder task

### DIFF
--- a/engine/apps/alerts/signals.py
+++ b/engine/apps/alerts/signals.py
@@ -24,6 +24,9 @@ alert_group_update_log_report_signal = django.dispatch.Signal()
 # Signal to rerender alert group's resolution note in all connected integrations (Slack)
 alert_group_update_resolution_note_signal = django.dispatch.Signal()
 
+# Signal to post acknowledge reminder message (Slack)
+post_ack_reminder_message_signal = django.dispatch.Signal()
+
 # Currently only writes error in Slack thread while notify user. Maybe it is worth to delete it?
 user_notification_action_triggered_signal = django.dispatch.Signal()
 
@@ -38,6 +41,10 @@ alert_group_action_triggered_signal.connect(
 
 alert_group_update_resolution_note_signal.connect(
     AlertGroupSlackRepresentative.on_alert_group_update_resolution_note,
+)
+
+post_ack_reminder_message_signal.connect(
+    AlertGroupSlackRepresentative.on_alert_group_post_acknowledge_reminder_message,
 )
 
 user_notification_action_triggered_signal.connect(

--- a/engine/apps/slack/representatives/alert_group_representative.py
+++ b/engine/apps/slack/representatives/alert_group_representative.py
@@ -284,4 +284,6 @@ class AlertGroupSlackRepresentative(AlertGroupAbstractRepresentative):
                 log_record = AlertGroupLogRecord.objects.get(pk=log_record_id)
             except AlertGroupLogRecord.DoesNotExist:
                 logger.warning(f"log record {log_record_id} never created or has been deleted")
+        else:
+            log_record = log_record_id
         return log_record

--- a/engine/apps/telegram/alert_group_representative.py
+++ b/engine/apps/telegram/alert_group_representative.py
@@ -41,7 +41,6 @@ class AlertGroupTelegramRepresentative(AlertGroupAbstractRepresentative):
             AlertGroupLogRecord.TYPE_AUTO_UN_ACK: "alert_group_action",
             AlertGroupLogRecord.TYPE_RESOLVED: "alert_group_action",
             AlertGroupLogRecord.TYPE_UN_RESOLVED: "alert_group_action",
-            AlertGroupLogRecord.TYPE_ACK_REMINDER_TRIGGERED: "alert_group_action",
             AlertGroupLogRecord.TYPE_SILENCE: "alert_group_action",
             AlertGroupLogRecord.TYPE_UN_SILENCE: "alert_group_action",
             AlertGroupLogRecord.TYPE_ATTACHED: "alert_group_action",


### PR DESCRIPTION
# What this PR does
- Adds 10 minutes lock for acknowledge reminder task to prevent task duplicates, that causes posting multiple reminder messages and flooding in Slack threads.
- Adds a new signal for acknowledge reminder task instead of using `alert_group_action_triggered_signal` since it is used only to post reminder message in Slack thread and it's not needed to be processed by other representatives

## Which issue(s) this PR closes

Related to https://github.com/grafana/oncall-private/issues/2953

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
