### PR TITLE
chore: update schedule checks notification period and improve wording

### DIFF
--- a/engine/apps/api/serializers/schedule_calendar.py
+++ b/engine/apps/api/serializers/schedule_calendar.py
@@ -2,7 +2,11 @@ from rest_framework import serializers
 
 from apps.api.serializers.schedule_base import ScheduleBaseSerializer
 from apps.schedules.models import OnCallScheduleCalendar
-from apps.schedules.tasks import schedule_notify_about_empty_shifts_in_schedule, schedule_notify_about_gaps_in_schedule
+from apps.schedules.tasks import (
+    check_gaps_and_empty_shifts_in_schedule,
+    schedule_notify_about_empty_shifts_in_schedule,
+    schedule_notify_about_gaps_in_schedule,
+)
 from apps.slack.models import SlackChannel, SlackUserGroup
 from common.api_helpers.custom_fields import OrganizationFilteredPrimaryKeyRelatedField, TimeZoneField
 from common.api_helpers.utils import validate_ical_url
@@ -58,7 +62,7 @@ class ScheduleCalendarCreateSerializer(ScheduleCalendarSerializer):
             or old_enable_web_overrides != updated_enable_web_overrides
         ):
             updated_schedule.drop_cached_ical()
-            updated_schedule.check_gaps_and_empty_shifts_for_next_week()
+            check_gaps_and_empty_shifts_in_schedule.apply_async((instance.pk,))
             schedule_notify_about_empty_shifts_in_schedule.apply_async((instance.pk,))
             schedule_notify_about_gaps_in_schedule.apply_async((instance.pk,))
         return updated_schedule

