### PR TITLE
fix: correct MS Teams capitalization in user settings tab

### DIFF
--- a/grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx
+++ b/grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx
@@ -130,7 +130,7 @@ export const Tabs = ({
       {showMsTeamsConnectionTab && (
         <Tab
           active={activeTab === UserSettingsTab.MSTeamsInfo}
-          label="Ms Teams connection"
+          label="MS Teams connection"
           key={UserSettingsTab.MSTeamsInfo}
           onChangeTab={getTabClickHandler(UserSettingsTab.MSTeamsInfo)}
           data-testid="tab-msteams"


### PR DESCRIPTION
## Summary

Fixes the capitalization of "Ms Teams" to "MS Teams" in the user settings tab label. Microsoft's official abbreviation is "MS Teams", not "Ms Teams".

## Changes

- `grafana-plugin/src/containers/UserSettings/parts/UserSettingsParts.tsx:133`: Changed `label="Ms Teams connection"` to `label="MS Teams connection"`

This is the only instance of the typo in the codebase (verified via grep).

## Context

A previous PR (#5175) addressed this but was auto-closed by the stale bot after 30 days without review. This is a fresh submission of the same one-line fix.

Fixes #4335

This contribution was developed with AI assistance (Claude Code).