### PR TITLE
Fix AttributeError when creating grafana_alerting integration via pub…

### DIFF
--- a/engine/apps/public_api/serializers/integrations.py
+++ b/engine/apps/public_api/serializers/integrations.py
@@ -123,7 +123,6 @@ class IntegrationSerializer(EagerLoadingMixin, serializers.ModelSerializer, Main
             connection_error = GrafanaAlertingSyncManager.check_for_connection_errors(organization)
             if connection_error:
                 raise serializers.ValidationError(connection_error)
-            validated_data = self._add_service_label_if_needed(organization, validated_data)
         user = self.context["request"].user
         with transaction.atomic():
             try:


### PR DESCRIPTION
## Bug Fix: AttributeError when creating grafana_alerting integration via public API

### Problem
When creating a `grafana_alerting` integration via the public API (used by Terraform provider), the API returns a 500 error with the following exception:

```
AttributeError: 'IntegrationSerializer' object has no attribute '_add_service_label_if_needed'
```

**Error Location:**
- File: `engine/apps/public_api/serializers/integrations.py`
- Line: 126 (in `IntegrationSerializer.create()` method)
- Stack trace shows the error occurs during integration creation via `POST /api/v1/integrations/`

**Terraform Error:**
```
Error: POST https://grafana-oncall-stg.trypencil.com/api/v1/integrations/ giving up after 5 attempt(s)
```

### Root Cause
The `IntegrationSerializer.create()` method was calling a non-existent method `_add_service_label_if_needed()` before creating the integration instance. This method was never defined in the class, causing an `AttributeError` when creating `grafana_alerting` integrations.

### Solution
Removed the call to the non-existent method `self._add_service_label_if_needed(organization, validated_data)` on line 126. The service label creation is already correctly handled after instance creation via `instance.create_service_name_dynamic_label()` on line 144, which matches the pattern used in `AlertReceiveChannelSerializer`.

### Changes Made
- **File:** `engine/apps/public_api/serializers/integrations.py`
- **Change:** Removed line 126 that called the non-existent `_add_service_label_if_needed()` method
- **Impact:** Service label creation remains functional via the existing `create_service_name_dynamic_label()` method

### Testing
- [x] Verified that service label creation still works correctly via `instance.create_service_name_dynamic_label()`
- [x] Confirmed the fix matches the pattern used in `AlertReceiveChannelSerializer`
- [x] No linting errors introduced

### Verification
The fix aligns with the existing codebase pattern:
- `AlertReceiveChannelSerializer` (internal API) also calls `instance.create_service_name_dynamic_label()` after instance creation
- Both serializers now follow the same pattern: create instance → then add service label

### Related Issues
Fixes the issue where Terraform provider fails to create `grafana_alerting` integrations with type `"grafana_alerting"`.

---

**Type:** Bug Fix  
**Priority:** High (blocks Terraform integration creation)  
**Breaking Change:** No

