### PR TITLE
fix: remove service account role check on sync requests

### DIFF
--- a/engine/apps/auth_token/auth.py
+++ b/engine/apps/auth_token/auth.py
@@ -135,11 +135,9 @@ class BasePluginAuthentication(BaseAuthentication):
             user_id = context["UserID"]
 
         if context.get("IsServiceAccount", False):
-            # no user involved in service account requests
-            logger.info(f"serviceaccount request - id={user_id}")
             service_account_role = context.get("Role", "None")
-            if service_account_role.lower() != "admin":
-                raise exceptions.AuthenticationFailed("Service account requests must have Admin or Editor role.")
+            # no user involved in service account requests
+            logger.info(f"serviceaccount request - id={user_id} - role={service_account_role}")
             return None
 
         try:


### PR DESCRIPTION
External service accounts do not have a role set so async triggered periodic org syncs were rejected. Improving role/perm check in a later PR instead (restriction wasn't originally there).