### PR TITLE
Add `managed_service_accounts_enabled` requirement for newer Grafana …

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Developer-friendly incident response with brilliant Slack integration.
 > [!IMPORTANT]  
 > These instructions are for using Grafana 11 or newer. You must enable the feature toggle for
 > `externalServiceAccounts`. This is already done for the docker files and helm charts.  If you are running Grafana
-> separately see the Grafana documentation on how to enable this.
+> separately see the Grafana documentation on how to enable this. For Grafana 11.3+ you also need to enable `managed_service_accounts_enabled`.
 
 We prepared multiple environments:
 


### PR DESCRIPTION
…versions.

# What this PR does
Add `managed_service_accounts_enabled` requirement for newer Grafana versions. 

## Which issue(s) this PR closes
I'm not sure that this closes this issue, but it should help people with this issue.

Related to https://github.com/grafana/oncall/issues/5100

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
