### PR TITLE
fix: service accounts creating webhooks through API

### DIFF
--- a/engine/apps/public_api/serializers/webhooks.py
+++ b/engine/apps/public_api/serializers/webhooks.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from rest_framework import fields, serializers
 from rest_framework.validators import UniqueTogetherValidator
 
+from apps.user_management.models import ServiceAccountUser
 from apps.webhooks.models import Webhook, WebhookResponse
 from apps.webhooks.models.webhook import PUBLIC_WEBHOOK_HTTP_METHODS, WEBHOOK_FIELD_PLACEHOLDER
 from apps.webhooks.presets.preset_options import WebhookPresetOptions
@@ -160,6 +161,11 @@ class WebhookCreateSerializer(EagerLoadingMixin, serializers.ModelSerializer):
 
     def validate_preset(self, preset):
         raise serializers.ValidationError(PRESET_VALIDATION_MESSAGE)
+
+    def validate_user(self, user):
+        if isinstance(user, ServiceAccountUser):
+            return None
+        return user
 
     def validate(self, data):
         if (

--- a/engine/apps/user_management/models/service_account.py
+++ b/engine/apps/user_management/models/service_account.py
@@ -26,6 +26,10 @@ class ServiceAccountUser:
         return self.service_account.id
 
     @property
+    def current_team(self):
+        return None
+
+    @property
     def organization_id(self):
         return self.organization.id
 


### PR DESCRIPTION
There is no user to be set when creating a webhook via the public API if authenticated using service account tokens (insight logs will still keep track of the service account information behind the request).