### PR TITLE
Fix dynamic label template validation

### DIFF
--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -301,16 +301,23 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
     rate_limited_in_slack_at = models.DateTimeField(null=True, default=None)
     rate_limit_message_task_id = models.CharField(max_length=100, null=True, default=None)
 
-    AlertGroupCustomLabelsDB = list[tuple[str, str | None, str | None]] | None
-    alert_group_labels_custom: AlertGroupCustomLabelsDB = models.JSONField(null=True, default=None)
     """
-    Stores "custom labels" for alert group labels. Custom labels can be either "plain" or "templated".
-    For plain labels, the format is: [<LABEL_KEY_ID>, <LABEL_VALUE_ID>, None]
-    For templated labels, the format is: [<LABEL_KEY_ID>, None, <JINJA2_TEMPLATE>]
+    Stores "labels schema" - set of config to map incoming alert payload to labels.
+    Labels can be either "static" or "dynamic".
+    LabelsSchemaEntryDB is a a one entry of a one labels schema. It's a tuple with 3 elements:
+    1. Key ID
+    2. Value ID or None
+    3. Value Template or None
+    If label value ID is present - it's a static key-value pair. If it's None - it's a dynamic key-template pair.
     """
-
+    LabelsSchemaEntryDB = tuple[str, str | None, str | None]
+    LabelsSchemaDB = list[LabelsSchemaEntryDB] | None
+    alert_group_labels_custom: LabelsSchemaDB = models.JSONField(null=True, default=None)
+    """
+    alert_group_labels_template is a Jinja2 template for "multi-label extraction template".
+    It extracts multiple labels from incoming alert payload.
+    """
     alert_group_labels_template: str | None = models.TextField(null=True, default=None)
-    """Stores a Jinja2 template for "advanced label templating" for alert group labels."""
 
     additional_settings: dict | None = models.JSONField(null=True, default=None)
 

--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -306,7 +306,7 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
     LabelsSchemaEntryDB is a a one entry of a one labels schema. It's a tuple with 3 elements:
     1. Key ID
     2. Value ID or None -  Deprecated, but left for backward compatibility with old data. Should be None all the time.
-    3. Value Template or None
+    3. Value Template or None – By business logic it should be always present, but it might be None if a legacy data.
     It means only [key_id, None, template] should be present.
     """
     LabelsSchemaEntryDB = tuple[str, str | None, str | None]

--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -301,23 +301,21 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
     rate_limited_in_slack_at = models.DateTimeField(null=True, default=None)
     rate_limit_message_task_id = models.CharField(max_length=100, null=True, default=None)
 
-    """
-    alert_group_labels_custom stores config of dynamic labels - mapping of incoming alert payload to labels
-    DynamicLabelsEntryDB is a a one entry of a one labels schema. It's a tuple with 3 elements:
-    1. Key ID
-    2. Value ID or None -  Deprecated, but left for backward compatibility with old data. Should be None all the time.
-    3. Value Template or None – By business logic it should be always present, but it might be None if a legacy data.
-    It means only [key_id, None, template] should be present.
-    // TODO: refactor to use just regular DB fields for dynamic label config.
-    """
     DynamicLabelsEntryDB = tuple[str, str | None, str | None]
     DynamicLabelsConfigDB = list[DynamicLabelsEntryDB] | None
     alert_group_labels_custom: DynamicLabelsConfigDB = models.JSONField(null=True, default=None)
     """
+    alert_group_labels_custom stores config of dynamic labels. It's stored as a list of tuples.
+    Format of tuple is: [<LABEL_KEY_ID>, None, <JINJA2_TEMPLATE>].
+    The second element is deprecated, so it's always None. It was used for static labels.
+    // TODO: refactor to use just regular DB fields for dynamic label config.
+    """
+
+    alert_group_labels_template: str | None = models.TextField(null=True, default=None)
+    """
     alert_group_labels_template is a Jinja2 template for "multi-label extraction template".
     It extracts multiple labels from incoming alert payload.
     """
-    alert_group_labels_template: str | None = models.TextField(null=True, default=None)
 
     additional_settings: dict | None = models.JSONField(null=True, default=None)
 

--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -308,6 +308,7 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
     2. Value ID or None -  Deprecated, but left for backward compatibility with old data. Should be None all the time.
     3. Value Template or None – By business logic it should be always present, but it might be None if a legacy data.
     It means only [key_id, None, template] should be present.
+    // TODO: refactor to use just regular DB fields for dynamic label config.
     """
     DynamicLabelsEntryDB = tuple[str, str | None, str | None]
     DynamicLabelsConfigDB = list[DynamicLabelsEntryDB] | None

