### PR TITLE
fix: disable recaptcha when site key is not set

### DIFF
--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oncall
 description: Developer-friendly incident response with brilliant Slack integration
 type: application
-version: 1.14.1
-appVersion: v1.14.1
+version: 1.14.3
+appVersion: v1.14.3
 dependencies:
   - name: cert-manager
     version: v1.8.0

--- a/helm/oncall/Chart.yaml
+++ b/helm/oncall/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oncall
 description: Developer-friendly incident response with brilliant Slack integration
 type: application
-version: 1.14.3
-appVersion: v1.14.3
+version: 1.14.1
+appVersion: v1.14.1
 dependencies:
   - name: cert-manager
     version: v1.8.0


### PR DESCRIPTION
# What this PR does
Although recaptcha verification is disabled by default on the backend for OSS installs, the plugin was still making use of the site key and trying to load recaptcha.  As that recaptcha site was removed this no longer works.  The updated plugin code will skip recaptcha verification if it does not have a site key set.

## Which issue(s) this PR closes

Related to #5449

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [x] Documentation added (or `pr:no public docs` PR label added if not required)
- [x] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
