### PR TITLE
fix: disable accessControlonCall for Grafana 11.3 in docker compose

### DIFF
--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -351,9 +351,6 @@ services:
         required: false
     profiles:
       - grafana
-    configs:
-      - source: grafana.ini
-        target: /etc/grafana/grafana.ini
 
 volumes:
   redisdata_dev:

--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -324,6 +324,7 @@ services:
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
       GF_FEATURE_TOGGLES_ENABLE: externalServiceAccounts
       ONCALL_API_URL: http://host.docker.internal:8080
+      GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     env_file:
       - ./dev/.env.${DB}.dev
     ports:
@@ -350,6 +351,9 @@ services:
         required: false
     profiles:
       - grafana
+    configs:
+      - source: grafana.ini
+        target: /etc/grafana/grafana.ini
 
 volumes:
   redisdata_dev:

--- a/docker-compose-mysql-rabbitmq.yml
+++ b/docker-compose-mysql-rabbitmq.yml
@@ -144,6 +144,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
       GF_INSTALL_PLUGINS: grafana-oncall-app
+      GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     deploy:
       resources:
         limits:
@@ -156,7 +157,16 @@ services:
         condition: service_healthy
     profiles:
       - with_grafana
+    configs:
+      - source: grafana.ini
+        target: /etc/grafana/grafana.ini
 
 volumes:
   dbdata:
   rabbitmqdata:
+
+configs:
+  grafana.ini:
+    content: |
+      [feature_toggles]
+      accessControlOnCall = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-oncall-app
       GF_INSTALL_PLUGINS: grafana-oncall-app
+      GF_AUTH_MANAGED_SERVICE_ACCOUNTS_ENABLED: true
     volumes:
       - grafana_data:/var/lib/grafana
     deploy:
@@ -103,9 +104,18 @@ services:
           cpus: "0.5"
     profiles:
       - with_grafana
+    configs:
+      - source: grafana.ini
+        target: /etc/grafana/grafana.ini
 
 volumes:
   grafana_data:
   prometheus_data:
   oncall_data:
   redis_data:
+
+configs:
+  grafana.ini:
+    content: |
+      [feature_toggles]
+      accessControlOnCall = false


### PR DESCRIPTION
# What this PR does

Disable accessControlOnCall for Grafana 11.3 in docker compose
Similar to https://github.com/grafana/oncall/pull/5245

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
