### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-environment: &oncall-environment
   PROMETHEUS_EXPORTER_SECRET: ${PROMETHEUS_EXPORTER_SECRET:-}
   REDIS_URI: redis://redis:6379/0
   DJANGO_SETTINGS_MODULE: settings.hobby
-  CELERY_WORKER_QUEUE: "default,critical,long,slack,telegram,webhook,retry,celery,grafana"
+  CELERY_WORKER_QUEUE: "default,critical,long,slack,telegram,mattermost,webhook,retry,celery,grafana"
   CELERY_WORKER_CONCURRENCY: "1"
   CELERY_WORKER_MAX_TASKS_PER_CHILD: "100"
   CELERY_WORKER_SHUTDOWN_INTERVAL: "65m"


### PR DESCRIPTION
# What this PR does
add mattermost to CELERY_WORKER_QUEUE

# Comment
#5553 
We think that with the 1.16.0 release it would be a good idea to add mattermost to the CELERY_WORKER_QUEUE so that no one else has the same issues as we did when we upgraded from 1.9 to 1.16.2 to get the Mattermost integration via ChatOps.

When we upgraded our OnCall and set up the Mattermost integration, we couldn't get any messages in MM because Celery was simply ignoring the Mattermost queue.