### PR TITLE
fix(settings): Repair database option parsing logic

### DIFF
--- a/engine/settings/base.py
+++ b/engine/settings/base.py
@@ -155,7 +155,7 @@ DATABASE_PORT = os.getenv("DATABASE_PORT") or os.getenv("MYSQL_PORT")
 DATABASE_OPTIONS = os.getenv("DATABASE_OPTIONS")
 if DATABASE_OPTIONS:
     try:
-        DATABASE_OPTIONS = dict([tuple(i.split("=")) for i in str(DATABASE_OPTIONS).split(" ")])
+        DATABASE_OPTIONS = dict([tuple(i.split("=",1)) for i in str(DATABASE_OPTIONS).split(";")])
     except Exception:
         raise Exception("Bad database options. Check DATABASE_OPTIONS variable")
 else:

--- a/helm/oncall/templates/_env.tpl
+++ b/helm/oncall/templates/_env.tpl
@@ -244,7 +244,7 @@
       key: {{ include "snippet.mysql.password.secret.key" . | quote }}
 {{- if not .Values.mariadb.enabled }}
 {{- with .Values.externalMysql.options }}
-- name: MYSQL_OPTIONS
+- name: DATABASE_OPTIONS
   value: {{ . | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION


# What this PR does
- Rename the variable name of MYSQL_OPTIONS to DATABASE_OPTIONS

- Modify the parsing logic of database options, using ";" to separate key-value pairs

- Update the environment variable definitions in the Helm template
## Which issue(s) this PR closes

Closes #5384

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
