### PR TITLE
fix: enable IRM in profile for Grafana v12

### DIFF
--- a/grafana-plugin/src/module.ts
+++ b/grafana-plugin/src/module.ts
@@ -21,15 +21,15 @@ if (isUseProfileExtensionPointEnabled()) {
   const extensionPointId = PluginExtensionPoints.UserProfileTab;
 
   if (plugin.addComponent) {
-    // v11
+    // v11+ (including v12)
     plugin.addComponent({
       title: IRM_TAB,
       description: 'IRM settings',
       component: MobileAppConnectionWrapper,
       targets: [extensionPointId],
     });
-  } else {
-    // v10
+  } else if ('configureExtensionComponent' in plugin) {
+    // v10 only (configureExtensionComponent removed in v12)
     // eslint-disable-next-line
     plugin.configureExtensionComponent({
       component: MobileAppConnectionWrapper,
@@ -43,10 +43,10 @@ if (isUseProfileExtensionPointEnabled()) {
 function isUseProfileExtensionPointEnabled(): boolean {
   return (
     isCurrentGrafanaVersionEqualOrGreaterThan({ minMajor: 10, minMinor: 3 }) &&
-    'configureExtensionComponent' in plugin &&
     PluginExtensionPoints != null &&
     'UserProfileTab' in PluginExtensionPoints &&
-    !getIsIrmPluginPresent()
+    !getIsIrmPluginPresent() &&
+    (plugin.addComponent || 'configureExtensionComponent' in plugin) // Check if either API exists
   );
 }
 


### PR DESCRIPTION
# What this PR does
Since `configureExtensionComponent` was removed in Grafana v12, the IRM tab in users profile no longer shows up.
## Which issue(s) this PR closes

Related to [issue link here]

<!--
*Note*: If you want the issue to be auto-closed once the PR is merged, change "Related to" to "Closes" in the line above.
If you have more than one GitHub issue that this PR closes, be sure to preface
each issue link with a [closing keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
This ensures that the issue(s) are auto-closed once the PR has been merged.
-->

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [ ] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
