### PR TITLE
Fix getting label by name

### DIFF
--- a/engine/apps/labels/models.py
+++ b/engine/apps/labels/models.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+from json import JSONDecodeError
 
 from django.db import models
 from django.utils import timezone
@@ -44,7 +45,7 @@ class LabelKeyCache(models.Model):
             label, _ = LabelsAPIClient(organization.grafana_url, organization.api_token).get_label_by_key_name(
                 label_key
             )
-        except LabelsRepoAPIException as e:
+        except (LabelsRepoAPIException, JSONDecodeError) as e:
             logger.error(f"Failed to get or create label key {key_name} for organization {organization.id}: {e}")
             return None
 

--- a/engine/apps/labels/tests/test_labels_cache.py
+++ b/engine/apps/labels/tests/test_labels_cache.py
@@ -1,3 +1,4 @@
+from json import JSONDecodeError
 from unittest.mock import call, patch
 
 import pytest
@@ -164,6 +165,12 @@ def test_update_instances_labels_cache_error(make_organization, make_alert_recei
 def test_get_or_create_label_key_cache_by_name(make_organization):
     organization = make_organization()
     label_key_data = {"id": "testid", "name": "testname", "prescribed": False}
+
+    # test empty response from label repo (json decode error)
+    with patch.object(LabelsAPIClient, "get_label_by_key_name", side_effect=JSONDecodeError("test", "test", 0)):
+        label = LabelKeyCache.get_or_create_by_name(organization, label_key_data["name"])
+
+    assert label is None
 
     # test label does not exist in labels repo
     with patch.object(LabelsAPIClient, "get_label_by_key_name", side_effect=LabelsRepoAPIException("test", "test")):


### PR DESCRIPTION
# What this PR does
Handle JSONDecodeError on getting label key by name

## Checklist

- [x] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
