### PR TITLE
Inbound email additional logging

### DIFF
--- a/engine/apps/email/inbound.py
+++ b/engine/apps/email/inbound.py
@@ -144,8 +144,9 @@ class InboundEmailWebhookView(AlertChannelDefiningMixin, APIView):
 
             messages = [event.message for event in events if isinstance(event, AnymailInboundEvent)]
             if messages:
-                logger.info(f"Received inbound email message from ESP: {esp}")
-                return messages[0]
+                message: AnymailInboundMessage = messages[0]
+                logger.info(f"Received inbound email message from ESP: {esp}, is HTML: {message.html is not None}")
+                return message
 
         logger.error("Failed to parse inbound email message")
         return None

--- a/engine/tox.ini
+++ b/engine/tox.ini
@@ -21,6 +21,7 @@ banned-modules =
 # --allow-hosts = allow connections to the given hostnames/IPs.
 #   - localhost = our tests on CI use localhost as the host to connect to databases running locally in docker container
 #   - oncall-dev-mariadb = if you're running things locally, with a MariaDB instance running, there's a good chance the hostname will be this
+# pytest-socket is disabled for now as it's making tests hang on CI
 addopts = --dist no --no-migrations --color=yes --showlocals
 # https://pytest-django.readthedocs.io/en/latest/faq.html#my-tests-are-not-being-found-why
 python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
# What this PR does

Adds some logging for inbound email + comment on why I disabled `pytest-socket` in a [recent PR](https://github.com/grafana/oncall/pull/5328)

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
