### PR TITLE
Update publishing workflows to use GitHub App authentication 

### DIFF
--- a/.github/workflows/publish-technical-documentation-next.yml
+++ b/.github/workflows/publish-technical-documentation-next.yml
@@ -1,58 +1,21 @@
-name: "Publish Technical Documentation (next)"
+name: publish-technical-documentation-next
 
 on:
   push:
     branches:
-      - "main"
+      - main
     paths:
       - "docs/sources/**"
   workflow_dispatch:
-
 jobs:
-  test:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v4"
-      - name: "Build website"
-        # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
-        # that no refs to external content can be used as these refs will not resolve in the
-        # docs-base image.
-        run: >
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest
-          -e HUGO_REFLINKSERRORLEVEL=ERROR
-          --rm grafana/docs-base:latest /bin/bash
-          -c 'echo -e "---\\nredirectURL: /hugo/content/docs/oncall/latest/\\ntype: redirect\\nversioned: true\\n---\\n"
-          > /hugo/content/docs/oncall/_index.md; make hugo'
-
   sync:
-    runs-on: "ubuntu-latest"
-    needs: "test"
+    if: github.repository == 'grafana/oncall'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
     steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v4"
-
-      - name: "Clone website-sync Action"
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: |
-          git clone --single-branch --no-tags --depth 1 \
-          -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync \
-          ./.github/actions/website-sync
-
-      - name: "Publish to website repository (next)"
-        uses: "./.github/actions/website-sync"
-        id: "publish-next"
+      - uses: actions/checkout@v4
+      - uses: grafana/writers-toolkit/publish-technical-documentation@publish-technical-documentation/v1
         with:
-          repository: "grafana/website"
-          branch: "master"
-          host: "github.com"
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
-          source_folder: "docs/sources"
-          target_folder: "content/docs/oncall/next"
+          website_directory: content/docs/oncall/next

--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -1,4 +1,4 @@
-name: "Publish Technical Documentation (release)"
+name: publish-technical-documentation-release
 
 on:
   push:
@@ -9,85 +9,20 @@ on:
     paths:
       - "docs/sources/**"
   workflow_dispatch:
-
 jobs:
-  test:
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: "Check out code"
-        uses: "actions/checkout@v4"
-      - name: "Build website"
-        # -e HUGO_REFLINKSERRORLEVEL=ERROR prevents merging broken refs with the downside
-        # that no refs to external content can be used as these refs will not resolve in the
-        # docs-base image.
-        run: >
-          docker run -v ${PWD}/docs/sources:/hugo/content/docs/oncall/latest
-          -e HUGO_REFLINKSERRORLEVEL=ERROR
-          --rm grafana/docs-base:latest /bin/bash
-          -c 'echo -e "---\\nredirectURL: /hugo/content/docs/oncall/latest/\\ntype: redirect\\nversioned: true\\n---\\n"
-          > /hugo/content/docs/oncall/_index.md; make hugo'
-
   sync:
-    runs-on: "ubuntu-latest"
-    needs: "test"
+    if: github.repository == 'grafana/oncall'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
     steps:
-      - name: "Checkout code and tags"
-        uses: "actions/checkout@v4"
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: "Checkout Actions library"
-        uses: "actions/checkout@v4"
+      - uses: grafana/writers-toolkit/publish-technical-documentation-release@publish-technical-documentation-release/v2
         with:
-          repository: "grafana/grafana-github-actions"
-          path: "./actions"
-
-      - name: "Install Actions from library"
-        run: "npm install --production --prefix ./actions"
-
-      - name: "Determine if there is a matching release tag"
-        id: "has-matching-release-tag"
-        uses: "./actions/has-matching-release-tag"
-        with:
-          ref_name: "${{ github.ref_name }}"
-          release_tag_regexp: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-          release_branch_regexp: "^release-(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
-
-      - name: "Determine technical documentation version"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        uses: "./actions/docs-target"
-        id: "target"
-        with:
-          ref_name: "${{ github.ref_name }}"
-
-      - name: "Clone website-sync Action"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        # WEBSITE_SYNC_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-        # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-        # GitHub administrator to update the organization secret.
-        # The IT helpdesk can update the organization secret.
-        run: |
-          git clone --single-branch --no-tags --depth 1 \
-          -b master https://grafanabot:${{ secrets.WEBSITE_SYNC_TOKEN }}@github.com/grafana/website-sync \
-          ./.github/actions/website-sync
-
-      - name: "Publish to website repository (release)"
-        if: "steps.has-matching-release-tag.outputs.bool == 'true'"
-        uses: "./.github/actions/website-sync"
-        id: "publish-release"
-        with:
-          repository: "grafana/website"
-          branch: "master"
-          host: "github.com"
-          # PUBLISH_TO_WEBSITE_TOKEN is a fine-grained GitHub Personal Access Token that expires.
-          # It must be regenerated in the grafanabot GitHub account and requires a Grafana organization
-          # GitHub administrator to update the organization secret.
-          # The IT helpdesk can update the organization secret.
-          github_pat: "grafanabot:${{ secrets.PUBLISH_TO_WEBSITE_TOKEN }}"
-          source_folder: "docs/sources"
-          # Append ".x" to target to produce a v<major>.<minor>.x directory.
-          target_folder: "content/docs/oncall/${{ steps.target.outputs.target }}.x"
-          # Allow the workflow to succeed if there are no changes to commit.
-          # This is only going to be true on tags as those events ignore the path
-          # filter in the workflow `on.push` section.
-          allow_no_changes: "true"
+          release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          release_branch_with_patch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          website_directory: content/docs/oncall


### PR DESCRIPTION
# What this PR does

Use a centralized composite action that uses GitHub App authentication to publish documentation.
The organization secrets used in the current workflows have expired.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
