### PR TITLE
fix: telegram polling for python-telegram-bot v20+ and sync_to_async

### DIFF
--- a/engine/engine/management/commands/start_telegram_polling.py
+++ b/engine/engine/management/commands/start_telegram_polling.py
@@ -1,8 +1,9 @@
 import logging
 
 import telegram.error
+from asgiref.sync import sync_to_async
 from django.core.management.base import BaseCommand
-from telegram.ext import CallbackQueryHandler, MessageHandler, Updater, filters
+from telegram.ext import ApplicationBuilder, CallbackQueryHandler, MessageHandler, filters
 
 from apps.telegram.client import TelegramClient
 from apps.telegram.updates.update_manager import UpdateManager
@@ -16,19 +17,19 @@ def start_telegram_polling():
 
     telegram_client.delete_webhook()
 
-    updater = Updater(token=telegram_client.token, use_context=True)
+    application = ApplicationBuilder().token(telegram_client.token).build()
 
-    # Register the error handler function with the dispatcher
-    updater.dispatcher.add_error_handler(error_handler)
+    # Register the error handler function
+    application.add_error_handler(error_handler)
 
     callback_handler = CallbackQueryHandler(handle_message)
 
-    # register the message handler function with the dispatcher
-    updater.dispatcher.add_handler(MessageHandler(filters.TEXT, handle_message))
-    updater.dispatcher.add_handler(callback_handler)
+    # register the message handler function with the application
+    application.add_handler(MessageHandler(filters.TEXT, handle_message))
+    application.add_handler(callback_handler)
 
     # start the long polling loop
-    updater.start_polling()
+    application.run_polling()
 
 
 def error_handler(update, context):
@@ -38,13 +39,15 @@ def error_handler(update, context):
         logger.warning(f"Tried to getUpdates() using telegram long polling, but conflict exists, got error: {e}")
 
 
-def handle_message(update, context):
+async def handle_message(update, context):
     logger.debug(f"Update from Telegram: {update}")
 
-    UpdateManager.process_update(update)
+    # Django ORM is sync-only; run it in a thread from async context
+    await sync_to_async(UpdateManager.process_update)(update)
 
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
         logger.info("Starting telegram polling...")
         start_telegram_polling()
+


### PR DESCRIPTION
# Fix Telegram polling for python-telegram-bot v20+ and async/sync context

## Summary

Fixes two related issues in `start_telegram_polling` that prevent the Telegram polling worker from working with **python-telegram-bot v20+**:

1. **Startup failure** — the code used the removed synchronous API (`Updater`, `dispatcher`), so the process failed on import or at startup.
2. **Runtime failure** — after switching to the new API, handlers run in an async context; calling Django ORM from them raises `SynchronousOnlyOperation`.

Both are addressed in `engine/management/commands/start_telegram_polling.py`.

---

## Problem 1: Incompatibility with python-telegram-bot v20+ (startup)

The library **python-telegram-bot v20.0+** removed the synchronous API and switched to an async-first API.

**Previously used (removed in v20+):**

- `Updater`, `updater.dispatcher`, `use_context=True`
- `updater.start_polling()`
- `Filters` (renamed to `filters`)

**Observed when running with v20+:**

- `ImportError: cannot import name 'Updater' from 'telegram.ext'`
- Or after only fixing imports: `AttributeError: 'Application' object has no attribute 'dispatcher'`
- The container may enter CrashLoopBackOff; logs show the error on first start.

**Fix:** Use the new API:

- `ApplicationBuilder().token(...).build()` instead of `Updater(...)`.
- Register handlers and error handler on `application` (e.g. `application.add_handler`, `application.add_error_handler`).
- `application.run_polling()` instead of `updater.start_polling()`.
- Use `filters` (lowercase) for message filters.

This allows the process to start and run the long-polling loop.

---

## Problem 2: SynchronousOnlyOperation when handling updates (runtime)

After fixing Problem 1, the bot starts and receives updates, but **handling** them can fail with:

```text
django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.
```

**Example traceback:**

```text
File "/etc/app/engine/management/commands/start_telegram_polling.py", line 44, in handle_message
    UpdateManager.process_update(update)
File "/etc/app/apps/telegram/updates/update_manager.py", line 26, in process_update
    cls._update_entity_names(update)
File "/etc/app/apps/telegram/updates/update_manager.py", line 68, in _update_entity_names
    cls._update_channel_and_group_names(update)
...
File "/usr/local/lib/python3.13/site-packages/django/db/models/query.py", line 1208, in update
    rows = query.get_compiler(self.db).execute_sql(CURSOR)
...
raise SynchronousOnlyOperation(message)
```

**Cause:** In v20+, the library invokes handlers in an **async** context. `handle_message` calls `UpdateManager.process_update(update)`, which uses Django ORM (sync). Django forbids synchronous DB access from an async context.

**Effect:** Any update that hits this path (e.g. channel/group name updates) is not processed; the error is logged and the update is effectively dropped. The pod keeps running and polling, but some messages are not handled.

**Fix:** Run the sync Django code in a thread when called from the async handler:

- Make `handle_message` an `async def`.
- Wrap the call to `UpdateManager.process_update` with `sync_to_async` and `await` it:

  ```python
  from asgiref.sync import sync_to_async

  async def handle_message(update, context):
      logger.debug(f"Update from Telegram: {update}")
      await sync_to_async(UpdateManager.process_update)(update)
  ```

This removes `SynchronousOnlyOperation` and ensures all updates are processed correctly.

---

## Changes in this PR

**File:** `engine/engine/management/commands/start_telegram_polling.py`

- **Imports:** `Updater` → `ApplicationBuilder`; add `sync_to_async` from `asgiref.sync`.
- **Startup:** Replace `Updater`/`dispatcher` with `ApplicationBuilder().token(...).build()`, register handlers and error handler on `application`, call `application.run_polling()`.
- **Handler:** Change `handle_message` to `async def` and call `UpdateManager.process_update` via `await sync_to_async(UpdateManager.process_update)(update)`.
- **Error handler:** Left as sync (no Django calls); compatible with the library’s async context.

No changes to Dockerfile or dependencies; `asgiref` is already in `requirements.txt`.

---

## How to verify

1. Build and run the engine with Telegram polling enabled (e.g. `python manage.py start_telegram_polling` or the same via your deployment).
2. **Startup:** Logs should show e.g. `Starting telegram polling...` and successful `getUpdates`/`getMe`/`deleteWebhook` calls; no `ImportError` or `AttributeError` for `Updater`/`dispatcher`.
3. **Runtime:** Send or forward messages (including from channels) that trigger `UpdateManager.process_update`; logs should not contain `SynchronousOnlyOperation`; updates should be processed and reflected in the app.

---

## References

- [python-telegram-bot v20.0 migration](https://docs.python-telegram-bot.org/en/v20.0/)
- Django: [Async views — SynchronousOnlyOperation](https://docs.djangoproject.com/en/stable/topics/async/#async-safety)
- Related upstream/commit that fixed imports only: e.g. ec1cebe3aa9ed436f7da843cd00c848876b7558c (Grafana Oncall)
