### PR TITLE
feat: add `grafana_irm_enabled` to `GET /organization` endpoint response

### DIFF
--- a/engine/apps/api/serializers/organization.py
+++ b/engine/apps/api/serializers/organization.py
@@ -26,6 +26,7 @@ class OrganizationSerializer(EagerLoadingMixin, serializers.ModelSerializer):
 
     rbac_enabled = serializers.BooleanField(read_only=True, source="is_rbac_permissions_enabled")
     grafana_incident_enabled = serializers.BooleanField(read_only=True, source="is_grafana_incident_enabled")
+    grafana_irm_enabled = serializers.BooleanField(read_only=True, source="is_grafana_irm_enabled")
 
     SELECT_RELATED = ["slack_team_identity", "slack_channel"]
 
@@ -39,6 +40,7 @@ class OrganizationSerializer(EagerLoadingMixin, serializers.ModelSerializer):
             "slack_channel",
             "rbac_enabled",
             "grafana_incident_enabled",
+            "grafana_irm_enabled",
             "direct_paging_prefer_important_policy",
         ]
         read_only_fields = [
@@ -46,6 +48,7 @@ class OrganizationSerializer(EagerLoadingMixin, serializers.ModelSerializer):
             "slack_team_identity",
             "rbac_enabled",
             "grafana_incident_enabled",
+            "grafana_irm_enabled",
         ]
 
 


### PR DESCRIPTION
# What this PR does

Backend portion of https://github.com/grafana/oncall-mobile-app/issues/1021

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