--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -303,15 +303,15 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
 
     """
     alert_group_labels_custom stores config of dynamic labels - mapping of incoming alert payload to labels
-    LabelsSchemaEntryDB is a a one entry of a one labels schema. It's a tuple with 3 elements:
+    DynamicLabelsEntryDB is a a one entry of a one labels schema. It's a tuple with 3 elements:
     1. Key ID
     2. Value ID or None -  Deprecated, but left for backward compatibility with old data. Should be None all the time.
     3. Value Template or None – By business logic it should be always present, but it might be None if a legacy data.
     It means only [key_id, None, template] should be present.
     """
-    LabelsSchemaEntryDB = tuple[str, str | None, str | None]
-    LabelsSchemaDB = list[LabelsSchemaEntryDB] | None
-    alert_group_labels_custom: LabelsSchemaDB = models.JSONField(null=True, default=None)
+    DynamicLabelsEntryDB = tuple[str, str | None, str | None]
+    DynamicLabelsConfigDB = list[DynamicLabelsEntryDB] | None
+    alert_group_labels_custom: DynamicLabelsConfigDB = models.JSONField(null=True, default=None)
     """
     alert_group_labels_template is a Jinja2 template for "multi-label extraction template".
     It extracts multiple labels from incoming alert payload.

--- a/engine/apps/alerts/models/alert_receive_channel.py
+++ b/engine/apps/alerts/models/alert_receive_channel.py
@@ -302,13 +302,12 @@ class AlertReceiveChannel(IntegrationOptionsMixin, MaintainableObject):
     rate_limit_message_task_id = models.CharField(max_length=100, null=True, default=None)
 
     """
-    Stores "labels schema" - set of config to map incoming alert payload to labels.
-    Labels can be either "static" or "dynamic".
+    alert_group_labels_custom stores config of dynamic labels - mapping of incoming alert payload to labels
     LabelsSchemaEntryDB is a a one entry of a one labels schema. It's a tuple with 3 elements:
     1. Key ID
-    2. Value ID or None
+    2. Value ID or None -  Deprecated, but left for backward compatibility with old data. Should be None all the time.
     3. Value Template or None
-    If label value ID is present - it's a static key-value pair. If it's None - it's a dynamic key-template pair.
+    It means only [key_id, None, template] should be present.
     """
     LabelsSchemaEntryDB = tuple[str, str | None, str | None]
     LabelsSchemaDB = list[LabelsSchemaEntryDB] | None

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -33,8 +33,7 @@ def _additional_settings_serializer_from_type(integration_type: str) -> serializ
     return cls
 
 
-# TODO: refactor this types.
-#  We no longer support two types of label values here, nut only templates, so it should be simplified.
+# TODO: refactor this types as w no longer support storing static labels in this field.
 # AlertGroupCustomLabelValue represents custom alert group label value for API requests
 # It handles two types of label's value:
 # 1. Just Label Value from a label repo for a static label

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -206,7 +206,7 @@ class IntegrationAlertGroupLabelsSerializer(serializers.Serializer):
     @staticmethod
     def _custom_labels_to_internal_value(
         custom_labels: AlertGroupCustomLabelsAPI,
-    ) -> AlertReceiveChannel.AlertGroupCustomLabelsDB:
+    ) -> AlertReceiveChannel.LabelsSchemaDB:
         """Convert custom labels from API representation to the schema used by the JSONField on the model."""
 
         return [
@@ -216,7 +216,7 @@ class IntegrationAlertGroupLabelsSerializer(serializers.Serializer):
 
     @staticmethod
     def _custom_labels_to_representation(
-        custom_labels: AlertReceiveChannel.AlertGroupCustomLabelsDB,
+        custom_labels: AlertReceiveChannel.LabelsSchemaDB,
     ) -> AlertGroupCustomLabelsAPI:
         """
         Inverse of the _custom_labels_to_internal_value method above.

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -33,6 +33,8 @@ def _additional_settings_serializer_from_type(integration_type: str) -> serializ
     return cls
 
 
