### PR TITLE
Remove deprecated identify slack scope

### DIFF
--- a/engine/apps/social_auth/backends.py
+++ b/engine/apps/social_auth/backends.py
@@ -9,7 +9,7 @@ from apps.auth_token.models import GoogleOAuth2Token, SlackAuthToken
 
 # Scopes for slack user token.
 # It is main purpose - retrieve user data in SlackOAuth2V2 but we are using it in legacy code or weird Slack api cases.
-USER_SCOPE = ["channels:read", "identify", "users.profile:read", "users:read", "users:read.email"]
+USER_SCOPE = ["channels:read", "users.profile:read", "users:read", "users:read.email"]
 
 # Scopes for slack bot token.
 # It is prime token we are using for most requests to Slack api.


### PR DESCRIPTION
# What this PR does
Tested on dev (by manually changing the sign in URL in oauth flow). All works correctly


## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
