### PR TITLE
[fix/recurrence_group_order] queryset to order_by to preseve data order in recurrence_group

### DIFF
--- a/engine/common/api_helpers/custom_fields.py
+++ b/engine/common/api_helpers/custom_fields.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Case, When
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import fields, serializers
 from rest_framework.exceptions import ValidationError
@@ -104,7 +105,7 @@ class UsersFilteredByOrganizationField(serializers.Field):
         if not request or not queryset:
             return None
 
-        users = queryset.filter(organization=request.user.organization, public_primary_key__in=data).distinct()
+        users = queryset.filter(organization=request.user.organization, public_primary_key__in=data).distinct().order_by(Case(*[When(public_primary_key=pk, then=pos) for pos, pk in enumerate(data)]))
         users_ppk = set(u.public_primary_key for u in users)
         data_set = set(data)
 


### PR DESCRIPTION
# What this PR does

## Which issue(s) this PR closes

Related to [issue link here]
the order of the user is not preserve in recurrence_group
![image](https://github.com/user-attachments/assets/71a9e221-8d17-405a-8101-db27defb71ec)


## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
