### PR TITLE
Undo schedules using ical cached final data

### DIFF
--- a/engine/apps/api/serializers/schedule_base.py
+++ b/engine/apps/api/serializers/schedule_base.py
@@ -37,7 +37,7 @@ class ScheduleBaseSerializer(EagerLoadingMixin, serializers.ModelSerializer):
             "enable_web_overrides",
         ]
 
-    SELECT_RELATED = ["organization"]
+    SELECT_RELATED = ["organization", "team", "user_group"]
 
     CANT_UPDATE_USER_GROUP_WARNING = (
         "Cannot update the user group, make sure to grant user group modification rights to "

--- a/engine/apps/public_api/serializers/schedules_base.py
+++ b/engine/apps/public_api/serializers/schedules_base.py
@@ -15,7 +15,7 @@ class ScheduleBaseSerializer(EagerLoadingMixin, serializers.ModelSerializer):
     slack = serializers.DictField(required=False)
     team_id = TeamPrimaryKeyRelatedField(required=False, allow_null=True, source="team")
 
-    SELECT_RELATED = ["team"]
+    SELECT_RELATED = ["team", "user_group"]
 
     def create(self, validated_data):
         validated_data = self._correct_validated_data(validated_data)
@@ -23,9 +23,7 @@ class ScheduleBaseSerializer(EagerLoadingMixin, serializers.ModelSerializer):
         return super().create(validated_data)
 
     def get_on_call_now(self, obj):
-        users_on_call = list_users_to_notify_from_ical(
-            obj, datetime.datetime.now(datetime.timezone.utc), from_cached_final=True
-        )
+        users_on_call = list_users_to_notify_from_ical(obj, datetime.datetime.now(datetime.timezone.utc))
         if users_on_call is not None:
             return [user.public_primary_key for user in users_on_call]
         else:


### PR DESCRIPTION
Undo one of the changes from https://github.com/grafana/oncall/pull/5172 (since it seems to make the schedules endpoint a bit worse; OTOH, other changes improved latency). Eventually we may consider using the cached on-call users information instead.