### PR TITLE
fix: correct header for Grafana OnCall API

### DIFF
--- a/docs/sources/oncall-api-reference/_index.md
+++ b/docs/sources/oncall-api-reference/_index.md
@@ -43,12 +43,14 @@ The endpoint refers to the OnCall Application endpoint and can be found on the O
 
 It is also possible to use a [service account token](https://grafana.com/docs/grafana/latest/administration/service-accounts/#service-account-tokens)
 to authenticate instead of an OnCall access token. In this case you will also need to provide a
-header (`X-Grafana-URL`) pointing to your Grafana stack:
+header (`X-Grafana-Instance-ID`) pointing to your Grafana stack:
 
 ```shell
 # With shell, you can just pass the correct header with each request
-curl "api_endpoint_here" --header "Authorization: <service account token>" --header "X-Grafana-URL: <your stack URL>"
+curl "api_endpoint_here" --header "Authorization: <service account token>" --header "X-Grafana-Instance-ID: <your stack URL>"
 ```
+
+You can retrieve the Instance ID of your Grafana stack by logging into the Grafana Admin Portal.
 
 Service accounts allow you to set explicit permissions for tokens as well as expire and/or disable them if needed.
 


### PR DESCRIPTION
# What this PR does
Updated docs reference, as currently our docs are saying for OnCall to use header 'X-Grafana-Stack' when authenticating with a Service Account token. This is incorrect, the API errors with 'Missing X-Grafana-Instance-ID'. I've updated the docs to reflect this, and how to get the Instance ID (as this is not the URL of the Grafana Stack).

## Which issue(s) this PR closes
NA

## Checklist

- [ ] Unit, integration, and e2e (if applicable) tests updated
- [X] Documentation added (or `pr:no public docs` PR label added if not required)
- [ ] Added the relevant release notes label (see labels prefixed w/ `release:`). These labels dictate how your PR will
    show up in the autogenerated release notes.