--- a/engine/apps/api/serializers/schedule_ical.py
+++ b/engine/apps/api/serializers/schedule_ical.py
@@ -1,6 +1,7 @@
 from apps.api.serializers.schedule_base import ScheduleBaseSerializer
 from apps.schedules.models import OnCallScheduleICal
 from apps.schedules.tasks import (
+    check_gaps_and_empty_shifts_in_schedule,
     refresh_ical_final_schedule,
     schedule_notify_about_empty_shifts_in_schedule,
     schedule_notify_about_gaps_in_schedule,
@@ -87,7 +88,7 @@ class ScheduleICalUpdateSerializer(ScheduleICalCreateSerializer):
 
         if old_ical_url_primary != updated_ical_url_primary or old_ical_url_overrides != updated_ical_url_overrides:
             updated_schedule.drop_cached_ical()
-            updated_schedule.check_gaps_and_empty_shifts_for_next_week()
+            check_gaps_and_empty_shifts_in_schedule.apply_async((instance.pk,))
             schedule_notify_about_empty_shifts_in_schedule.apply_async((instance.pk,))
             schedule_notify_about_gaps_in_schedule.apply_async((instance.pk,))
             # for iCal-based schedules we need to refresh final schedule information

--- a/engine/apps/api/views/schedule.py
+++ b/engine/apps/api/views/schedule.py
@@ -481,7 +481,7 @@ class ScheduleView(
     def reload_ical(self, request, pk):
         schedule = self.get_object(annotate=False)
         schedule.drop_cached_ical()
-        schedule.check_gaps_and_empty_shifts_for_next_week()
+        schedule.check_gaps_and_empty_shifts_for_next_days()
 
         if schedule.user_group is not None:
             update_slack_user_group_for_schedules.apply_async((schedule.user_group.pk,))

--- a/engine/apps/schedules/constants.py
+++ b/engine/apps/schedules/constants.py
@@ -29,5 +29,6 @@ EXPORT_WINDOW_DAYS_BEFORE = 15
 
 SCHEDULE_ONCALL_CACHE_KEY_PREFIX = "schedule_oncall_users_"
 SCHEDULE_ONCALL_CACHE_TTL = 15 * 60  # 15 minutes in seconds
+SCHEDULE_CHECK_NEXT_DAYS = 30
 
 PREFETCHED_SHIFT_SWAPS = "prefetched_shift_swaps"

--- a/engine/apps/schedules/models/on_call_schedule.py
+++ b/engine/apps/schedules/models/on_call_schedule.py
@@ -33,6 +33,7 @@ from apps.schedules.constants import (
     ICAL_SUMMARY,
     ICAL_UID,
     PREFETCHED_SHIFT_SWAPS,
+    SCHEDULE_CHECK_NEXT_DAYS,
 )
 from apps.schedules.ical_utils import (
     EmptyShifts,
@@ -293,9 +294,9 @@ class OnCallSchedule(PolymorphicModel):
             (self.prev_ical_file_overrides, self.cached_ical_file_overrides),
         ]
 
-    def check_gaps_and_empty_shifts_for_next_week(self) -> None:
+    def check_gaps_and_empty_shifts_for_next_days(self, days=SCHEDULE_CHECK_NEXT_DAYS) -> None:
         datetime_start = timezone.now()
-        datetime_end = datetime_start + datetime.timedelta(days=7)
+        datetime_end = datetime_start + datetime.timedelta(days=days)
 
         # get empty shifts from all events and gaps from final events
         events = self.filter_events(
@@ -313,14 +314,14 @@ class OnCallSchedule(PolymorphicModel):
             self.has_empty_shifts = has_empty_shifts
             self.save(update_fields=["has_gaps", "has_empty_shifts"])
 
-    def get_gaps_for_next_week(self) -> ScheduleEvents:
+    def get_gaps_for_next_days(self, days=SCHEDULE_CHECK_NEXT_DAYS) -> ScheduleEvents:
         today = timezone.now()
-        events = self.final_events(today, today + datetime.timedelta(days=7))
+        events = self.final_events(today, today + datetime.timedelta(days=days))
         return [event for event in events if event["is_gap"]]
 
-    def get_empty_shifts_for_next_week(self) -> EmptyShifts:
+    def get_empty_shifts_for_next_days(self, days=SCHEDULE_CHECK_NEXT_DAYS) -> EmptyShifts:
         today = timezone.now().date()
-        return list_of_empty_shifts_in_schedule(self, today, today + datetime.timedelta(days=7))
+        return list_of_empty_shifts_in_schedule(self, today, today + datetime.timedelta(days=days))
 
     def drop_cached_ical(self):
         self._drop_primary_ical_file()

--- a/engine/apps/schedules/tasks/check_gaps_and_empty_shifts.py
+++ b/engine/apps/schedules/tasks/check_gaps_and_empty_shifts.py
@@ -19,5 +19,5 @@ def check_gaps_and_empty_shifts_in_schedule(schedule_pk):
         task_logger.info(f"Tried to check_gaps_and_empty_shifts_in_schedule for non-existing schedule {schedule_pk}")
         return
 
-    schedule.check_gaps_and_empty_shifts_for_next_week()
+    schedule.check_gaps_and_empty_shifts_for_next_days()
     task_logger.info(f"Finish check_gaps_and_empty_shifts_in_schedule {schedule_pk}")

--- a/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
@@ -54,9 +54,9 @@ def notify_about_empty_shifts_in_schedule_task(schedule_pk):
     if len(empty_shifts) != 0:
         schedule.has_empty_shifts = True
         text = (
-            f'Tried to parse schedule *"{schedule.name}"* and found events without associated users.\n'
-            f"To ensure you don't miss any notifications, use a Grafana username as the event name in the calendar. "
-            f"The user should have Editor or Admin access.\n\n"
+            f"Reviewing *{schedule.slack_url}* on-call schedule found events without valid associated users.\n"
+            f"To ensure you don't miss any notifications, make sure user exists (or you provided a valid Grafana username). "
+            f"The user should have the right permissions, or be an Editor or Admin.\n\n"
         )
         for idx, empty_shift in enumerate(empty_shifts):
             start_timestamp = empty_shift.start.astimezone(pytz.UTC).timestamp()
@@ -80,7 +80,6 @@ def notify_about_empty_shifts_in_schedule_task(schedule_pk):
                 text += '*All-day* event in "UTC" TZ\n'
             else:
                 text += f"From {format_datetime_to_slack_with_time(start_timestamp)} to {format_datetime_to_slack_with_time(end_timestamp)} (your TZ)\n"
-            text += f"_From {OnCallSchedule.CALENDAR_TYPE_VERBAL[empty_shift.calendar_type]} calendar_\n"
             if idx != len(empty_shifts) - 1:
                 text += "\n\n"
         post_message_to_channel(schedule.organization, schedule.slack_channel_slack_id, text)

--- a/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_empty_shifts_in_schedule.py
@@ -48,7 +48,7 @@ def notify_about_empty_shifts_in_schedule_task(schedule_pk):
         task_logger.info(f"Tried to notify_about_empty_shifts_in_schedule_task for non-existing schedule {schedule_pk}")
         return
 
-    empty_shifts = schedule.get_empty_shifts_for_next_week()
+    empty_shifts = schedule.get_empty_shifts_for_next_days()
     schedule.empty_shifts_report_sent_at = timezone.now().date()
 
     if len(empty_shifts) != 0:

--- a/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
@@ -48,7 +48,7 @@ def notify_about_gaps_in_schedule_task(schedule_pk):
         task_logger.info(f"Tried to notify_about_gaps_in_schedule_task for non-existing schedule {schedule_pk}")
         return
 
-    gaps = schedule.get_gaps_for_next_week()
+    gaps = schedule.get_gaps_for_next_days()
     schedule.gaps_report_sent_at = timezone.now().date()
 
     if len(gaps) != 0:

--- a/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tasks/notify_about_gaps_in_schedule.py
@@ -53,8 +53,8 @@ def notify_about_gaps_in_schedule_task(schedule_pk):
 
     if len(gaps) != 0:
         schedule.has_gaps = True
-        text = f"There are time periods that are unassigned in *{schedule.name}* on-call schedule.\n"
-        for idx, gap in enumerate(gaps):
+        text = f"There are time periods that are unassigned in *{schedule.slack_url}* on-call schedule.\n"
+        for gap in gaps:
             if gap["start"]:
                 start_verbal = format_datetime_to_slack_with_time(gap["start"].astimezone(pytz.UTC).timestamp())
             else:
@@ -64,8 +64,7 @@ def notify_about_gaps_in_schedule_task(schedule_pk):
             else:
                 end_verbal = "..."
             text += f"From {start_verbal} to {end_verbal} (your TZ)\n"
-            if idx != len(gaps) - 1:
-                text += "\n\n"
+        text += "\n\n"
         post_message_to_channel(schedule.organization, schedule.slack_channel_slack_id, text)
     else:
         schedule.has_gaps = False

--- a/engine/apps/schedules/tests/test_notify_about_gaps_in_schedule.py
+++ b/engine/apps/schedules/tests/test_notify_about_gaps_in_schedule.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from django.utils import timezone
 
+from apps.schedules.constants import SCHEDULE_CHECK_NEXT_DAYS
 from apps.schedules.models import CustomOnCallShift, OnCallScheduleCalendar, OnCallScheduleICal, OnCallScheduleWeb
 from apps.schedules.tasks import notify_about_gaps_in_schedule_task, start_notify_about_gaps_in_schedule
 
@@ -236,7 +237,7 @@ def test_gaps_near_future_trigger_notification(
 
 
 @pytest.mark.django_db
-def test_gaps_later_than_7_days_no_triggering_notification(
+def test_gaps_later_than_days_no_triggering_notification(
     make_slack_team_identity,
     make_slack_channel,
     make_organization,
@@ -259,8 +260,8 @@ def test_gaps_later_than_7_days_no_triggering_notification(
         prev_ical_file_overrides=None,
         cached_ical_file_overrides=None,
     )
-    start_date = now - datetime.timedelta(days=7, minutes=1)
-    until_date = now + datetime.timedelta(days=8)
+    start_date = now - datetime.timedelta(days=SCHEDULE_CHECK_NEXT_DAYS, minutes=1)
+    until_date = now + datetime.timedelta(days=SCHEDULE_CHECK_NEXT_DAYS + 1)
     data = {
         "start": start_date,
         "rotation_start": start_date,


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2994

- Extend gaps/empty shift checks to consider 30 days (customizable via param, eventually make it customizable per schedule?); ie. every week (per beat schedule), check the schedule next 30 days
- Trigger checks via async task on schedule API updates (instead of a sync call)
- Update notifications wording / link to schedule