### PR TITLE
Limit slack block text length when rendering alert group timeline

### DIFF
--- a/engine/apps/slack/scenarios/alertgroup_timeline.py
+++ b/engine/apps/slack/scenarios/alertgroup_timeline.py
@@ -2,6 +2,7 @@ import typing
 
 from apps.api.permissions import RBACPermission
 from apps.slack.chatops_proxy_routing import make_private_metadata
+from apps.slack.constants import BLOCK_SECTION_TEXT_MAX_SIZE
 from apps.slack.scenarios import scenario_step
 from apps.slack.scenarios.slack_renderer import AlertGroupLogSlackRenderer
 from apps.slack.types import (
@@ -47,9 +48,13 @@ class OpenAlertGroupTimelineDialogStep(AlertGroupActionsMixin, scenario_step.Sce
         future_log_report = AlertGroupLogSlackRenderer.render_alert_group_future_log_report_text(alert_group)
         blocks: typing.List[Block.Section] = []
         if past_log_report:
-            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": past_log_report}})
+            blocks.append(
+                {"type": "section", "text": {"type": "mrkdwn", "text": past_log_report[:BLOCK_SECTION_TEXT_MAX_SIZE]}}
+            )
         if future_log_report:
-            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": future_log_report}})
+            blocks.append(
+                {"type": "section", "text": {"type": "mrkdwn", "text": future_log_report[:BLOCK_SECTION_TEXT_MAX_SIZE]}}
+            )
 
         view: ModalView = {
             "blocks": blocks,


### PR DESCRIPTION
# What this PR does
Limit length of text in block being posted to slack when showing alert group timeline.

## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
