### PR TITLE
fix: disable accessControlOnCall for Grafana 11.3

### DIFF
--- a/.github/workflows/linting-and-tests.yml
+++ b/.github/workflows/linting-and-tests.yml
@@ -244,6 +244,7 @@ jobs:
         grafana_version:
           - 10.3.0
           - 11.2.0
+          - latest
       fail-fast: false
     with:
       grafana_version: ${{ matrix.grafana_version }}

--- a/Tiltfile
+++ b/Tiltfile
@@ -32,12 +32,23 @@ def plugin_json():
         return plugin_file
     return 'NOT_A_PLUGIN'
 
+def extra_grafana_ini():
+    return {
+        'feature_toggles': {
+            'accessControlOnCall': 'false'
+        }
+    }
+
 def extra_env():
     return {
         "GF_APP_URL": grafana_url,
         "GF_SERVER_ROOT_URL": grafana_url, 
         "GF_FEATURE_TOGGLES_ENABLE": "externalServiceAccounts",
-        "ONCALL_API_URL": "http://oncall-dev-engine:8080"
+        "ONCALL_API_URL": "http://oncall-dev-engine:8080",
+
+        # Enables managed service accounts for plugin authentication in Grafana >= 11.3
+        # https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#managed_service_accounts_enabled
+        "GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED": "true",
     }
 
 def extra_deps():
@@ -132,7 +143,16 @@ def load_grafana():
                 "GF_APP_URL": grafana_url,  # older versions of grafana need this
                 "GF_SERVER_ROOT_URL": grafana_url,
                 "GF_FEATURE_TOGGLES_ENABLE": "externalServiceAccounts",
-                "ONCALL_API_URL": "http://oncall-dev-engine:8080"
+                "ONCALL_API_URL": "http://oncall-dev-engine:8080",
+
+                # Enables managed service accounts for plugin authentication in Grafana >= 11.3
+                # https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#managed_service_accounts_enabled
+                "GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED": "true",
+            },
+            extra_grafana_ini={
+                "feature_toggles": {
+                    "accessControlOnCall": "false"
+                }
             },
         )
 # --- GRAFANA END ----

--- a/dev/helm-local.yml
+++ b/dev/helm-local.yml
@@ -47,6 +47,8 @@ externalGrafana:
 grafana:
   enabled: false
   grafana.ini:
+    feature_toggles:
+      accessControlOnCall: false
     server:
       domain: localhost:3000
       root_url: "%(protocol)s://%(domain)s"
@@ -71,6 +73,7 @@ grafana:
           value: oncallpassword
   env:
     GF_FEATURE_TOGGLES_ENABLE: externalServiceAccounts
+    GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     GF_SECURITY_ADMIN_PASSWORD: oncall
     GF_SECURITY_ADMIN_USER: oncall
     GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app

--- a/helm/oncall/values.yaml
+++ b/helm/oncall/values.yaml
@@ -639,6 +639,9 @@ grafana:
       serve_from_sub_path: true
     feature_toggles:
       enable: externalServiceAccounts
+      accessControlOnCall: false
+  env:
+    GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
   persistence:
     enabled: true
   # Disable psp as PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+


### PR DESCRIPTION
# What this PR does

Disable accessControlOnCall for Grafana 11.3

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
