### PR TITLE
fix: update missing users / empty shifts check

### DIFF
--- a/engine/apps/schedules/ical_utils.py
+++ b/engine/apps/schedules/ical_utils.py
@@ -54,6 +54,19 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+class MissingUser:
+    """Represent a missing user in a rolling users shift."""
+
+    DISPLAY_NAME = "(missing)"
+
+    def __init__(self, pk):
+        self.pk = pk
+
+    @property
+    def username(self):
+        return self.DISPLAY_NAME
+
+
 EmptyShift = namedtuple(
     "EmptyShift",
     ["start", "end", "summary", "description", "attendee", "all_day", "calendar_type", "calendar_tz", "shift_pk"],

--- a/engine/apps/schedules/tasks/__init__.py
+++ b/engine/apps/schedules/tasks/__init__.py
@@ -1,17 +1,13 @@
 from .check_gaps_and_empty_shifts import check_gaps_and_empty_shifts_in_schedule  # noqa: F401
 from .drop_cached_ical import drop_cached_ical_for_custom_events_for_organization, drop_cached_ical_task  # noqa: F401
 from .notify_about_empty_shifts_in_schedule import (  # noqa: F401
-    check_empty_shifts_in_schedule,
     notify_about_empty_shifts_in_schedule_task,
     schedule_notify_about_empty_shifts_in_schedule,
-    start_check_empty_shifts_in_schedule,
     start_notify_about_empty_shifts_in_schedule,
 )
 from .notify_about_gaps_in_schedule import (  # noqa: F401
-    check_gaps_in_schedule,
     notify_about_gaps_in_schedule_task,
     schedule_notify_about_gaps_in_schedule,
-    start_check_gaps_in_schedule,
     start_notify_about_gaps_in_schedule,
 )
 from .refresh_ical_files import (  # noqa: F401

--- a/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
@@ -11,18 +11,6 @@ from common.utils import trim_if_needed
 task_logger = get_task_logger(__name__)
 
 
-# deprecated # todo: delete this task from here and from task routes after the next release
-@shared_dedicated_queue_retry_task()
-def start_check_empty_shifts_in_schedule():
-    return
-
-
-# deprecated # todo: delete this task from here and from task routes after the next release
-@shared_dedicated_queue_retry_task()
-def check_empty_shifts_in_schedule(schedule_pk):
-    return
-
-
 @shared_dedicated_queue_retry_task()
 def start_notify_about_empty_shifts_in_schedule():
     from apps.schedules.models import OnCallSchedule

--- a/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
@@ -1,6 +1,7 @@
 import pytz
 from celery.utils.log import get_task_logger
 from django.core.cache import cache
+from django.db.models import Q
 from django.utils import timezone
 
 from apps.slack.utils import format_datetime_to_slack_with_time, post_message_to_channel
@@ -30,7 +31,7 @@ def start_notify_about_gaps_in_schedule():
     today = timezone.now().date()
     week_ago = today - timezone.timedelta(days=7)
     schedules = OnCallSchedule.objects.filter(
-        gaps_report_sent_at__lte=week_ago,
+        Q(gaps_report_sent_at__lte=week_ago) | Q(gaps_report_sent_at__isnull=True),
         slack_channel__isnull=False,
         organization__deleted_at__isnull=True,
     )

--- a/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
@@ -10,18 +10,6 @@ from common.custom_celery_tasks import shared_dedicated_queue_retry_task
 task_logger = get_task_logger(__name__)
 
 
-# deprecated # todo: delete this task from here and from task routes after the next release
-@shared_dedicated_queue_retry_task()
-def start_check_gaps_in_schedule():
-    return
-
-
-# deprecated # todo: delete this task from here and from task routes after the next release
-@shared_dedicated_queue_retry_task()
-def check_gaps_in_schedule(schedule_pk):
-    return
-
-
 @shared_dedicated_queue_retry_task()
 def start_notify_about_gaps_in_schedule():
     from apps.schedules.models import OnCallSchedule

--- a/engine/settings/celery_task_routes.py
+++ b/engine/settings/celery_task_routes.py
@@ -33,13 +33,9 @@ CELERY_TASK_ROUTES = {
     "apps.schedules.tasks.refresh_ical_files.refresh_ical_final_schedule": {"queue": "default"},
     "apps.schedules.tasks.refresh_ical_files.start_refresh_ical_final_schedules": {"queue": "default"},
     "apps.schedules.tasks.check_gaps_and_empty_shifts.check_gaps_and_empty_shifts_in_schedule": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_gaps_in_schedule.check_empty_shifts_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.start_notify_about_gaps_in_schedule": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_gaps_in_schedule.check_gaps_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.notify_about_gaps_in_schedule_task": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.schedule_notify_about_gaps_in_schedule": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_gaps_in_schedule.start_check_empty_shifts_in_schedule": {"queue": "default"},
-    "apps.schedules.tasks.notify_about_gaps_in_schedule.start_check_gaps_in_schedule": {"queue": "default"},
     "apps.schedules.tasks.notify_about_gaps_in_schedule.start_notify_about_empty_shifts_in_schedule": {
         "queue": "default"
     },


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2950

- Represent missing users in schedule events (so they are displayed in the web UI)
- Fix schedule checks for gaps/empty shifts so they send notifications