### PR TITLE
Use tags only workflow behavior

### DIFF
--- a/.github/workflows/publish-technical-documentation-release.yml
+++ b/.github/workflows/publish-technical-documentation-release.yml
@@ -25,4 +25,6 @@ jobs:
           release_tag_regexp: "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           release_branch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
           release_branch_with_patch_regexp: "^release-(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$"
+          # This repository only releases from the tag reference and not from long-lived release branches.
+          tags_only: true
           website_directory: content/docs/oncall


### PR DESCRIPTION
# What this PR does

Without this, the action assumes there is a release branch that a tag is made on because that is common to most other Grafana repositories. Those repositories maintain a long-lived release branch to facilitate backports to documentation and code.

Since grafana/oncall doesn't follow this pattern, it doesn't make sense to try and discover the matching release branch. That action behavior is disabled by the `tags_only: true` setting.

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
