### PR TITLE
chore: update django version

### DIFF
--- a/engine/requirements-dev.txt
+++ b/engine/requirements-dev.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.2
     #   requests
 distlib==0.3.9
     # via virtualenv
-django==4.2.22
+django==4.2.24
     # via
     #   -c requirements.txt
     #   django-stubs
@@ -36,6 +36,8 @@ djangorestframework-stubs==3.14.2
     # via
     #   -r requirements-dev.in
     #   django-filter-stubs
+exceptiongroup==1.3.0
+    # via pytest
 execnet==2.1.1
     # via pytest-xdist
 factory-boy==2.12.0
@@ -118,6 +120,12 @@ toml==0.10.2
     # via
     #   -c requirements.txt
     #   pre-commit
+tomli==2.2.1
+    # via
+    #   -c requirements.txt
+    #   django-stubs
+    #   mypy
+    #   pytest
 types-beautifulsoup4==4.12.0.5
     # via -r requirements-dev.in
 types-html5lib==1.1.11.20250516
@@ -141,11 +149,13 @@ types-urllib3==1.26.25.14
 typing-extensions==4.14.0
     # via
     #   -c requirements.txt
+    #   asgiref
     #   celery-types
     #   django-filter-stubs
     #   django-stubs
     #   django-stubs-ext
     #   djangorestframework-stubs
+    #   exceptiongroup
     #   mypy
     #   pytest-factoryboy
 tzdata==2025.2

--- a/engine/requirements.in
+++ b/engine/requirements.in
@@ -2,7 +2,7 @@ babel==2.12.1
 beautifulsoup4==4.12.2
 celery[redis]==5.3.6
 cryptography==44.0.1
-django==4.2.22
+django==4.2.24
 django-add-default-value==0.10.0
 django-anymail[amazon-ses]==12.0
 django-cors-headers==3.7.0

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -8,6 +8,8 @@ apscheduler==3.6.3
     # via python-telegram-bot
 asgiref==3.8.1
     # via django
+async-timeout==5.0.1
+    # via redis
 attrs==25.3.0
     # via
     #   jsonschema
@@ -75,7 +77,7 @@ deprecated==1.2.18
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-semantic-conventions
-django==4.2.22
+django==4.2.24
     # via
     #   -r requirements.in
     #   django-add-default-value
@@ -446,6 +448,8 @@ sqlparse==0.5.3
     #   django-silk
 toml==0.10.2
     # via django-migration-linter
+tomli==2.2.1
+    # via autopep8
 tornado==6.5.1
     # via python-telegram-bot
 tqdm==4.67.1
@@ -454,6 +458,7 @@ twilio==6.37.0
     # via -r requirements.in
 typing-extensions==4.14.0
     # via
+    #   asgiref
     #   opentelemetry-sdk
     #   pyopenssl
     #   referencing


### PR DESCRIPTION
Update django 4.2.22 -> 4.2.24 previous dependabot [PR](https://github.com/grafana/oncall/pull/5573) downgraded a dependency so this replaces it. 