### PR TITLE
chore(deps): Bump `django` to `4.2.27`

### DIFF
--- a/engine/requirements-dev.txt
+++ b/engine/requirements-dev.txt
@@ -18,7 +18,7 @@ charset-normalizer==3.4.2
     #   requests
 distlib==0.3.9
     # via virtualenv
-django==6.0
+django==4.2.27
     # via
     #   -c requirements.txt
     #   django-stubs
@@ -152,7 +152,7 @@ tzdata==2025.2
     # via
     #   -c requirements.txt
     #   faker
-urllib3==2.6.2
+urllib3==1.26.20
     # via
     #   -c requirements.txt
     #   requests

--- a/engine/requirements.in
+++ b/engine/requirements.in
@@ -57,7 +57,7 @@ slack-export-viewer==1.1.4
 slack_sdk==3.21.3
 social-auth-app-django==5.4.1
 twilio~=6.37.0
-urllib3>=2.6.0
+urllib3==1.26.20
 uwsgi==2.0.28
 whitenoise==5.3.0
 google-api-python-client==2.122.0

--- a/engine/requirements.txt
+++ b/engine/requirements.txt
@@ -468,7 +468,7 @@ uritemplate==4.2.0
     # via
     #   drf-spectacular
     #   google-api-python-client
-urllib3==2.6.2
+urllib3==1.26.20
     # via
     #   -r requirements.in
     #   botocore


### PR DESCRIPTION
## What?

- Bumps `django` from `4.2.26` to `4.2.27`.
- Bumps `urllib3` to `1.26.20`.