### PR TITLE
Fix issue with DST starting/ending causing overlaps/gaps

### DIFF
--- a/engine/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py
+++ b/engine/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py
@@ -39,7 +39,7 @@ class AmixrRecurringIcalEventsAdapter(IcalService):
         )
 
         for event in events:
-            if hasattr(event[ICAL_DATETIME_END].dt,'tzinfo'):
+            if hasattr(event[ICAL_DATETIME_END].dt, "tzinfo"):
                 dt = event[ICAL_DATETIME_END].dt
                 tz = dt.tzinfo
                 normalized = tz.normalize(dt)

--- a/engine/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py
+++ b/engine/apps/schedules/ical_events/adapter/amixr_recurring_ical_events_adapter.py
@@ -38,6 +38,15 @@ class AmixrRecurringIcalEventsAdapter(IcalService):
             end_date + datetime.timedelta(days=EXTRA_LOOKUP_DAYS),
         )
 
+        for event in events:
+            if hasattr(event[ICAL_DATETIME_END].dt,'tzinfo'):
+                dt = event[ICAL_DATETIME_END].dt
+                tz = dt.tzinfo
+                normalized = tz.normalize(dt)
+                if normalized.tzinfo != tz:
+                    diff = dt.dst() - normalized.dst()
+                    event[ICAL_DATETIME_END].dt = normalized + diff
+
         def filter_extra_days(event):
             event_start, event_end = self.get_start_and_end_with_respect_to_event_type(event)
             if event_start > event_end:


### PR DESCRIPTION
# What this PR does

This older version of recurring_ical_events does not call the pytz .normalize() function, which can cause some invalid datetime objects to return when a DST swap happens. For example: Nov 3, 2024 9:00 AM CDT instead of the correct 8:00 AM CST). By calling tz.normalize on the end date and checking if the time zone information changed, we can detect when DST starts/stops and adjust the end date accordingly.

| | DST stopping on November 3, 2024: | DST starting on March 9, 2024 |
|-|-----------------------------------------|-----------------------------------|
| Before | ![image](https://github.com/user-attachments/assets/933bce80-9b6a-475b-88f2-6356d0e3a6fd) | ![image](https://github.com/user-attachments/assets/264b816f-6f40-4f14-bbc0-1d03f7b74ac4)
| After | ![image](https://github.com/user-attachments/assets/fbd71991-c4f8-4685-a527-6dbb147b2cb6) | ![image](https://github.com/user-attachments/assets/ccd932df-2ab4-4472-bc90-045372712f75) |

## Which issue(s) this PR closes

Closes #5247

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
