### PR TITLE
chore: fix spelling in CommonAlertTemplatesForm.config.ts

### DIFF
--- a/grafana-plugin/src/components/AlertTemplates/CommonAlertTemplatesForm.config.ts
+++ b/grafana-plugin/src/components/AlertTemplates/CommonAlertTemplatesForm.config.ts
@@ -142,7 +142,7 @@ export const commonTemplateForEdit: { [id: string]: TemplateForEdit } = {
     name: IntegrationTemplateOptions.Grouping.key,
     displayName: 'Grouping',
     description:
-      'Reduce noise, minimize duplication with Alert Grouping, based on time, alert content, and even multiple features at the same time.  Check the cheasheet to customize your template.',
+      'Reduce noise, minimize duplication with Alert Grouping, based on time, alert content, and even multiple features at the same time.  Check the cheatsheet to customize your template.',
     type: 'plain',
   },
   acknowledge_condition_template: {


### PR DESCRIPTION
# What this PR does
Spelling fix. Noticed during a demo that cheatsheet was misspelled.