### PR TITLE
feat: add filter affected services internal endpoint

### DIFF
--- a/engine/apps/grafana_plugin/tests/test_ui_url_builder.py
+++ b/engine/apps/grafana_plugin/tests/test_ui_url_builder.py
@@ -103,3 +103,9 @@ def test_build_url_overriden_base_url(org_setup):
 @pytest.mark.django_db
 def test_build_url_works_for_irm_and_oncall_plugins(org_setup, is_grafana_irm_enabled, expected_url):
     assert UIURLBuilder(org_setup(is_grafana_irm_enabled)).alert_group_detail(ALERT_GROUP_ID) == expected_url
+
+
+@pytest.mark.django_db
+def test_build_url_service_detail_page(org_setup):
+    builder = UIURLBuilder(org_setup())
+    assert builder.service_page("service-a") == f"{GRAFANA_URL}/a/{PluginID.SLO}/service/service-a"

--- a/engine/apps/grafana_plugin/ui_url_builder.py
+++ b/engine/apps/grafana_plugin/ui_url_builder.py
@@ -56,3 +56,6 @@ class UIURLBuilder:
 
     def declare_incident(self, path_extra: str = "") -> str:
         return self._build_url("incidents/declare", path_extra, plugin_id=PluginID.INCIDENT)
+
+    def service_page(self, service_name: str, path_extra: str = "") -> str:
+        return self._build_url(f"service/{service_name}", path_extra, plugin_id=PluginID.SLO)

--- a/engine/common/constants/plugin_ids.py
+++ b/engine/common/constants/plugin_ids.py
@@ -5,3 +5,4 @@ class PluginID:
     INCIDENT = "grafana-incident-app"
     LABELS = "grafana-labels-app"
     ML = "grafana-ml-app"
+    SLO = "grafana-slo-app"


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2977

e.g.

`GET /api/plugins/grafana-oncall-app/resources/alertgroups/filter_affected_services?service=service-a&service=service-b`

```
[
  {"name": "service-a",
   "service_url": "http://localhost:3000/a/grafana-slo-app/service/service-a",
   "alert_groups_url": "http://localhost:3000/a/grafana-oncall-app/alert-groups?status=0&status=1&started_at=now-7d_now&label=service_name:service-a"}
]
```