### PR TITLE
refactor `SlackMessage.channel_id` (`CHAR` field) to `SlackMessage.channel` (foreign key relationship)

### DIFF
--- a/engine/apps/alerts/models/alert_group.py
+++ b/engine/apps/alerts/models/alert_group.py
@@ -1983,7 +1983,7 @@ class AlertGroup(AlertGroupSlackRenderingMixin, EscalationSnapshotMixin, models.
         if not self.channel.organization.slack_team_identity:
             return None
         elif self.slack_message:
-            return self.slack_message.channel_id
+            return self.slack_message.channel.slack_id
         elif self.channel_filter:
             return self.channel_filter.slack_channel_id_or_org_default_id
         return None

--- a/engine/apps/alerts/tests/test_alert_group.py
+++ b/engine/apps/alerts/tests/test_alert_group.py
@@ -24,14 +24,15 @@ def test_render_for_phone_call(
     make_alert_receive_channel,
     make_alert_group,
     make_alert,
+    make_slack_channel,
+    make_slack_message,
 ):
-    organization, _ = make_organization_with_slack_team_identity()
+    organization, slack_team_identity = make_organization_with_slack_team_identity()
     alert_receive_channel = make_alert_receive_channel(organization)
 
     alert_group = make_alert_group(alert_receive_channel)
-    SlackMessage.objects.create(channel_id="CWER1ASD", alert_group=alert_group)
-
-    alert_group = make_alert_group(alert_receive_channel)
+    slack_channel = make_slack_channel(slack_team_identity)
+    make_slack_message(alert_group=alert_group, channel=slack_channel)
 
     make_alert(
         alert_group,
@@ -105,7 +106,7 @@ def test_delete(
     make_alert(alert_group, raw_request_data={})
 
     # Create Slack messages
-    slack_message = make_slack_message(alert_group=alert_group, channel_id="test_channel_id", slack_id="test_slack_id")
+    slack_message = make_slack_message(alert_group=alert_group, channel=slack_channel1)
     resolution_note_1 = make_resolution_note_slack_message(
         alert_group=alert_group,
         user=user,
@@ -154,7 +155,7 @@ def test_delete(
     assert mock_chat_delete.call_args_list[0] == call(
         channel=resolution_note_1.slack_channel_id, ts=resolution_note_1.ts
     )
-    assert mock_chat_delete.call_args_list[1] == call(channel=slack_message.channel_id, ts=slack_message.slack_id)
+    assert mock_chat_delete.call_args_list[1] == call(channel=slack_message.channel.slack_id, ts=slack_message.slack_id)
     mock_reactions_remove.assert_called_once_with(
         channel=resolution_note_2.slack_channel_id, name="memo", timestamp=resolution_note_2.ts
     )
@@ -188,7 +189,7 @@ def test_delete_slack_ratelimit(
     make_alert(alert_group, raw_request_data={})
 
     # Create Slack messages
-    make_slack_message(alert_group=alert_group, channel_id="test_channel_id", slack_id="test_slack_id")
+    make_slack_message(alert_group=alert_group, channel=slack_channel1)
     make_resolution_note_slack_message(
         alert_group=alert_group,
         user=user,
@@ -259,7 +260,7 @@ def test_delete_slack_api_error_other_than_ratelimit(
     make_alert(alert_group, raw_request_data={})
 
     # Create Slack messages
-    make_slack_message(alert_group=alert_group, channel_id="test_channel_id", slack_id="test_slack_id")
+    make_slack_message(alert_group=alert_group, channel=slack_channel1)
     make_resolution_note_slack_message(
         alert_group=alert_group,
         user=user,

--- a/engine/apps/alerts/tests/test_notify_user.py
+++ b/engine/apps/alerts/tests/test_notify_user.py
@@ -232,19 +232,17 @@ def test_notify_user_perform_notification_skip_if_resolved(
 def test_perform_notification_reason_to_skip_escalation_in_slack(
     reason_to_skip_escalation,
     error_code,
-    make_organization,
-    make_slack_team_identity,
+    make_organization_with_slack_team_identity,
     make_user,
     make_user_notification_policy,
     make_alert_receive_channel,
     make_alert_group,
     make_user_notification_policy_log_record,
+    make_slack_channel,
     make_slack_message,
 ):
-    organization = make_organization()
-    slack_team_identity = make_slack_team_identity()
-    organization.slack_team_identity = slack_team_identity
-    organization.save()
+    organization, slack_team_identity = make_organization_with_slack_team_identity()
+
     user = make_user(organization=organization)
     user_notification_policy = make_user_notification_policy(
         user=user,
@@ -252,19 +250,26 @@ def test_perform_notification_reason_to_skip_escalation_in_slack(
         notify_by=UserNotificationPolicy.NotificationChannel.SLACK,
     )
     alert_receive_channel = make_alert_receive_channel(organization=organization)
-    alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
-    alert_group.reason_to_skip_escalation = reason_to_skip_escalation
-    alert_group.save()
+
+    alert_group = make_alert_group(
+        alert_receive_channel=alert_receive_channel,
+        reason_to_skip_escalation=reason_to_skip_escalation,
+    )
+
     log_record = make_user_notification_policy_log_record(
         author=user,
         alert_group=alert_group,
         notification_policy=user_notification_policy,
         type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_TRIGGERED,
     )
+
     if not error_code:
-        make_slack_message(alert_group=alert_group, channel_id="test_channel_id", slack_id="test_slack_id")
+        slack_channel = make_slack_channel(slack_team_identity=slack_team_identity)
+        make_slack_message(alert_group=alert_group, channel=slack_channel)
+
     with patch.object(SlackMessage, "send_slack_notification") as mocked_send_slack_notification:
         perform_notification(log_record.pk, False)
+
     last_log_record = UserNotificationPolicyLogRecord.objects.last()
 
     if error_code:
@@ -280,25 +285,24 @@ def test_perform_notification_reason_to_skip_escalation_in_slack(
 
 @pytest.mark.django_db
 def test_perform_notification_slack_prevent_posting(
-    make_organization,
-    make_slack_team_identity,
+    make_organization_with_slack_team_identity,
     make_user,
     make_user_notification_policy,
     make_alert_receive_channel,
     make_alert_group,
     make_user_notification_policy_log_record,
+    make_slack_channel,
     make_slack_message,
 ):
-    organization = make_organization()
-    slack_team_identity = make_slack_team_identity()
-    organization.slack_team_identity = slack_team_identity
-    organization.save()
+    organization, slack_team_identity = make_organization_with_slack_team_identity()
+
     user = make_user(organization=organization)
     user_notification_policy = make_user_notification_policy(
         user=user,
         step=UserNotificationPolicy.Step.NOTIFY,
         notify_by=UserNotificationPolicy.NotificationChannel.SLACK,
     )
+
     alert_receive_channel = make_alert_receive_channel(organization=organization)
     alert_group = make_alert_group(alert_receive_channel=alert_receive_channel)
     log_record = make_user_notification_policy_log_record(
@@ -308,7 +312,9 @@ def test_perform_notification_slack_prevent_posting(
         type=UserNotificationPolicyLogRecord.TYPE_PERSONAL_NOTIFICATION_TRIGGERED,
         slack_prevent_posting=True,
     )
-    make_slack_message(alert_group=alert_group, channel_id="test_channel_id", slack_id="test_slack_id")
+
+    slack_channel = make_slack_channel(slack_team_identity=slack_team_identity)
+    make_slack_message(alert_group=alert_group, channel=slack_channel)
 
     with patch.object(SlackMessage, "send_slack_notification") as mocked_send_slack_notification:
         perform_notification(log_record.pk, False)

--- a/engine/apps/public_api/tests/test_alert_groups.py
+++ b/engine/apps/public_api/tests/test_alert_groups.py
@@ -162,9 +162,7 @@ def test_get_alert_group_slack_links(
     organization.slack_team_identity = slack_team_identity
     organization.save()
     slack_channel = make_slack_channel(slack_team_identity)
-    slack_message = make_slack_message(
-        alert_group=alert_group, channel_id=slack_channel.slack_id, cached_permalink="the-link"
-    )
+    slack_message = make_slack_message(alert_group=alert_group, channel=slack_channel, cached_permalink="the-link")
 
     url = reverse("api-public:alert_groups-detail", kwargs={"pk": expected_response["id"]})
     response = client.get(url, format="json", HTTP_AUTHORIZATION=token)

--- a/engine/apps/schedules/tests/tasks/shift_swaps/test_slack_followups.py
+++ b/engine/apps/schedules/tests/tasks/shift_swaps/test_slack_followups.py
@@ -161,7 +161,7 @@ def test_send_shift_swap_request_followup(mock_slack_chat_post_message, shift_sw
     send_shift_swap_request_slack_followup(shift_swap_request.pk)
 
     mock_slack_chat_post_message.assert_called_once_with(
-        channel=shift_swap_request.slack_message.channel_id,
+        channel=shift_swap_request.slack_message.channel.slack_id,
         thread_ts=shift_swap_request.slack_message.slack_id,
         reply_broadcast=True,
         blocks=ANY,

--- a/engine/apps/slack/models/slack_channel.py
+++ b/engine/apps/slack/models/slack_channel.py
@@ -1,8 +1,13 @@
+import typing
+
 from django.conf import settings
 from django.core.validators import MinLengthValidator
 from django.db import models
 
 from common.public_primary_keys import generate_public_primary_key, increase_public_primary_key_length
+
+if typing.TYPE_CHECKING:
+    from apps.slack.models import SlackTeamIdentity
 
 
 def generate_public_primary_key_for_slack_channel():
@@ -20,6 +25,8 @@ def generate_public_primary_key_for_slack_channel():
 
 
 class SlackChannel(models.Model):
+    slack_team_identity: "SlackTeamIdentity"
+
     public_primary_key = models.CharField(
         max_length=20,
         validators=[MinLengthValidator(settings.PUBLIC_PRIMARY_KEY_MIN_LENGTH + 1)],

--- a/engine/apps/slack/models/slack_user_identity.py
+++ b/engine/apps/slack/models/slack_user_identity.py
@@ -131,7 +131,8 @@ class SlackUserIdentity(models.Model):
                     {
                         "type": "mrkdwn",
                         "text": (
-                            f"You received this message because you're not a member of <#{slack_message.channel_id}>.\n"
+                            f"You received this message because you're not a member of "
+                            f"<#{slack_message.channel.slack_id}>.\n"
                             "Please join the channel to get notified right in the alert group thread."
                         ),
                     }

--- a/engine/apps/slack/scenarios/alertgroup_appearance.py
+++ b/engine/apps/slack/scenarios/alertgroup_appearance.py
@@ -83,18 +83,14 @@ class UpdateAppearanceStep(scenario_step.ScenarioStep):
         from apps.alerts.models import AlertGroup
 
         private_metadata = json.loads(payload["view"]["private_metadata"])
-        alert_group_pk = private_metadata["alert_group_pk"]
-
-        alert_group = AlertGroup.objects.get(pk=alert_group_pk)
-
-        attachments = alert_group.render_slack_attachments()
-        blocks = alert_group.render_slack_blocks()
+        alert_group = AlertGroup.objects.get(pk=private_metadata["alert_group_pk"])
+        slack_message = alert_group.slack_message
 
         self._slack_client.chat_update(
-            channel=alert_group.slack_message.channel_id,
-            ts=alert_group.slack_message.slack_id,
-            attachments=attachments,
-            blocks=blocks,
+            channel=slack_message.channel.slack_id,
+            ts=slack_message.slack_id,
+            attachments=alert_group.render_slack_attachments(),
+            blocks=alert_group.render_slack_blocks(),
         )
 
 

--- a/engine/apps/slack/scenarios/distribute_alerts.py
+++ b/engine/apps/slack/scenarios/distribute_alerts.py
@@ -22,6 +22,7 @@ from apps.slack.errors import (
     SlackAPIRestrictedActionError,
     SlackAPITokenError,
 )
+from apps.slack.models import SlackChannel, SlackTeamIdentity, SlackUserIdentity
 from apps.slack.scenarios import scenario_step
 from apps.slack.slack_formatter import SlackFormatter
 from apps.slack.tasks import send_message_to_thread_if_bot_not_in_channel, update_incident_slack_message
@@ -41,7 +42,6 @@ from common.utils import clean_markup, is_string_with_visible_characters
 from .step_mixins import AlertGroupActionsMixin
 
 if typing.TYPE_CHECKING:
-    from apps.slack.models import SlackTeamIdentity, SlackUserIdentity
     from apps.user_management.models import Organization
 
 ATTACH_TO_ALERT_GROUPS_LIMIT = 20
@@ -67,19 +67,19 @@ class AlertShootingStep(scenario_step.ScenarioStep):
 
         if num_updated_rows == 1:
             try:
-                channel_id = (
-                    alert.group.channel_filter.slack_channel_id_or_org_default_id
+                slack_channel = (
+                    alert.group.channel_filter.slack_channel
                     if alert.group.channel_filter
                     # if channel filter is deleted mid escalation, use default Slack channel
-                    else alert.group.channel.organization.default_slack_channel_slack_id
+                    else alert.group.channel.organization.default_slack_channel
                 )
-                self._send_first_alert(alert, channel_id)
+                self._send_first_alert(alert, slack_channel)
             except (SlackAPIError, TimeoutError):
                 AlertGroup.objects.filter(pk=alert.group.pk).update(slack_message_sent=False)
                 raise
 
             if alert.group.channel.maintenance_mode == AlertReceiveChannel.DEBUG_MAINTENANCE:
-                self._send_debug_mode_notice(alert.group, channel_id)
+                self._send_debug_mode_notice(alert.group, slack_channel)
 
             if alert.group.is_maintenance_incident:
                 # not sending log report message for maintenance incident
@@ -87,7 +87,7 @@ class AlertShootingStep(scenario_step.ScenarioStep):
             else:
                 # check if alert group was posted to slack before posting message to thread
                 if not alert.group.skip_escalation_in_slack:
-                    self._send_message_to_thread_if_bot_not_in_channel(alert.group, channel_id)
+                    self._send_message_to_thread_if_bot_not_in_channel(alert.group, slack_channel)
         else:
             # check if alert group was posted to slack before updating its message
             if not alert.group.skip_escalation_in_slack:
@@ -103,43 +103,44 @@ class AlertShootingStep(scenario_step.ScenarioStep):
             else:
                 logger.info("Skip updating alert_group in Slack due to rate limit")
 
-    def _send_first_alert(self, alert: Alert, channel_id: str) -> None:
-        attachments = alert.group.render_slack_attachments()
-        blocks = alert.group.render_slack_blocks()
+    def _send_first_alert(self, alert: Alert, slack_channel: typing.Optional[SlackChannel]) -> None:
         self._post_alert_group_to_slack(
             slack_team_identity=self.slack_team_identity,
             alert_group=alert.group,
             alert=alert,
-            attachments=attachments,
-            channel_id=channel_id,
-            blocks=blocks,
+            attachments=alert.group.render_slack_attachments(),
+            slack_channel=slack_channel,
+            blocks=alert.group.render_slack_blocks(),
         )
 
     def _post_alert_group_to_slack(
         self,
-        slack_team_identity: "SlackTeamIdentity",
+        slack_team_identity: SlackTeamIdentity,
         alert_group: AlertGroup,
         alert: Alert,
         attachments,
-        channel_id: str,
+        slack_channel: typing.Optional[SlackChannel],
         blocks: Block.AnyBlocks,
     ) -> None:
-        # channel_id can be None if general log channel for slack_team_identity is not set
-        if channel_id is None:
-            logger.info(f"Failed to post message to Slack for alert_group {alert_group.pk} because channel_id is None")
+        # slack_channel can be None if org default slack channel for slack_team_identity is not set
+        if slack_channel is None:
+            logger.info(
+                f"Failed to post message to Slack for alert_group {alert_group.pk} because slack_channel is None"
+            )
+
             alert_group.reason_to_skip_escalation = AlertGroup.CHANNEL_NOT_SPECIFIED
             alert_group.save(update_fields=["reason_to_skip_escalation"])
+
             return
 
         try:
-            result = self._slack_client.chat_postMessage(channel=channel_id, attachments=attachments, blocks=blocks)
-
-            alert_group.slack_messages.create(
-                slack_id=result["ts"],
-                organization=alert_group.channel.organization,
-                _slack_team_identity=slack_team_identity,
-                channel_id=channel_id,
+            result = self._slack_client.chat_postMessage(
+                channel=slack_channel.slack_id,
+                attachments=attachments,
+                blocks=blocks,
             )
+
+            alert_group.slack_messages.create(slack_id=result["ts"], channel=slack_channel)
 
             alert.delivered = True
         except SlackAPITokenError:
@@ -174,12 +175,14 @@ class AlertShootingStep(scenario_step.ScenarioStep):
         finally:
             alert.save()
 
-    def _send_debug_mode_notice(self, alert_group: AlertGroup, channel_id: str) -> None:
+    def _send_debug_mode_notice(self, alert_group: AlertGroup, slack_channel: SlackChannel) -> None:
         blocks: Block.AnyBlocks = []
+
         text = "Escalations are silenced due to Debug mode"
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": text}})
+
         self._slack_client.chat_postMessage(
-            channel=channel_id,
+            channel=slack_channel.slack_id,
             text=text,
             attachments=[],
             thread_ts=alert_group.slack_message.slack_id,
@@ -187,16 +190,20 @@ class AlertShootingStep(scenario_step.ScenarioStep):
             blocks=blocks,
         )
 
-    def _send_message_to_thread_if_bot_not_in_channel(self, alert_group: AlertGroup, channel_id: str) -> None:
+    def _send_message_to_thread_if_bot_not_in_channel(
+        self,
+        alert_group: AlertGroup,
+        slack_channel: SlackChannel,
+    ) -> None:
         send_message_to_thread_if_bot_not_in_channel.apply_async(
-            (alert_group.pk, self.slack_team_identity.pk, channel_id),
+            (alert_group.pk, self.slack_team_identity.pk, slack_channel.slack_id),
             countdown=1,  # delay for message so that the log report is published first
         )
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -213,8 +220,8 @@ class InviteOtherPersonToIncident(AlertGroupActionsMixin, scenario_step.Scenario
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -250,8 +257,8 @@ class SilenceGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -280,8 +287,8 @@ class UnSilenceGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -301,8 +308,8 @@ class SelectAttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -459,7 +466,7 @@ class AttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
             if slack_user_identity:
                 self._slack_client.chat_postEphemeral(
                     user=slack_user_identity.slack_id,
-                    channel=alert_group.slack_message.channel_id,
+                    channel=alert_group.slack_message.channel.slack_id,
                     text="{}{}".format(ephemeral_text[:1].upper(), ephemeral_text[1:]),
                     unfurl_links=True,
                 )
@@ -468,8 +475,8 @@ class AttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -521,8 +528,8 @@ class UnAttachGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -547,8 +554,8 @@ class StopInvitationProcess(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -575,8 +582,8 @@ class ResolveGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -617,8 +624,8 @@ class UnResolveGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -638,8 +645,8 @@ class AcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep):
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -659,8 +666,8 @@ class UnAcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep)
 
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -675,10 +682,12 @@ class UnAcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep)
         from apps.alerts.models import AlertGroupLogRecord
 
         alert_group = log_record.alert_group
+        slack_message = alert_group.slack_message
+
         logger.debug(f"Started process_signal in UnAcknowledgeGroupStep for alert_group {alert_group.pk}")
 
         if log_record.type == AlertGroupLogRecord.TYPE_AUTO_UN_ACK:
-            channel_id = alert_group.slack_message.channel_id
+
             if log_record.author is not None:
                 user_verbal = log_record.author.get_username_with_slack_verbal(mention=True)
             else:
@@ -695,11 +704,12 @@ class UnAcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep)
                 f"{user_verbal} hasn't responded to an acknowledge timeout reminder."
                 f" Alert Group is unacknowledged automatically."
             )
-            if alert_group.slack_message.ack_reminder_message_ts:
+
+            if slack_message.ack_reminder_message_ts:
                 try:
                     self._slack_client.chat_update(
-                        channel=channel_id,
-                        ts=alert_group.slack_message.ack_reminder_message_ts,
+                        channel=slack_message.channel.slack_id,
+                        ts=slack_message.ack_reminder_message_ts,
                         text=text,
                         attachments=message_attachments,
                     )
@@ -714,6 +724,7 @@ class UnAcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep)
                 self.alert_group_slack_service.publish_message_to_alert_group_thread(
                     alert_group, attachments=message_attachments, text=text
                 )
+
         self.alert_group_slack_service.update_alert_group_slack_message(alert_group)
         logger.debug(f"Finished process_signal in UnAcknowledgeGroupStep for alert_group {alert_group.pk}")
 
@@ -721,8 +732,8 @@ class UnAcknowledgeGroupStep(AlertGroupActionsMixin, scenario_step.ScenarioStep)
 class AcknowledgeConfirmationStep(AcknowledgeGroupStep):
     def process_scenario(
         self,
-        slack_user_identity: "SlackUserIdentity",
-        slack_team_identity: "SlackTeamIdentity",
+        slack_user_identity: SlackUserIdentity,
+        slack_team_identity: SlackTeamIdentity,
         payload: "EventPayload",
         predefined_org: typing.Optional["Organization"] = None,
     ) -> None:
@@ -771,49 +782,45 @@ class AcknowledgeConfirmationStep(AcknowledgeGroupStep):
         from apps.user_management.models import Organization
 
         alert_group = log_record.alert_group
-        channel_id = alert_group.slack_message.channel_id
+        slack_channel = alert_group.slack_message.channel
+        slack_channel_id = slack_channel.slack_id
+
         user_verbal = log_record.author.get_username_with_slack_verbal(mention=True)
         text = f"{user_verbal}, please confirm that you're still working on this Alert Group."
 
         if alert_group.channel.organization.unacknowledge_timeout != Organization.UNACKNOWLEDGE_TIMEOUT_NEVER:
-            attachments = [
-                {
-                    "fallback": "Are you still working on this Alert Group?",
-                    "text": text,
-                    "callback_id": "alert",
-                    "attachment_type": "default",
-                    "footer": "This is a reminder that the Alert Group is still acknowledged"
-                    " and not resolved. It will be unacknowledged automatically and escalation will"
-                    " start again soon.",
-                    "actions": [
-                        {
-                            "name": scenario_step.ScenarioStep.get_step(
-                                "distribute_alerts", "AcknowledgeConfirmationStep"
-                            ).routing_uid(),
-                            "text": "Confirm",
-                            "type": "button",
-                            "style": "primary",
-                            "value": make_value({"alert_group_pk": alert_group.pk}, alert_group.channel.organization),
-                        },
-                    ],
-                }
-            ]
             try:
                 response = self._slack_client.chat_postMessage(
-                    channel=channel_id,
+                    channel=slack_channel_id,
                     text=text,
-                    attachments=attachments,
+                    attachments=[
+                        {
+                            "fallback": "Are you still working on this Alert Group?",
+                            "text": text,
+                            "callback_id": "alert",
+                            "attachment_type": "default",
+                            "footer": "This is a reminder that the Alert Group is still acknowledged"
+                            " and not resolved. It will be unacknowledged automatically and escalation will"
+                            " start again soon.",
+                            "actions": [
+                                {
+                                    "name": scenario_step.ScenarioStep.get_step(
+                                        "distribute_alerts", "AcknowledgeConfirmationStep"
+                                    ).routing_uid(),
+                                    "text": "Confirm",
+                                    "type": "button",
+                                    "style": "primary",
+                                    "value": make_value({"alert_group_pk": alert_group.pk}, alert_group.channel.organization),
+                                },
+                            ],
+                        }
+                    ],
                     thread_ts=alert_group.slack_message.slack_id,
                 )
             except (SlackAPITokenError, SlackAPIChannelArchivedError, SlackAPIChannelNotFoundError):
                 pass
             else:
-                alert_group.slack_messages.create(
-                    slack_id=response["ts"],
-                    organization=alert_group.channel.organization,
-                    _slack_team_identity=self.slack_team_identity,
-                    channel_id=channel_id,
-                )
+                alert_group.slack_messages.create(slack_id=response["ts"], channel=slack_channel)
 
                 alert_group.slack_message.ack_reminder_message_ts = response["ts"]
                 alert_group.slack_message.save(update_fields=["ack_reminder_message_ts"])

--- a/engine/apps/slack/scenarios/resolution_note.py
+++ b/engine/apps/slack/scenarios/resolution_note.py
@@ -255,7 +255,7 @@ class UpdateResolutionNoteStep(scenario_step.ScenarioStep):
         resolution_note_slack_message = resolution_note.resolution_note_slack_message
         alert_group = resolution_note.alert_group
         alert_group_slack_message = alert_group.slack_message
-        slack_channel_id = alert_group_slack_message.channel_id
+        slack_channel_id = alert_group_slack_message.channel.slack_id
         blocks = self.get_resolution_note_blocks(resolution_note)
 
         slack_channel = SlackChannel.objects.get(
@@ -298,7 +298,7 @@ class UpdateResolutionNoteStep(scenario_step.ScenarioStep):
             resolution_note_text = Truncator(resolution_note_slack_message.text)
             try:
                 self._slack_client.chat_update(
-                    channel=alert_group_slack_message.channel_id,
+                    channel=slack_channel_id,
                     ts=resolution_note_slack_message.ts,
                     text=resolution_note_text.chars(BLOCK_SECTION_TEXT_MAX_SIZE),
                     blocks=blocks,

--- a/engine/apps/slack/scenarios/shift_swap_requests.py
+++ b/engine/apps/slack/scenarios/shift_swap_requests.py
@@ -186,7 +186,7 @@ class BaseShiftSwapRequestStep(scenario_step.ScenarioStep):
             return
 
         self._slack_client.chat_postMessage(
-            channel=shift_swap_request.slack_message.channel_id,
+            channel=shift_swap_request.slack_message.channel.slack_id,
             thread_ts=shift_swap_request.slack_message.slack_id,
             reply_broadcast=reply_broadcast,
             blocks=blocks,

--- a/engine/apps/slack/tests/factories.py
+++ b/engine/apps/slack/tests/factories.py
@@ -41,7 +41,6 @@ class SlackChannelFactory(factory.DjangoModelFactory):
 
 class SlackMessageFactory(factory.DjangoModelFactory):
     slack_id = UniqueFaker("sentence", nb_words=3)
-    channel_id = factory.Faker("word")
 
     class Meta:
         model = SlackMessage

--- a/engine/apps/slack/tests/scenario_steps/test_resolution_note.py
+++ b/engine/apps/slack/tests/scenario_steps/test_resolution_note.py
@@ -428,7 +428,7 @@ def test_add_to_resolution_note_deleted_org(
 ):
     settings.UNIFIED_SLACK_APP_ENABLED = True
 
-    organization, user, slack_team_identity, slack_user_identity = make_organization_and_user_with_slack_identities()
+    organization, _, slack_team_identity, slack_user_identity = make_organization_and_user_with_slack_identities()
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
     make_alert(alert_group=alert_group, raw_request_data={})
@@ -439,7 +439,7 @@ def test_add_to_resolution_note_deleted_org(
     other_user = make_user_for_organization(organization=other_organization, slack_user_identity=slack_user_identity)
 
     payload = {
-        "channel": {"id": slack_message.channel_id},
+        "channel": {"id": slack_message.channel.slack_id},
         "message_ts": "random_ts",
         "message": {
             "type": "message",

--- a/engine/apps/slack/tests/scenario_steps/test_shift_swap_requests.py
+++ b/engine/apps/slack/tests/scenario_steps/test_shift_swap_requests.py
@@ -158,7 +158,7 @@ class TestBaseShiftSwapRequestStep:
 
         assert slack_message.slack_id == ts
         assert slack_message.organization == organization
-        assert slack_message.channel_id == ssr.slack_channel_id
+        assert slack_message.channel.slack_id == ssr.slack_channel_id
         assert slack_message._slack_team_identity == slack_team_identity
 
     @patch("apps.slack.scenarios.shift_swap_requests.BaseShiftSwapRequestStep._generate_blocks")

--- a/engine/apps/slack/tests/tasks/test_send_message_to_thread_if_bot_not_in_channel.py
+++ b/engine/apps/slack/tests/tasks/test_send_message_to_thread_if_bot_not_in_channel.py
@@ -37,7 +37,7 @@ def test_send_message_to_thread_if_bot_not_in_channel(
     alert_receive_channel = make_alert_receive_channel(organization)
     alert_group = make_alert_group(alert_receive_channel)
 
-    send_message_to_thread_if_bot_not_in_channel(alert_group.pk, slack_team_identity.pk, slack_channel.pk)
+    send_message_to_thread_if_bot_not_in_channel(alert_group.pk, slack_team_identity.pk, slack_channel)
 
     MockSlackClient.assert_called_once_with(slack_team_identity, enable_ratelimit_retry=True)
     mock_get_conversation_members.assert_called_once_with(MockSlackClient.return_value, slack_channel.pk)

--- a/engine/conftest.py
+++ b/engine/conftest.py
@@ -528,16 +528,8 @@ def make_slack_user_identity():
 
 @pytest.fixture
 def make_slack_message():
-    def _make_slack_message(alert_group=None, organization=None, **kwargs):
-        organization = organization or alert_group.channel.organization
-        slack_message = SlackMessageFactory(
-            alert_group=alert_group,
-            organization=organization,
-            _slack_team_identity=organization.slack_team_identity,
-            **kwargs,
-        )
-        return slack_message
-
+    def _make_slack_message(alert_group=None, **kwargs):
+        return SlackMessageFactory(alert_group=alert_group, **kwargs)
     return _make_slack_message
 
 


### PR DESCRIPTION
# What this PR does

Related to https://github.com/grafana/oncall-private/issues/2947

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
