### PR TITLE
fix: allow service account requests to access organization teams

### DIFF
--- a/engine/apps/public_api/tests/test_escalation_chain.py
+++ b/engine/apps/public_api/tests/test_escalation_chain.py
@@ -1,7 +1,11 @@
+import httpretty
 import pytest
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
+
+from apps.api import permissions
+from apps.auth_token.tests.helpers import setup_service_account_api_mocks
 
 
 @pytest.mark.django_db
@@ -52,6 +56,43 @@ def test_create_escalation_chain(make_organization_and_user_with_token):
     }
     assert response.status_code == status.HTTP_201_CREATED
     assert response.data == expected_data
+
+
+@pytest.mark.django_db
+@httpretty.activate(verbose=True, allow_net_connect=False)
+def test_create_escalation_chain_via_service_account(
+    make_organization,
+    make_service_account_for_organization,
+    make_token_for_service_account,
+    make_team,
+):
+    organization = make_organization(grafana_url="http://grafana.test")
+    team = make_team(organization=organization)
+    service_account = make_service_account_for_organization(organization)
+    token_string = "glsa_token"
+    make_token_for_service_account(service_account, token_string)
+
+    perms = {
+        permissions.RBACPermission.Permissions.ESCALATION_CHAINS_WRITE.value: ["*"],
+    }
+    setup_service_account_api_mocks(organization.grafana_url, perms)
+
+    client = APIClient()
+    url = reverse("api-public:escalation_chains-list")
+    data = {"name": "test", "team_id": team.public_primary_key}
+    response = client.post(
+        url,
+        data=data,
+        format="json",
+        HTTP_AUTHORIZATION=f"{token_string}",
+        HTTP_X_GRAFANA_URL=organization.grafana_url,
+    )
+    if not organization.is_rbac_permissions_enabled:
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+    else:
+        assert response.status_code == status.HTTP_201_CREATED
+        escalation_chain = organization.escalation_chains.get(name="test")
+        assert escalation_chain.team == team
 
 
 @pytest.mark.django_db

--- a/engine/apps/user_management/models/service_account.py
+++ b/engine/apps/user_management/models/service_account.py
@@ -30,6 +30,10 @@ class ServiceAccountUser:
         return None
 
     @property
+    def available_teams(self):
+        return self.organization.teams
+
+    @property
     def organization_id(self):
         return self.organization.id
 


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2826