### PR TITLE
refactor: Update telegram filters import and usage syntax

### DIFF
--- a/engine/engine/management/commands/start_telegram_polling.py
+++ b/engine/engine/management/commands/start_telegram_polling.py
@@ -2,7 +2,7 @@ import logging
 
 import telegram.error
 from django.core.management.base import BaseCommand
-from telegram.ext import CallbackQueryHandler, Filters, MessageHandler, Updater
+from telegram.ext import CallbackQueryHandler, MessageHandler, Updater, filters
 
 from apps.telegram.client import TelegramClient
 from apps.telegram.updates.update_manager import UpdateManager
@@ -24,7 +24,7 @@ def start_telegram_polling():
     callback_handler = CallbackQueryHandler(handle_message)
 
     # register the message handler function with the dispatcher
-    updater.dispatcher.add_handler(MessageHandler(Filters.text, handle_message))
+    updater.dispatcher.add_handler(MessageHandler(filters.TEXT, handle_message))
     updater.dispatcher.add_handler(callback_handler)
 
     # start the long polling loop


### PR DESCRIPTION
# What this PR does

Fix syntax for python-telegram-bot imports after upgrade to 20.0+ version

See release notes for [python-telegram-bot 20.0](https://docs.python-telegram-bot.org/en/v20.0/telegram.ext.filters.html)

>2. Removed the Filters class. The filters are now directly attributes/classes of the [filters](https://docs.python-telegram-bot.org/en/v21.7/telegram.ext.filters.html#module-telegram.ext.filters) module.
>3. The names of all filters has been updated:
> - Filter classes which are ready for use, e.g Filters.all are now capitalized, e.g filters.ALL.

> - Filters which need to be initialized are now in CamelCase. E.g. filters.User(...).

> - Filters which do both (like Filters.text) are now split as ready-to-use version filters.TEXT and class version filters.Text(...).

Without this change, the logs of the telegram‑polling container show the following error:
```
ImportError: cannot import name 'Filters' from 'telegram.ext' (/usr/local/lib/python3.12/site-packages/telegram/ext/__init__.py). Did you mean: 'filters'?
```