### PR TITLE
feat: restyled UI to match Figma

### DIFF
--- a/grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx
@@ -58,7 +58,7 @@ export const Tabs = ({
     <TabsBar>
       <Tab
         active={activeTab === UserSettingsTab.UserInfo}
-        label="User Info"
+        label="User info"
         key={UserSettingsTab.UserInfo}
         onChangeTab={getTabClickHandler(UserSettingsTab.UserInfo)}
         data-testid="tab-user-info"
@@ -66,7 +66,7 @@ export const Tabs = ({
       {showNotificationSettingsTab && (
         <Tab
           active={activeTab === UserSettingsTab.NotificationSettings}
-          label="Notification Settings"
+          label="Notification settings"
           key={UserSettingsTab.NotificationSettings}
           onChangeTab={getTabClickHandler(UserSettingsTab.NotificationSettings)}
           data-testid="tab-notification-settings"
@@ -75,7 +75,7 @@ export const Tabs = ({
       {showGoogleCalendarTab && (
         <Tab
           active={activeTab === UserSettingsTab.GoogleCalendar}
-          label="Google Calendar"
+          label="Google calendar"
           key={UserSettingsTab.GoogleCalendar}
           onChangeTab={getTabClickHandler(UserSettingsTab.GoogleCalendar)}
           data-testid="google-calendar-tab"
@@ -83,7 +83,7 @@ export const Tabs = ({
       )}
       <Tab
         active={activeTab === UserSettingsTab.PhoneVerification}
-        label="Phone Verification"
+        label="Phone verification"
         key={UserSettingsTab.PhoneVerification}
         onChangeTab={getTabClickHandler(UserSettingsTab.PhoneVerification)}
         data-testid="tab-phone-verification"
@@ -91,7 +91,7 @@ export const Tabs = ({
       {showMobileAppConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.MobileAppConnection}
-          label="Mobile App Connection"
+          label="Mobile app connection"
           key={UserSettingsTab.MobileAppConnection}
           onChangeTab={getTabClickHandler(UserSettingsTab.MobileAppConnection)}
           data-testid="tab-mobile-app"
@@ -100,7 +100,7 @@ export const Tabs = ({
       {showSlackConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.SlackInfo}
-          label="Slack Connection"
+          label="Slack connection"
           key={UserSettingsTab.SlackInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.SlackInfo)}
           data-testid="tab-slack"
@@ -109,7 +109,7 @@ export const Tabs = ({
       {showTelegramConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.TelegramInfo}
-          label="Telegram Connection"
+          label="Telegram connection"
           key={UserSettingsTab.TelegramInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.TelegramInfo)}
           data-testid="tab-telegram"
@@ -118,7 +118,7 @@ export const Tabs = ({
       {showPersonalWebhookConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.PersonalWebhookInfo}
-          label="Webhook Connection"
+          label="Webhook connection"
           key={UserSettingsTab.PersonalWebhookInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.PersonalWebhookInfo)}
           data-testid="tab-personalwebhook"
@@ -127,7 +127,7 @@ export const Tabs = ({
       {showMsTeamsConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.MSTeamsInfo}
-          label="Ms Teams Connection"
+          label="Ms Teams connection"
           key={UserSettingsTab.MSTeamsInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.MSTeamsInfo)}
           data-testid="tab-msteams"

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/PersonalWebhookInfo/PersonalWebhookInfo.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/PersonalWebhookInfo/PersonalWebhookInfo.tsx
@@ -1,12 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { css } from '@emotion/css';
-import { LoadingPlaceholder, Button, Select, Stack, Field, TextArea } from '@grafana/ui';
+import { LoadingPlaceholder, Button, Select, Stack, Field, TextArea, Icon } from '@grafana/ui';
 import { StackSize } from 'helpers/consts';
 import { observer } from 'mobx-react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { PluginLink } from 'components/PluginLink/PluginLink';
+import { PLUGIN_ROOT } from 'helpers/consts';
 import { Text } from 'components/Text/Text';
 import { WithConfirm } from 'components/WithConfirm/WithConfirm';
 import { ActionKey } from 'models/loader/action-keys';
@@ -129,28 +130,38 @@ export const PersonalWebhookInfo = observer(() => {
     )
   }
 
-  if (!isLoadingOptions && !hasConnectedWebhook && webhookOptions.length === 0) {
-    return (
-      <Stack direction="column" alignItems="center" gap={StackSize.lg}>
-        <Text type="secondary">
-          No webhooks found. Make sure you have added at least one webhook with the Trigger Type set to "Personal Notification".
-        </Text>
-        <PluginLink query={{ page: 'outgoing_webhooks' }}>
-          <Button variant="primary">
-            Go to Outgoing Webhooks
-          </Button>
-        </PluginLink>
-      </Stack>
-    )
-  }
-
+  // if (!isLoadingOptions && !hasConnectedWebhook && webhookOptions.length === 0) {
+  //   return (
+  //     <Stack direction="column" alignItems="center" gap={StackSize.lg}>
+  //       <Text type="secondary">
+  //         No webhooks found. Make sure you have added at least one webhook with the Trigger Type set to "Personal Notification".
+  //       </Text>
+  //       <PluginLink query={{ page: 'outgoing_webhooks' }}>
+  //         <Button variant="primary">
+  //           Go to Outgoing Webhooks
+  //         </Button>
+  //       </PluginLink>
+  //     </Stack>
+  //   )
+  // }
   return (
     <Stack direction="column" alignItems="flex-start" gap={StackSize.lg}>
-      <Text.Title level={2}>Connect a personal webhook</Text.Title>
       <form className={styles.form}>
         <Field
-          label="Webhook"
-          description="Select a webhook to trigger as your personal notification channel."
+          label="Add webhook to send personal notifications"
+          description={
+            <p>The list only displays webhooks that have Personal notification as a trigger.
+              <a href={`${PLUGIN_ROOT}/outgoing_webhooks`} target="_blank" rel="noreferrer" className={styles.link}>
+                <Text type="link">
+                  <span>Configure</span>
+                  <Icon
+                    name="external-link-alt"
+                    className={styles.linkIcon}
+                  />
+                </Text>
+              </a>
+            </p>
+          }
         >
           <Controller
             name="webhook"
@@ -159,29 +170,59 @@ export const PersonalWebhookInfo = observer(() => {
               <Select
                 {...field}
                 menuShouldPortal
-                placeholder={(user.messaging_backends?.WEBHOOK?.name as string) ?? 'Select personal webhook to trigger'}
+                placeholder={(user.messaging_backends?.WEBHOOK?.name as string) ?? 'Select webhook'}
                 onChange={({ value }) => field.onChange(value)}
                 options={webhookOptions}
               />
             }
           />
         </Field>
+<<<<<<< HEAD
         {selectedWebhook != null ? (
           <Field
             label="Context"
             description="Optional. Set additional context (as a JSON dict) to make it available in the webhook payload and/or templates."
             invalid={!!errors.context}
             error={errors.context?.message}
+=======
+        {
+          selectedWebhook != null ? (
+            <Field
+              label="Context"
+              description={
+                <p>You can add additional JSON template to use the same webhook for multiple users events.
+                  <a href={"https://grafana.com/docs/oncall/latest/configure/integrations/outgoing-webhooks"} target="_blank" rel="noreferrer" className={styles.link}>
+                    <Text type="link">
+                      <span>Learn more in docs</span>
+                      <Icon
+                        name="external-link-alt"
+                        className={styles.linkIcon}
+                      />
+                    </Text>
+                  </a>
+                </p>
+              }
+              invalid={!!errors.context}
+              error={errors.context?.message}
+            >
+              <Controller
+                name="context"
+                control={control}
+                rules={contextRules}
+                render={({ field }) => <TextArea {...field} rows={8} />}
+              />
+            </Field>
+          ) : null
+        }
+        <Stack direction="row" gap={2}>
+          <Button
+            type="submit"
+            variant="primary" disabled={!isDirty || !isValid || !hasSelectedValidWebhook}
+            onClick={handleSubmit(onFormSubmit)}
+>>>>>>> 7d4667f0 (restyled UI to match Figma)
           >
-            <Controller
-              name="context"
-              control={control}
-              rules={contextRules}
-              render={({ field }) => <TextArea {...field} rows={8} />}
-            />
-          </Field>
-        ) : null}
-        <Stack direction="row" gap={2} justifyContent="flex-end">
+            {hasConnectedWebhook ? 'Save' : 'Connect'}
+          </Button>
           {hasConnectedWebhook ? (
             <WithConfirm
               title={`Are you sure you want to disconnect the webhook named "${user.messaging_backends.WEBHOOK?.name}"?`}
@@ -193,21 +234,37 @@ export const PersonalWebhookInfo = observer(() => {
               >Disconnect</Button>
             </WithConfirm>
           ) : null}
-          <Button
-            type="submit"
-            variant="primary" disabled={!isDirty || !isValid || !hasSelectedValidWebhook}
-            onClick={handleSubmit(onFormSubmit)}
-          >
-            {hasConnectedWebhook ? 'Update' : 'Connect'}
-          </Button>
         </Stack>
-      </form>
-    </Stack>
+      </form >
+    </Stack >
   );
 });
 
 const styles = {
   form: css`
     width: 100%;
+
+    & > div {
+      margin-bottom: 24px;
+    }
+
+    & > div:last-child {
+      margin-bottom: 0;
+    }
+
+    div {
+      max-width: unset;
+    }
+    
+    p {
+      margin-bottom: 8px;
+    }
   `,
+  link: css`
+    margin-left: 8px;
+  `,
+  linkIcon: css`
+    margin-left: 4px;
+    margin-bottom: 2px;
+  `
 }

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/PersonalWebhookInfo/PersonalWebhookInfo.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/PersonalWebhookInfo/PersonalWebhookInfo.tsx
@@ -6,7 +6,6 @@ import { StackSize } from 'helpers/consts';
 import { observer } from 'mobx-react';
 import { Controller, useForm } from 'react-hook-form';
 
-import { PluginLink } from 'components/PluginLink/PluginLink';
 import { PLUGIN_ROOT } from 'helpers/consts';
 import { Text } from 'components/Text/Text';
 import { WithConfirm } from 'components/WithConfirm/WithConfirm';
@@ -130,20 +129,6 @@ export const PersonalWebhookInfo = observer(() => {
     )
   }
 
-  // if (!isLoadingOptions && !hasConnectedWebhook && webhookOptions.length === 0) {
-  //   return (
-  //     <Stack direction="column" alignItems="center" gap={StackSize.lg}>
-  //       <Text type="secondary">
-  //         No webhooks found. Make sure you have added at least one webhook with the Trigger Type set to "Personal Notification".
-  //       </Text>
-  //       <PluginLink query={{ page: 'outgoing_webhooks' }}>
-  //         <Button variant="primary">
-  //           Go to Outgoing Webhooks
-  //         </Button>
-  //       </PluginLink>
-  //     </Stack>
-  //   )
-  // }
   return (
     <Stack direction="column" alignItems="flex-start" gap={StackSize.lg}>
       <form className={styles.form}>
@@ -177,14 +162,6 @@ export const PersonalWebhookInfo = observer(() => {
             }
           />
         </Field>
-<<<<<<< HEAD
-        {selectedWebhook != null ? (
-          <Field
-            label="Context"
-            description="Optional. Set additional context (as a JSON dict) to make it available in the webhook payload and/or templates."
-            invalid={!!errors.context}
-            error={errors.context?.message}
-=======
         {
           selectedWebhook != null ? (
             <Field
@@ -219,7 +196,6 @@ export const PersonalWebhookInfo = observer(() => {
             type="submit"
             variant="primary" disabled={!isDirty || !isValid || !hasSelectedValidWebhook}
             onClick={handleSubmit(onFormSubmit)}
->>>>>>> 7d4667f0 (restyled UI to match Figma)
           >
             {hasConnectedWebhook ? 'Save' : 'Connect'}
           </Button>

--- a/grafana-plugin/src/containers/UserSettings/parts/tabs/PersonalWebhookInfo/PersonalWebhookInfo.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/tabs/PersonalWebhookInfo/PersonalWebhookInfo.tsx
@@ -167,8 +167,8 @@ export const PersonalWebhookInfo = observer(() => {
             <Field
               label="Context"
               description={
-                <p>You can add additional JSON template to use the same webhook for multiple users events.
-                  <a href={"https://grafana.com/docs/oncall/latest/configure/integrations/outgoing-webhooks"} target="_blank" rel="noreferrer" className={styles.link}>
+                <p>You can add additional JSON context to be used by the webhook templates allowing for webhook reusability between different users.
+                  <a href={"https://grafana.com/docs/oncall/latest/manage/notify/webhook/"} target="_blank" rel="noreferrer" className={styles.link}>
                     <Text type="link">
                       <span>Learn more in docs</span>
                       <Icon


### PR DESCRIPTION
# What this PR does

Restyles the Webhook connection UI to match [the designs in Figma](https://www.figma.com/design/sJ4RvHvnUq6AZAiHYYiB5j/Grafana-OnCall?node-id=12993-188431&t=6h84zanlHB0agXlX-1)

![image](https://github.com/user-attachments/assets/5f37b1af-c39c-4dbf-9c13-8032d8417d78)

## Which issue(s) this PR closes

Related to https://github.com/grafana/irm/issues/332