### PR TITLE
fix: pass redis SSL config to connection pool

### DIFF
--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -257,7 +257,7 @@ CACHES = {
             "DB": REDIS_DATABASE,
             "PARSER_CLASS": "redis.connection._HiredisParser",
             "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
-            "CONNECTION_POOL_CLASS_KWARGS": REDIS_SSL_CONFIG
+            "CONNECTION_POOL_KWARGS": REDIS_SSL_CONFIG
             | {
                 "max_connections": 50,
                 "timeout": 20,


### PR DESCRIPTION
# What this PR does

This fix will pass SSL config properly to redis connection pool.
django-redis passes `CONNECTION_POOL_KWARGS` and not `CONNECTION_POOL_CLASS_KWARGS` to connection pool class, related django-redis code can be seen [here](https://github.com/jazzband/django-redis/blob/5.4.0/django_redis/pool.py#L26).

Also, without this fix other settings `max_connections` and `timeout` are also not passed to connection pool.

I had issues with external Redis with in-transit encryption enabled using self-signed certs (Google managed Redis).
After changing this I can properly pass self-signed CA cert to redis client using `REDIS_SSL_CA_CERTS` env variable.

## Which issue(s) this PR closes

There is no issue created for this problem.

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
