### PR TITLE
Fix test connection on integration create

### DIFF
--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -2066,6 +2066,12 @@ def test_alert_receive_channel_test_connection(
     data = {
         "integration": integration_config.slug,
         "team": None,
+        "create_default_webhooks": True,
+        "alert_group_labels": {
+            "inheritable": {},
+            "custom": [],
+            "template": None,
+        },
     }
 
     # no test connection setup

--- a/engine/apps/api/views/alert_receive_channel.py
+++ b/engine/apps/api/views/alert_receive_channel.py
@@ -24,6 +24,7 @@ from apps.api.serializers.alert_receive_channel import (
     AlertReceiveChannelSerializer,
     AlertReceiveChannelUpdateSerializer,
     FilterAlertReceiveChannelSerializer,
+    IntegrationAlertGroupLabelsSerializer,
 )
 from apps.api.serializers.alert_receive_channel_connection import (
     AlertReceiveChannelConnectedChannelSerializer,
@@ -309,7 +310,10 @@ class AlertReceiveChannelView(
         # check we have all the required information
         serializer.is_valid(raise_exception=True)
         if instance is None:
+            # pop extra fields so they are not passed to AlertReceiveChannel(**serializer.validated_data)
             serializer.validated_data.pop("create_default_webhooks", None)
+            IntegrationAlertGroupLabelsSerializer.pop_alert_group_labels(serializer.validated_data)
+
             # create in-memory instance to test with the (possible) unsaved data
             instance = AlertReceiveChannel(**serializer.validated_data)
         else:


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/13751

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
