### PR TITLE
Change mapping of permission NORIFICATION_READ to legacy role

### DIFF
--- a/engine/apps/api/permissions.py
+++ b/engine/apps/api/permissions.py
@@ -261,7 +261,7 @@ class RBACPermission(permissions.BasePermission):
         )
 
         NOTIFICATIONS_READ = LegacyAccessControlCompatiblePermission(
-            Resources.NOTIFICATIONS, Actions.READ, LegacyAccessControlRole.EDITOR
+            Resources.NOTIFICATIONS, Actions.READ, LegacyAccessControlRole.VIEWER
         )
 
         NOTIFICATION_SETTINGS_READ = LegacyAccessControlCompatiblePermission(


### PR DESCRIPTION
The problem the PR solves is a user must have `EDITOR` role in Grafana to be included into a Schedule. 

If we compare other `_READ` level privileges with their legacy roles, they are mapped to `VIEWER` role (except API keys read).

In short, the main idea of this change is to avoid granting a user `EDITOR` role in a whole organization only because a user should be a part of some Schedule.

# What this PR does
This PR changes a mapping of `NOTIFICATIONS_READ` permission from `EDITOR` to `VIEWER` role.

## Which issue(s) this PR closes


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