+# TODO: refactor this types.
+#  We no longer support two types of label values here, nut only templates, so it should be simplified.
 # AlertGroupCustomLabelValue represents custom alert group label value for API requests
 # It handles two types of label's value:
 # 1. Just Label Value from a label repo for a static label

--- a/engine/apps/api/serializers/alert_receive_channel.py
+++ b/engine/apps/api/serializers/alert_receive_channel.py
@@ -206,7 +206,7 @@ class IntegrationAlertGroupLabelsSerializer(serializers.Serializer):
     @staticmethod
     def _custom_labels_to_internal_value(
         custom_labels: AlertGroupCustomLabelsAPI,
-    ) -> AlertReceiveChannel.LabelsSchemaDB:
+    ) -> AlertReceiveChannel.DynamicLabelsConfigDB:
         """Convert custom labels from API representation to the schema used by the JSONField on the model."""
 
         return [
@@ -216,7 +216,7 @@ class IntegrationAlertGroupLabelsSerializer(serializers.Serializer):
 
     @staticmethod
     def _custom_labels_to_representation(
-        custom_labels: AlertReceiveChannel.LabelsSchemaDB,
+        custom_labels: AlertReceiveChannel.DynamicLabelsConfigDB,
     ) -> AlertGroupCustomLabelsAPI:
         """
         Inverse of the _custom_labels_to_internal_value method above.

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -1486,14 +1486,14 @@ def test_alert_receive_channel_contact_points_wrong_integration(
 def test_integration_filter_by_labels(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,
-    make_integration_label_association,
+    make_integration_static_label_config,
     make_user_auth_headers,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel_1 = make_alert_receive_channel(organization)
     alert_receive_channel_2 = make_alert_receive_channel(organization)
-    associated_label_1 = make_integration_label_association(organization, alert_receive_channel_1)
-    associated_label_2 = make_integration_label_association(organization, alert_receive_channel_1)
+    associated_label_1 = make_integration_static_label_config(organization, alert_receive_channel_1)
+    associated_label_2 = make_integration_static_label_config(organization, alert_receive_channel_1)
     alert_receive_channel_2.labels.create(
         key=associated_label_1.key, value=associated_label_1.value, organization=organization
     )
@@ -1659,7 +1659,7 @@ def test_alert_group_labels_get(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,
     make_label_key_and_value,
-    make_integration_label_association,
+    make_integration_static_label_config,
     make_user_auth_headers,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
@@ -1674,7 +1674,7 @@ def test_alert_group_labels_get(
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["alert_group_labels"] == {"inheritable": {}, "custom": [], "template": None}
 
-    label = make_integration_label_association(organization, alert_receive_channel)
+    label = make_integration_static_label_config(organization, alert_receive_channel)
 
     template = "{{ payload.labels | tojson }}"
     alert_receive_channel.alert_group_labels_template = template
@@ -1707,14 +1707,14 @@ def test_alert_group_labels_get(
 def test_alert_group_labels_put(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,
-    make_integration_label_association,
+    make_integration_static_label_config,
     make_user_auth_headers,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_1 = make_integration_label_association(organization, alert_receive_channel)
-    label_2 = make_integration_label_association(organization, alert_receive_channel)
-    label_3 = make_integration_label_association(organization, alert_receive_channel)
+    label_1 = make_integration_static_label_config(organization, alert_receive_channel)
+    label_2 = make_integration_static_label_config(organization, alert_receive_channel)
+    label_3 = make_integration_static_label_config(organization, alert_receive_channel)
 
     custom = [
         # plain label

--- a/engine/apps/api/tests/test_alert_receive_channel.py
+++ b/engine/apps/api/tests/test_alert_receive_channel.py
@@ -1486,14 +1486,14 @@ def test_alert_receive_channel_contact_points_wrong_integration(
 def test_integration_filter_by_labels(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,
-    make_integration_static_label_config,
+    make_static_label_config,
     make_user_auth_headers,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel_1 = make_alert_receive_channel(organization)
     alert_receive_channel_2 = make_alert_receive_channel(organization)
-    associated_label_1 = make_integration_static_label_config(organization, alert_receive_channel_1)
-    associated_label_2 = make_integration_static_label_config(organization, alert_receive_channel_1)
+    associated_label_1 = make_static_label_config(organization, alert_receive_channel_1)
+    associated_label_2 = make_static_label_config(organization, alert_receive_channel_1)
     alert_receive_channel_2.labels.create(
         key=associated_label_1.key, value=associated_label_1.value, organization=organization
     )
@@ -1659,7 +1659,7 @@ def test_alert_group_labels_get(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,
     make_label_key_and_value,
-    make_integration_static_label_config,
+    make_static_label_config,
     make_user_auth_headers,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
@@ -1674,7 +1674,7 @@ def test_alert_group_labels_get(
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["alert_group_labels"] == {"inheritable": {}, "custom": [], "template": None}
 
-    label = make_integration_static_label_config(organization, alert_receive_channel)
+    label = make_static_label_config(organization, alert_receive_channel)
 
     template = "{{ payload.labels | tojson }}"
     alert_receive_channel.alert_group_labels_template = template
@@ -1707,14 +1707,14 @@ def test_alert_group_labels_get(
 def test_alert_group_labels_put(
     make_organization_and_user_with_plugin_token,
     make_alert_receive_channel,
-    make_integration_static_label_config,
+    make_static_label_config,
     make_user_auth_headers,
 ):
     organization, user, token = make_organization_and_user_with_plugin_token()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_1 = make_integration_static_label_config(organization, alert_receive_channel)
-    label_2 = make_integration_static_label_config(organization, alert_receive_channel)
-    label_3 = make_integration_static_label_config(organization, alert_receive_channel)
+    label_1 = make_static_label_config(organization, alert_receive_channel)
+    label_2 = make_static_label_config(organization, alert_receive_channel)
+    label_3 = make_static_label_config(organization, alert_receive_channel)
 
     custom = [
         # plain label

--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -74,7 +74,7 @@ def assign_labels(
 def _apply_dynamic_labels(
     alert_receive_channel: "AlertReceiveChannel", raw_request_data: "Alert.RawRequestData"
 ) -> types.AlertLabels:
-    from apps.labels.models import LabelKeyCache, LabelValueCache
+    from apps.labels.models import LabelKeyCache
 
     if alert_receive_channel.alert_group_labels_custom is None:
         return {}
@@ -87,17 +87,9 @@ def _apply_dynamic_labels(
         ).only("id", "name")
     }
 
-    # fetch up-to-date label value names
-    label_value_names = {
-        v.id: v.name
-        for v in LabelValueCache.objects.filter(
-            id__in=[label[1] for label in alert_receive_channel.alert_group_labels_custom if label[1]]
-        ).only("id", "name")
-    }
-
     result_labels = {}
     for label in alert_receive_channel.alert_group_labels_custom:
-        label = _apply_dynamic_label_entry(label, label_key_names, label_value_names, raw_request_data)
+        label = _apply_dynamic_label_entry(label, label_key_names, raw_request_data)
         if label:
             key, value = label
             result_labels[key] = value

--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -178,7 +178,7 @@ def _apply_multi_label_extraction_template(
 
         result_labels[key] = rendered_labels[key]
 
-    return rendered_labels
+    return result_labels
 
 
 def _validate_templated_value(value: typing.Any) -> bool:

--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -106,7 +106,7 @@ def _apply_dynamic_labels(
 
 
 def _apply_dynamic_label_entry(
-    label: "AlertReceiveChannel.LabelsSchemaEntryDB", keys, values, payload
+    label: "AlertReceiveChannel.DynamicLabelsEntryDB", keys, values, payload
 ) -> typing.Optional[tuple[str, str]]:
     key_id, value_id, template = label
     key, value = "", ""

--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -162,21 +162,21 @@ def _apply_multi_label_extraction_template(
         return {}
 
     # validate rendered k-v pairs & drop invalid ones
+    result_labels = {}
     for key in rendered_labels:
         # check key length
         if len(key) == 0:
             logger.warning("Template result key is empty. %s", key)
-            del rendered_labels[key]
             continue
 
         if len(key) > MAX_KEY_NAME_LENGTH:
             logger.warning("Template result key is too long. %s", key)
-            del rendered_labels[key]
             continue
 
         if not _validate_templated_value(rendered_labels[key]):
-            del rendered_labels[key]
             continue
+
+        result_labels[key] = rendered_labels[key]
 
     return rendered_labels
 

--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -106,7 +106,7 @@ def _apply_dynamic_labels(
 
 
 def _apply_dynamic_label_entry(
-    label: "AlertReceiveChannel.DynamicLabelsEntryDB", keys, values, payload
+    label: "AlertReceiveChannel.DynamicLabelsEntryDB", keys: dict, payload: "Alert.RawRequestData"
 ) -> typing.Optional[tuple[str, str]]:
     key_id, value_id, template = label
     key, value = "", ""

--- a/engine/apps/labels/alert_group_labels.py
+++ b/engine/apps/labels/alert_group_labels.py
@@ -107,7 +107,7 @@ def _apply_dynamic_labels(
 
 def _apply_dynamic_label_entry(
     label: "AlertReceiveChannel.LabelsSchemaEntryDB", keys, values, payload
-) -> typing.Optional[str, str]:
+) -> typing.Optional[tuple[str, str]]:
     key_id, value_id, template = label
     key, value = "", ""
 

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -91,9 +91,9 @@ def test_assign_dynamic_labels(
     _ = make_label_value(label_key_severity, value_name="critical")
 
     # set-up some keys to test invalid templates
-    label_key_3 = make_label_key(organization=organization)
-    label_key_4 = make_label_key(organization=organization)
-    label_key_5 = make_label_key(organization=organization)
+    label_key_cluster = make_label_key(organization=organization, key_name="cluster")
+    label_key_region = make_label_key(organization=organization, key_name="region")
+    label_key_team = make_label_key(organization=organization, key_name="team")
 
     # create alert receive channel with all 3 types of labels
     alert_receive_channel = make_alert_receive_channel(
@@ -104,11 +104,11 @@ def test_assign_dynamic_labels(
             # valid templated label, parsed value NOT present in label repo  Expected to be attached anyway.
             [label_key_service.id, None, "{{ payload.service }}"],
             # templated label too long.  Expected to be ignored
-            [label_key_3.id, None, TOO_LONG_VALUE_NAME],
+            [label_key_cluster.id, None, TOO_LONG_VALUE_NAME],
             # templated label with jinja template pointing to nonexistent attribute in alert payload,  Expected to be ignored
-            [label_key_4.id, None, "{{ payload.nonexistent }}"],
+            [label_key_region.id, None, "{{ payload.nonexistent }}"],
             # templated label explicitly set to None. Expected to be ignored
-            [label_key_5.id, None, "{{ payload.nonexistent or None}}"],
+            [label_key_team.id, None, "{{ payload.nonexistent or None}}"],
             # templated label with nonexistent key ID. Expected to be ignored
             ["nonexistent", None, "{{ payload.severity }}"],
         ],

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -108,7 +108,7 @@ def test_assign_dynamic_labels(
             # templated label with jinja template pointing to nonexistent attribute in alert payload,  Expected to be ignored
             [label_key_region.id, None, "{{ payload.nonexistent }}"],
             # templated label explicitly set to None. Expected to be ignored
-            [label_key_team.id, None, "{{ payload.nonexistent or None}}"],
+            [label_key_team.id, None, "{{ payload.nonexistent or None }}"],
             # templated label with nonexistent key ID. Expected to be ignored
             ["nonexistent", None, "{{ payload.severity }}"],
         ],

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -161,7 +161,7 @@ def test_assign_static_labels(
         link_to_upstream_details=None,
     )
 
-    assert [(label.key_name, label.value_name) for label in alert.group.labels.all()] == [("a", "b")]
+    assert [(label.key_name, label.value_name) for label in alert.group.labels.all()] == [("severity", "critical")]
 
 
 @pytest.mark.django_db

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -12,11 +12,11 @@ TOO_LONG_VALUE_NAME = "v" * (MAX_VALUE_NAME_LENGTH + 1)
 @mock.patch("apps.labels.alert_group_labels.is_labels_feature_enabled", return_value=False)
 @pytest.mark.django_db
 def test_assign_labels_feature_flag_disabled(
-    _, make_organization, make_alert_receive_channel, make_integration_static_label_config
+    _, make_organization, make_alert_receive_channel, make_static_label_config
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    make_integration_static_label_config(organization, alert_receive_channel)
+    make_static_label_config(organization, alert_receive_channel)
 
     alert = Alert.create(
         title="the title",
@@ -37,7 +37,7 @@ def test_multi_label_extraction_template(
     make_alert_receive_channel,
     make_label_key_and_value,
     make_label_key,
-    make_integration_static_label_config,
+    make_static_label_config,
 ):
     organization = make_organization()
 
@@ -141,17 +141,15 @@ def test_assign_dynamic_labels(
 def test_assign_static_labels(
     make_organization,
     make_alert_receive_channel,
-    make_integration_static_label_config,
+    make_static_label_config,
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization, alert_group_labels_custom=None)
     # Configure a static label - expected to be attached to group.
-    make_integration_static_label_config(
-        organization, alert_receive_channel, key_name="severity", value_name="critical"
-    )
+    make_static_label_config(organization, alert_receive_channel, key_name="severity", value_name="critical")
 
     # Configure a static label & delete key and value caches. Expected to be ignored.
-    make_integration_static_label_config(organization, alert_receive_channel, key_name="service", value_name="oncall")
+    make_static_label_config(organization, alert_receive_channel, key_name="service", value_name="oncall")
     key = LabelKeyCache.objects.get(name="service")
     LabelValueCache.objects.filter(name="oncall", key=key).delete()
     key.delete()
@@ -171,7 +169,7 @@ def test_assign_static_labels(
 
 @pytest.mark.django_db
 def test_assign_labels_too_many(
-    make_organization, make_alert_receive_channel, make_integration_static_label_config, make_label_key_and_value
+    make_organization, make_alert_receive_channel, make_static_label_config, make_label_key_and_value
 ):
     organization = make_organization()
 
@@ -181,7 +179,7 @@ def test_assign_labels_too_many(
         alert_group_labels_custom=[[label_key.id, label_value.id, None]],
         alert_group_labels_template='{{ {"b": payload.b} | tojson }}',
     )
-    make_integration_static_label_config(organization, alert_receive_channel, key_name="c", value_name="test")
+    make_static_label_config(organization, alert_receive_channel, key_name="c", value_name="test")
 
     with mock.patch("apps.labels.alert_group_labels.MAX_LABELS_PER_ALERT_GROUP", 2):
         alert = Alert.create(

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -81,7 +81,6 @@ def test_assign_dynamic_labels(
     make_label_key_and_value,
     make_label_key,
     make_label_value,
-    make_static_label_config,
 ):
     organization = make_organization()
 
@@ -114,8 +113,6 @@ def test_assign_dynamic_labels(
             ["nonexistent", None, "{{ payload.severity }}"],
         ],
     )
-    make_static_label_config(organization, alert_receive_channel, key_name="e", value_name="f")
-
     # create alert group
     alert = Alert.create(
         title="the title",
@@ -132,8 +129,8 @@ def test_assign_dynamic_labels(
     )
 
     assert [(label.key_name, label.value_name) for label in alert.group.labels.all()] == [
-        ("severity", "critical"),
         ("service", "oncall"),
+        ("severity", "critical"),
     ]
 
 

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -94,6 +94,7 @@ def test_assign_dynamic_labels(
     # set-up some keys to test invalid templates
     label_key_3 = make_label_key(organization=organization)
     label_key_4 = make_label_key(organization=organization)
+    label_key_5 = make_label_key(organization=organization)
 
     # create alert receive channel with all 3 types of labels
     alert_receive_channel = make_alert_receive_channel(
@@ -107,6 +108,8 @@ def test_assign_dynamic_labels(
             [label_key_3.id, None, TOO_LONG_VALUE_NAME],
             # templated label with jinja template pointing to nonexistent attribute in alert payload,  Expected to be ignored
             [label_key_4.id, None, "{{ payload.nonexistent }}"],
+            # templated label explicitly set to None. Expected to be ignored
+            [label_key_5.id, None, "{{ payload.nonexistent or None}}"],
             # templated label with nonexistent key ID. Expected to be ignored
             ["nonexistent", None, "{{ payload.severity }}"],
         ],

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -81,7 +81,7 @@ def test_assign_dynamic_labels(
     make_label_key_and_value,
     make_label_key,
     make_label_value,
-    make_integration_static_label_config,
+    make_static_label_config,
 ):
     organization = make_organization()
 
@@ -111,7 +111,7 @@ def test_assign_dynamic_labels(
             ["nonexistent", None, "{{ payload.severity }}"],
         ],
     )
-    make_integration_static_label_config(organization, alert_receive_channel, key_name="e", value_name="f")
+    make_static_label_config(organization, alert_receive_channel, key_name="e", value_name="f")
 
     # create alert group
     alert = Alert.create(

--- a/engine/apps/labels/tests/test_alert_group.py
+++ b/engine/apps/labels/tests/test_alert_group.py
@@ -173,9 +173,9 @@ def test_assign_labels_too_many(
     label_key, label_value = make_label_key_and_value(organization, key_name="a", value_name="test")
     alert_receive_channel = make_alert_receive_channel(
         organization,
-        alert_group_labels_custom=[[label_key.id, label_value.id, None]],
         alert_group_labels_template='{{ {"b": payload.b} | tojson }}',
     )
+    make_static_label_config(organization, alert_receive_channel, key_name="a", value_name="test")
     make_static_label_config(organization, alert_receive_channel, key_name="c", value_name="test")
 
     with mock.patch("apps.labels.alert_group_labels.MAX_LABELS_PER_ALERT_GROUP", 2):

--- a/engine/apps/labels/tests/test_labels.py
+++ b/engine/apps/labels/tests/test_labels.py
@@ -92,12 +92,12 @@ def test_label_associate_existing_label(make_label_key_and_value, make_organizat
 
 @pytest.mark.django_db
 def test_label_update_association_by_removing_label(
-    make_integration_label_association, make_organization, make_alert_receive_channel
+    make_integration_static_label_config, make_organization, make_alert_receive_channel
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association_1 = make_integration_label_association(organization, alert_receive_channel)
-    label_association_2 = make_integration_label_association(organization, alert_receive_channel)
+    label_association_1 = make_integration_static_label_config(organization, alert_receive_channel)
+    label_association_2 = make_integration_static_label_config(organization, alert_receive_channel)
     labels_data = [
         {
             "key": {"id": label_association_1.key_id, "name": label_association_1.key.name, "prescribed": False},

--- a/engine/apps/labels/tests/test_labels.py
+++ b/engine/apps/labels/tests/test_labels.py
@@ -92,12 +92,12 @@ def test_label_associate_existing_label(make_label_key_and_value, make_organizat
 
 @pytest.mark.django_db
 def test_label_update_association_by_removing_label(
-    make_integration_static_label_config, make_organization, make_alert_receive_channel
+    make_static_label_config, make_organization, make_alert_receive_channel
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association_1 = make_integration_static_label_config(organization, alert_receive_channel)
-    label_association_2 = make_integration_static_label_config(organization, alert_receive_channel)
+    label_association_1 = make_static_label_config(organization, alert_receive_channel)
+    label_association_2 = make_static_label_config(organization, alert_receive_channel)
     labels_data = [
         {
             "key": {"id": label_association_1.key_id, "name": label_association_1.key.name, "prescribed": False},

--- a/engine/apps/labels/tests/test_labels_cache.py
+++ b/engine/apps/labels/tests/test_labels_cache.py
@@ -89,11 +89,11 @@ def test_update_labels_cache(make_organization, make_label_key_and_value, make_l
 
 @pytest.mark.django_db
 def test_update_instances_labels_cache_recently_synced(
-    make_organization, make_alert_receive_channel, make_integration_static_label_config
+    make_organization, make_alert_receive_channel, make_static_label_config
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association = make_integration_static_label_config(organization, alert_receive_channel)
+    label_association = make_static_label_config(organization, alert_receive_channel)
 
     assert not label_association.key.is_outdated
     assert not label_association.value.is_outdated
@@ -109,11 +109,11 @@ def test_update_instances_labels_cache_recently_synced(
 
 @pytest.mark.django_db
 def test_update_instances_labels_cache_outdated(
-    make_organization, make_alert_receive_channel, make_integration_static_label_config
+    make_organization, make_alert_receive_channel, make_static_label_config
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association = make_integration_static_label_config(organization, alert_receive_channel)
+    label_association = make_static_label_config(organization, alert_receive_channel)
     outdated_last_synced = timezone.now() - timezone.timedelta(minutes=LABEL_OUTDATED_TIMEOUT_MINUTES + 1)
 
     LabelKeyCache.objects.filter(id=label_association.key_id).update(last_synced=outdated_last_synced)
@@ -140,12 +140,10 @@ def test_update_instances_labels_cache_outdated(
 
 
 @pytest.mark.django_db
-def test_update_instances_labels_cache_error(
-    make_organization, make_alert_receive_channel, make_integration_static_label_config
-):
+def test_update_instances_labels_cache_error(make_organization, make_alert_receive_channel, make_static_label_config):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association = make_integration_static_label_config(organization, alert_receive_channel)
+    label_association = make_static_label_config(organization, alert_receive_channel)
     outdated_last_synced = timezone.now() - timezone.timedelta(minutes=LABEL_OUTDATED_TIMEOUT_MINUTES + 1)
 
     LabelKeyCache.objects.filter(id=label_association.key_id).update(last_synced=outdated_last_synced)

--- a/engine/apps/labels/tests/test_labels_cache.py
+++ b/engine/apps/labels/tests/test_labels_cache.py
@@ -89,11 +89,11 @@ def test_update_labels_cache(make_organization, make_label_key_and_value, make_l
 
 @pytest.mark.django_db
 def test_update_instances_labels_cache_recently_synced(
-    make_organization, make_alert_receive_channel, make_integration_label_association
+    make_organization, make_alert_receive_channel, make_integration_static_label_config
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association = make_integration_label_association(organization, alert_receive_channel)
+    label_association = make_integration_static_label_config(organization, alert_receive_channel)
 
     assert not label_association.key.is_outdated
     assert not label_association.value.is_outdated
@@ -109,11 +109,11 @@ def test_update_instances_labels_cache_recently_synced(
 
 @pytest.mark.django_db
 def test_update_instances_labels_cache_outdated(
-    make_organization, make_alert_receive_channel, make_integration_label_association
+    make_organization, make_alert_receive_channel, make_integration_static_label_config
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association = make_integration_label_association(organization, alert_receive_channel)
+    label_association = make_integration_static_label_config(organization, alert_receive_channel)
     outdated_last_synced = timezone.now() - timezone.timedelta(minutes=LABEL_OUTDATED_TIMEOUT_MINUTES + 1)
 
     LabelKeyCache.objects.filter(id=label_association.key_id).update(last_synced=outdated_last_synced)
@@ -141,11 +141,11 @@ def test_update_instances_labels_cache_outdated(
 
 @pytest.mark.django_db
 def test_update_instances_labels_cache_error(
-    make_organization, make_alert_receive_channel, make_integration_label_association
+    make_organization, make_alert_receive_channel, make_integration_static_label_config
 ):
     organization = make_organization()
     alert_receive_channel = make_alert_receive_channel(organization)
-    label_association = make_integration_label_association(organization, alert_receive_channel)
+    label_association = make_integration_static_label_config(organization, alert_receive_channel)
     outdated_last_synced = timezone.now() - timezone.timedelta(minutes=LABEL_OUTDATED_TIMEOUT_MINUTES + 1)
 
     LabelKeyCache.objects.filter(id=label_association.key_id).update(last_synced=outdated_last_synced)

--- a/engine/conftest.py
+++ b/engine/conftest.py
@@ -1088,7 +1088,7 @@ def make_label_key_and_value(make_label_key, make_label_value):
 
 
 @pytest.fixture
-def make_integration_static_label_config(make_label_key_and_value):
+def make_static_label_config(make_label_key_and_value):
     def _make_integration_label_association(
         organization, alert_receive_channel, key_id=None, key_name=None, value_id=None, value_name=None, **kwargs
     ):

--- a/engine/conftest.py
+++ b/engine/conftest.py
@@ -1088,7 +1088,7 @@ def make_label_key_and_value(make_label_key, make_label_value):
 
 
 @pytest.fixture
-def make_integration_label_association(make_label_key_and_value):
+def make_integration_static_label_config(make_label_key_and_value):
     def _make_integration_label_association(
         organization, alert_receive_channel, key_id=None, key_name=None, value_id=None, value_name=None, **kwargs
     ):


### PR DESCRIPTION
1. Fix https://github.com/grafana/irm/issues/530 - applied same validation logic as for multi-label extraction template to dynamic label.  Actual fix is here - https://github.com/grafana/oncall/pull/5363/files#diff-58657df0f1ff9a8578a14504f1c6cfd240e45e084171c5bbeb09d975c3ec72ddR74
2. Some minor refactorings over static/dynamic/integration label naming. This work should be continued in separate PR.