### PR TITLE
chore: update service account token auth organization setup check

### DIFF
--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -361,7 +361,7 @@ class GrafanaServiceAccountAuthentication(BaseAuthentication):
 
         organization = self.get_organization(request, auth)
         if not organization:
-            raise exceptions.AuthenticationFailed("Invalid organization.")
+            raise exceptions.AuthenticationFailed("Organization not found.")
         if organization.is_moved:
             raise OrganizationMovedException(organization)
         if organization.deleted_at:
@@ -374,9 +374,10 @@ class GrafanaServiceAccountAuthentication(BaseAuthentication):
         if grafana_url:
             organization = Organization.objects.filter(grafana_url=grafana_url).first()
             if not organization:
-                success = setup_organization(grafana_url, auth)
-                if not success:
-                    raise exceptions.AuthenticationFailed("Invalid Grafana URL.")
+                # trigger a request to sync the organization
+                # (ignore response since we can get a 400 if sync was already triggered;
+                # if organization exists, we are good)
+                setup_organization(grafana_url, auth)
                 organization = Organization.objects.filter(grafana_url=grafana_url).first()
             return organization
 

--- a/engine/apps/auth_token/tests/test_grafana_auth.py
+++ b/engine/apps/auth_token/tests/test_grafana_auth.py
@@ -93,7 +93,7 @@ def test_grafana_authentication_missing_org():
 
     with pytest.raises(exceptions.AuthenticationFailed) as exc:
         GrafanaServiceAccountAuthentication().authenticate(request)
-    assert exc.value.detail == "Invalid organization."
+    assert exc.value.detail == "Organization not found."
 
 
 @pytest.mark.django_db
@@ -112,7 +112,7 @@ def test_grafana_authentication_invalid_grafana_url():
 
     with pytest.raises(exceptions.AuthenticationFailed) as exc:
         GrafanaServiceAccountAuthentication().authenticate(request)
-    assert exc.value.detail == "Invalid Grafana URL."
+    assert exc.value.detail == "Organization not found."
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Ignore setup organization response (for now, since it can return a 400 when a sync is/was recently in progress) and base response on organization being available or not instead.